### PR TITLE
Configure initial CI build for iOS

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -66,6 +66,9 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '10.x'
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.7'
       - run: npm install -g @ionic/cli
       - run: npm install
         working-directory: ./client/ionic
@@ -73,5 +76,8 @@ jobs:
         working-directory: ./client/ionic
       - run: ionic capacitor copy ios
         working-directory: ./client/ionic
+      - run: gem install cocoapods
+      - run: pod install
+        working-directory: ./client/ionic/ios/App
       - run: xcodebuild -scheme App build -workspace ios/App/App.xcworkspace CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO"
         working-directory: ./client/ionic

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -58,3 +58,20 @@ jobs:
         working-directory: ./client/ionic/android
       - run: ./gradlew build
         working-directory: ./client/ionic/android
+  # Builds the iOS app
+  build-ios-debug:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
+      - run: npm install -g @ionic/cli
+      - run: npm install
+        working-directory: ./client/ionic
+      - run: ionic build
+        working-directory: ./client/ionic
+      - run: ionic capacitor copy ios
+        working-directory: ./client/ionic
+      - run: xcodebuild -scheme App build -workspace ios/App/App.xcworkspace CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO"
+        working-directory: ./client/ionic


### PR DESCRIPTION
Builds iOS as part of CI. Keeps this pretty simple, uses `xcodebuild` while disabling code signing.

This is a WIP that is tough to debug locally, so pushing here. I don't have much experience with GitHub Actions so this may take a few commits to get right...

Closes #117 