### PR TITLE
Set default fonts (San Francisco and Roboto)

### DIFF
--- a/client/ionic/src/theme/variables.css
+++ b/client/ionic/src/theme/variables.css
@@ -76,6 +76,14 @@ http://ionicframework.com/docs/theming/ */
   --ion-color-light-tint: #f5f6f9;
 }
 
+.ios {
+  --ion-font-family: "San Francisco";
+}
+.md {
+  /* Android and web */
+  --ion-font-family: Roboto;
+}
+
 @media (prefers-color-scheme: dark) {
   /*
    * Dark Colors


### PR DESCRIPTION
## What does this PR accomplish?
Fonts -- use San Francisco for iOS and Roboto for Android / web.

## Did you add any dependencies?
No

## How did you test the change?
I tested it on web and all text had a font set to Roboto.