### PR TITLE
Remove .css files from being `gts check`'d in lint-staged

### DIFF
--- a/client/ionic/package.json
+++ b/client/ionic/package.json
@@ -74,7 +74,7 @@
     }
   },
   "lint-staged": {
-    "*.{json,css,ts,tsx}": [
+    "*.{json,ts,tsx}": [
       "gts check"
     ]
   }


### PR DESCRIPTION
## What does this PR accomplish?
Remove .css files from being `gts check`'d in lint-staged. This is because by default, it appears that running `gts check` doesn't actually check any css files -- so our CI doesn't catch formatting errors in CSS files. However, it is run on precommit -- and then when you run `gts fix`, it doesn't fix the css files either. This makes for a very unpleasant development experience.

Ideally, we should eventually find out what the problem is with `gts` that makes it ignore .css files, but for now, we should just exclude .css files from being checked in `lint-staged`.