### PR TITLE
Treat eslint warnings as errors on build

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -52,6 +52,8 @@ jobs:
         working-directory: ./client/ionic
       - run: ionic build
         working-directory: ./client/ionic
+        env:
+          CI: true
       - run: ionic cap sync
         working-directory: ./client/ionic
       - run: ./gradlew test
@@ -74,6 +76,8 @@ jobs:
         working-directory: ./client/ionic
       - run: ionic build
         working-directory: ./client/ionic
+        env:
+          CI: true
       - run: ionic capacitor copy ios
         working-directory: ./client/ionic
       - run: gem install cocoapods

--- a/client/ionic/src/pages/About.tsx
+++ b/client/ionic/src/pages/About.tsx
@@ -68,7 +68,7 @@ const About: React.FC = () => {
                     </IonSlide>
                   );
                 default:
-                /** TODO: Handle errors of unsupported screen types correctly. */
+                  /** TODO: Handle errors of unsupported screen types correctly. */
                   return null;
               }
             })}

--- a/client/ionic/src/pages/About.tsx
+++ b/client/ionic/src/pages/About.tsx
@@ -69,6 +69,7 @@ const About: React.FC = () => {
                   );
                 default:
                 /** TODO: Handle errors of unsupported screen types correctly. */
+                  return null;
               }
             })}
           </IonSlides>

--- a/client/ionic/src/pages/CopingEveryone.tsx
+++ b/client/ionic/src/pages/CopingEveryone.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { FlowLoader, Flow, LoadedFlow } from '../content/flow';
 import {
   IonContent,
   IonPage,
@@ -11,7 +10,6 @@ import {
 } from '@ionic/react';
 import TopNav from '../components/TopNav';
 import 'tachyons';
-import { getUserContext } from '../content/userContext';
 import useDynamicFlow from '../hooks/useDynamicFlow';
 
 const CopingEveryone: React.FC = () => {
@@ -49,6 +47,7 @@ const CopingEveryone: React.FC = () => {
                   );
                 default:
                 /** TODO: Handle errors of unsupported screen types correctly. */
+                  return null;
               }
             })}
           </IonSlides>

--- a/client/ionic/src/pages/CopingEveryone.tsx
+++ b/client/ionic/src/pages/CopingEveryone.tsx
@@ -46,7 +46,7 @@ const CopingEveryone: React.FC = () => {
                     </IonSlide>
                   );
                 default:
-                /** TODO: Handle errors of unsupported screen types correctly. */
+                  /** TODO: Handle errors of unsupported screen types correctly. */
                   return null;
               }
             })}

--- a/client/ionic/src/pages/CopingParents.tsx
+++ b/client/ionic/src/pages/CopingParents.tsx
@@ -46,7 +46,7 @@ const CopingParents: React.FC = () => {
                     </IonSlide>
                   );
                 default:
-                /** TODO: Handle errors of unsupported screen types correctly. */
+                  /** TODO: Handle errors of unsupported screen types correctly. */
                   return null;
               }
             })}

--- a/client/ionic/src/pages/CopingParents.tsx
+++ b/client/ionic/src/pages/CopingParents.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { FlowLoader, Flow, LoadedFlow } from '../content/flow';
 import {
   IonContent,
   IonPage,
@@ -11,7 +10,6 @@ import {
 } from '@ionic/react';
 import TopNav from '../components/TopNav';
 import 'tachyons';
-import { getUserContext } from '../content/userContext';
 import useDynamicFlow from '../hooks/useDynamicFlow';
 
 const CopingParents: React.FC = () => {
@@ -49,6 +47,7 @@ const CopingParents: React.FC = () => {
                   );
                 default:
                 /** TODO: Handle errors of unsupported screen types correctly. */
+                  return null;
               }
             })}
           </IonSlides>

--- a/client/ionic/src/pages/ProtectYourself.tsx
+++ b/client/ionic/src/pages/ProtectYourself.tsx
@@ -46,7 +46,7 @@ const ProtectYourself: React.FC = () => {
                     </IonSlide>
                   );
                 default:
-                /** TODO: Handle errors of unsupported screen types correctly. */
+                  /** TODO: Handle errors of unsupported screen types correctly. */
                   return null;
               }
             })}

--- a/client/ionic/src/pages/ProtectYourself.tsx
+++ b/client/ionic/src/pages/ProtectYourself.tsx
@@ -47,6 +47,7 @@ const ProtectYourself: React.FC = () => {
                   );
                 default:
                 /** TODO: Handle errors of unsupported screen types correctly. */
+                  return null;
               }
             })}
           </IonSlides>


### PR DESCRIPTION
By setting `CI=true` during `ionic build`, we can make sure that eslint warnings are treated as errors on build. This PR sets that setting and also fixes existing eslint errors (`array-callback-return`, `@typescript-eslint/no-unused-vars`).