### PR TITLE
Added a "npx cap update android" command

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -52,6 +52,7 @@ To run on Android, from the `client/ionic` directory run:
 ```
 ionic build
 ionic capacitor copy android
+npx cap update android
 ionic capacitor run android -l --host=YOUR_IP_ADDRESS
 ```
 


### PR DESCRIPTION
## What does this PR accomplish?

Adds a "npx cap update android" command to fix the issue of client/ionic/android/capacitor-cordova-android-plugins/cordova.variables.gradle not being found in Android Studio.

See https://github.com/ionic-team/capacitor/issues/1628 for a similar issue, with the suggested fix (that worked for me).


## Did you add any dependencies?

n/a

## How did you test the change?

Android Studio now builds the project for me.