### PR TITLE
Configures CI build for Mac

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -19,8 +19,10 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job


### PR DESCRIPTION
Adding Mac for now cause it works.  Will need to tweak the way run scripts are coded to get it to work on Windows, but that can be done later.

Affects #81 