### PR TITLE
Optimize CI process with artifacts

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -12,7 +12,7 @@ on:
       - '.github/workflows/**'
       - 'client/ionic/**'
 jobs:
-  test:
+  test-and-build:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest]
@@ -38,6 +38,7 @@ jobs:
           name: build
           path: ./client/ionic/build
   build-android-debug:
+    needs: test-and-build
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest]

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -1,9 +1,5 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
-# Controls when the action will run. Triggers the workflow on push or pull request 
-# events but only for the master branch
 on:
   push:
     branches: [ master ]
@@ -15,7 +11,6 @@ on:
     paths:
       - '.github/workflows/**'
       - 'client/ionic/**'
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   test:
     strategy:
@@ -23,17 +18,25 @@ jobs:
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: '10.x'
-      - run: cd client/ionic && npm install
-      - run: cd client/ionic && npm audit --audit-level=moderate
-      - run: cd client/ionic && CI=true npm test
-  # This builds the android APK
+      - run: npm i -g @ionic/cli  
+      - run: npm ci
+        working-directory: ./client/ionic
+      - run: npm audit --audit-level=moderate
+        working-directory: ./client/ionic
+      - run: npm test
+        working-directory: ./client/ionic
+      - run: ionic build
+        env:
+          CI: true
+      - uses: actions/upload-artifact@v1
+        with:
+          name: build
+          path: ./client/ionic/build
   build-android-debug:
     strategy:
       matrix:
@@ -48,11 +51,13 @@ jobs:
         with:
           node-version: '10.x'
       - run: npm install -g @ionic/cli
-      - run: npm install
+      - run: npm ci
         working-directory: ./client/ionic
-      - run: ionic build
-        working-directory: ./client/ionic
-      - run: ionic cap sync
+      - uses: actions/download-artifact@v1
+        with:
+          name: build
+          path: ./client/ionic/build
+      - run: npx capacitor sync
         working-directory: ./client/ionic
       - run: ./gradlew test
         working-directory: ./client/ionic/android

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -33,6 +33,7 @@ jobs:
         env:
           CI: true
       - run: ionic build
+        working-directory: ./client/ionic
       - uses: actions/upload-artifact@v1
         with:
           name: build

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -30,9 +30,9 @@ jobs:
         working-directory: ./client/ionic
       - run: npm test
         working-directory: ./client/ionic
-      - run: ionic build
         env:
           CI: true
+      - run: ionic build
       - uses: actions/upload-artifact@v1
         with:
           name: build


### PR DESCRIPTION
for #119

I didn't reinstall node_modules because I think that may be OS-dependent. Instead, I uploaded the result from `ionic build` into a build artifact and then uploaded it.

Also, changed it to use `npm ci` instead of `npm install` because this is [much faster](https://docs.npmjs.com/cli/ci.html) than npm install and suitable for CI process.