### PR TITLE
docs: fix links in PR template and contributor guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 NOTE: Please ensure you:
 * provide a detailed pull request description and a succinct title (consider template below for guidance),
-* follow the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/CONTRIBUTING.md),
+* follow the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md),
 * use a draft PR if you don't want the committers to review your code,
 * and make sure that all contributions are properly licensed pursuant to the LICENSE file in the root of the repository.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -11,7 +11,7 @@ While we're working quickly, please abide by a few rules to keep us safe and san
 
 ## Pull Requests
 
-Please follow the [default Pull Request template](../.github/PULL_REQUEST_TEMPLATE/default_pull_request_template.md) when creating your PR, and follow these rules:
+Please follow the [default Pull Request template](../.github/pull_request_template.md) when creating your PR, and follow these rules:
 
 * For authors, before you submit a PR for review:
   * Add your name to the end of the `team` array in the [content/credits.yaml](../content/credits.yaml) contributor list if its your first commit.


### PR DESCRIPTION

## What does this PR accomplish?
Fixes links to other docs in the PR template and contributor guidelines.

## Did you add any dependencies?
N/A

## How did you test the change?
Using the GitHub rendering of the markdown files to confirm that clicking the links goes to the right place.
