### PR TITLE
feat: TextEmoji screen and WHO Myth-busters page

### DIFF
--- a/client/ionic/src/App.tsx
+++ b/client/ionic/src/App.tsx
@@ -10,6 +10,7 @@ import SplashInfo from './pages/SplashInfo';
 import SplashCarousel from './pages/SplashCarousel';
 import Menu from './pages/Menu';
 import ProtectYourself from './pages/ProtectYourself';
+import WhoMythbusters from './pages/WhoMythbusters';
 
 /* Core CSS required for Ionic components to work properly */
 import '@ionic/react/css/core.css';
@@ -54,6 +55,11 @@ const App: React.FC = () => (
         <Route
           path="/protect-yourself"
           component={ProtectYourself}
+          exact={true}
+        />
+        <Route
+          path="/who-mythbusters"
+          component={WhoMythbusters}
           exact={true}
         />
         <Route

--- a/client/ionic/src/components/Carousel.tsx
+++ b/client/ionic/src/components/Carousel.tsx
@@ -40,25 +40,21 @@ const TextImage = ({
   );
 };
 
-const TextEmoji = ({
-  screen,
-}: {
-  screen: TextEmojiScreen;
-}) => {
+const TextEmoji = ({ screen }: { screen: TextEmojiScreen }) => {
   return (
     <IonSlide>
       <div className="flex flex-column justify-around h-100 pa4">
         <div className="mt3 tl">
-          { screen.bodyTexts && (
+          {screen.bodyTexts && (
             <div style={{ fontSize: '1.5em', textAlign: 'center' }}>
-              { screen.bodyTexts.map((txt, key) => (
+              {screen.bodyTexts.map((txt, key) => (
                 <RenderHTML source={txt} key={key} />
               ))}
             </div>
           )}
         </div>
         <div>
-          { screen.bottomEmoji && (
+          {screen.bottomEmoji && (
             <p style={{ fontSize: '6em' }}>{screen.bottomEmoji}</p>
           )}
         </div>

--- a/client/ionic/src/components/Carousel.tsx
+++ b/client/ionic/src/components/Carousel.tsx
@@ -3,7 +3,7 @@ import { IonContent, IonPage, IonSlides, IonSlide, IonImg } from '@ionic/react';
 import 'tachyons';
 import useDynamicFlow from '../hooks/useDynamicFlow';
 import TopNav from '../components/TopNav';
-import { TextImageScreen, LoadedFlow } from '../content/flow';
+import { TextEmojiScreen, TextImageScreen, LoadedFlow } from '../content/flow';
 import RenderHTML from './RenderHTML';
 
 const TextImage = ({
@@ -40,6 +40,33 @@ const TextImage = ({
   );
 };
 
+const TextEmoji = ({
+  screen,
+}: {
+  screen: TextEmojiScreen;
+}) => {
+  return (
+    <IonSlide>
+      <div className="flex flex-column justify-around h-100 pa4">
+        <div className="mt3 tl">
+          { screen.bodyTexts && (
+            <div style={{ fontSize: '1.5em', textAlign: 'center' }}>
+              { screen.bodyTexts.map((txt, key) => (
+                <RenderHTML source={txt} key={key} />
+              ))}
+            </div>
+          )}
+        </div>
+        <div>
+          { screen.bottomEmoji && (
+            <p style={{ fontSize: '6em' }}>{screen.bottomEmoji}</p>
+          )}
+        </div>
+      </div>
+    </IonSlide>
+  );
+};
+
 const Carousel = ({ flow: flowName }: { flow: string }) => {
   const flow = useDynamicFlow(flowName);
   const slidesStyles = {
@@ -56,6 +83,8 @@ const Carousel = ({ flow: flowName }: { flow: string }) => {
               switch (screen.type) {
                 case 'TextImage':
                   return <TextImage key={key} screen={screen} flow={flow} />;
+                case 'TextEmoji':
+                  return <TextEmoji key={key} screen={screen} />;
                 default:
                   /** TODO: Handle errors of unsupported screen types correctly. */
                   return null;

--- a/client/ionic/src/content/flow.ts
+++ b/client/ionic/src/content/flow.ts
@@ -20,13 +20,19 @@ export interface TextImageScreen extends BaseScreen {
   bottomImageUri?: string;
 }
 
+export interface TextEmojiScreen extends BaseScreen {
+  type: 'TextEmoji';
+  bodyTexts?: string[];
+  bottomEmoji?: string;
+}
+
 // TODO: This is an example, and is not yet implemented.
 export interface HeroImageScreen extends BaseScreen {
   type: 'HeroImage';
   imageUri: string;
 }
 
-export type Screen = TextImageScreen | HeroImageScreen;
+export type Screen = TextImageScreen | TextEmojiScreen | HeroImageScreen;
 
 export interface BaseFlow {
   type: string;

--- a/client/ionic/src/pages/Menu.tsx
+++ b/client/ionic/src/pages/Menu.tsx
@@ -47,8 +47,10 @@ const Menu: React.FC = () => {
           <MenuItem fill link="/check-your-health">
             Check Your Health
           </MenuItem>
+          <MenuItem fill link="/who-mythbusters">
+            WHO Myth-busters
+          </MenuItem>
           <MenuItem link="/about">Share the App</MenuItem>
-          <MenuItem link="/about">Send Feedback</MenuItem>
           <MenuItem link="/about">About the App</MenuItem>
         </div>
       </IonContent>

--- a/client/ionic/src/pages/WhoMythbusters.tsx
+++ b/client/ionic/src/pages/WhoMythbusters.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import Carousel from '../components/Carousel';
+
+const WhoMythbusters = () => <Carousel flow="who-mythbusters" />;
+
+export default WhoMythbusters;

--- a/content/flows/v1/protect-yourself.ww.en.yaml
+++ b/content/flows/v1/protect-yourself.ww.en.yaml
@@ -1,32 +1,37 @@
 type: LinearCarousel
 screens:
-  - type: TextImage
-    bottomImageUri: placeholder/protect/washHands.png
+  - type: TextEmoji
+    bottomEmoji: 🧼
     bodyTexts:
       - >
-        <em>Wash your hands</em> often with soap and running water frequently
-  - type: TextImage
-    bottomImageUri: placeholder/protect/cough.png
+        <em>Wash your hands</em> frequently
+  - type: TextEmoji
+    bottomEmoji: 👄
     bodyTexts:
       - >
-        When coughing and squeezing <em>cover mouth and nose</em> with flexed elbow or tissue
-  - type: TextImage
-    bottomImageUri: placeholder/protect/cough.png
+        Avoid touching your eyes, mouth and nose
+  - type: TextEmoji
+    bottomEmoji: 💪
     bodyTexts:
       - >
-        Throw tissue into <em>closed bin</em> immediately after use
-  - type: TextImage
-    bottomImageUri: placeholder/protect/washHands.png
+        Cover your mouth and nose with your bent elbow or tissue when you cough or sneeze
+  - type: TextEmoji
+    bottomEmoji: 🚷
     bodyTexts:
       - >
-        Wash your hands again, <em>frequently</em>
-  - type: TextImage
-    bottomImageUri: placeholder/protect/distance.png
+        Avoid crowded places
+  - type: TextEmoji
+    bottomEmoji: 🏠
     bodyTexts:
       - >
-        <em>Avoid close contact</em> and keep the physical distancing
-  - type: TextImage
-    bottomImageUri: placeholder/protect/distance.png
+        Stay at home if you feel unwell - even with a slight fever and cough
+  - type: TextEmoji
+    bottomEmoji: 🤒
     bodyTexts:
       - >
-        <em>Seek medical care early</em> if you have fever, cough and difficulty breathing
+        If you have a fever, cough and difficulty breathing, <em>seek medical care early</em> - but call by phone first
+  - type: TextEmoji
+    bottomEmoji: ℹ️
+    bodyTexts:
+      - >
+        <em>Stay aware</em> of the latest information from WHO

--- a/content/flows/v1/who-mythbusters.ww.en.yaml
+++ b/content/flows/v1/who-mythbusters.ww.en.yaml
@@ -1,0 +1,82 @@
+type: LinearCarousel
+screens:
+  - type: TextEmoji
+    bottomEmoji: 🧠
+    bodyTexts: 
+      - >
+        There is a lot of false information around. These are the facts.
+  - type: TextEmoji
+    bottomEmoji: 🔢
+    bodyTexts:
+      - >
+        People of all ages CAN be infected by the coronavirus. Older people, and people with pre-existing medical conditions (such as asthma, diabetes, heart disease) appear to be more vulnerable to becoming severely ill with the virus
+  - type: TextEmoji
+    bottomEmoji: ❄️
+    bodyTexts:
+      - >
+        Cold weather and snow CANNOT kill the coronavirus
+  - type: TextEmoji
+    bottomEmoji: ☀️
+    bodyTexts:
+      - >
+        The coronavirus CAN be transmitted in areas with hot and humid climates
+  - type: TextEmoji
+    bottomEmoji: 🦟
+    bodyTexts:
+      - >
+        The coronavirus CANNOT be transmitted through mosquito bites
+  - type: TextEmoji
+    bottomEmoji: 🐶
+    bodyTexts:
+      - >
+        There is NO evidence that companion animals/pets such as dogs or cats can transmit the coronavirus
+  - type: TextEmoji
+    bottomEmoji: 🛀
+    bodyTexts:
+      - >
+        Taking a hot bath DOES NOT prevent the coronavirus
+  - type: TextEmoji
+    bottomEmoji: 💨
+    bodyTexts:
+      - >
+        Hand dryers are NOT effective in killing the coronavirus
+  - type: TextEmoji
+    bottomEmoji: 🟣
+    bodyTexts:
+      - >
+        Ultraviolet light SHOULD NOT be used for sterilization and can cause skin irritation
+  - type: TextEmoji
+    bottomEmoji: 🌡️
+    bodyTexts:
+      - >
+        Thermal scanners CAN detect if people have a fever but CANNOT detect whether or not someone has the coronavirus
+  - type: TextEmoji
+    bottomEmoji: 💦
+    bodyTexts:
+      - >
+        Spraying alcohol or chlorine all over your body WILL NOT kill viruses that have already entered your body
+  - type: TextEmoji
+    bottomEmoji: 💉
+    bodyTexts:
+      - >
+        Vaccines against pneumonia, such as pneumococcal vaccine and Haemophilus influenzae type b (Hib) vaccine, DO NOT provide protection against the coronavirus
+  - type: TextEmoji
+    bottomEmoji: 👃
+    bodyTexts:
+      - >
+        There is NO evidence that regularly rinsing the nose with saline has protected people from infection with the coronavirus
+  - type: TextEmoji
+    bottomEmoji: 🧄
+    bodyTexts:
+      - >
+        Garlic is healthy but there is NO evidence from the current outbreak that eating garlic has protected people from the coronavirus
+  - type: TextEmoji
+    bottomEmoji: 💊
+    bodyTexts:
+      - >
+        Antibiotics DO NOT work against viruses, antibiotics only work against bacteria
+  - type: TextEmoji
+    bottomEmoji: 🧪
+    bodyTexts:
+      - >
+        To date, there is NO specific medicine recommended to prevent or treat the coronavirus


### PR DESCRIPTION
## What does this PR accomplish?

Creates a new TextEmoji screen type that renders text at the top of the screen and a large emoji (as text) at the bottom. Creates a new WHO Myth-busters page using TextEmoji screens, and updates the Protect Yourself page to use TextEmoji screens.

I believe this solves 2 problems for us:
1. Approved, license-compatible, relevant imagery has been hard to come by. I believe we should be able to use emojis in the app without worrying about licenses, since they are rendered by the OS
2. We are attempting to build our content to match the WHO WhatsApp Bot functionality, and the bot already uses these emoji - makes it easy to transfer the content to our app

Potential concerns to investigate with using emoji:
* Will there be any cross-device rendering issues with emoji?
* Will we be losing support for some older devices and/or operating systems that can't render emoji?
  * Including if any emoji we are using were added in a later spec
* Are there any accessibility concerns with using emoji?

I think that the above concerns are somewhat mitigated by the fact that the emoji is just auxiliary content on the page, and it is the text that is the essential information of the screen. So someone can still get the primary meaning of each screen even if the emoji doesn't render exactly as we hope.

Closes #227 

## Did you add any dependencies?

N/A

## How did you test the change?

* [x] In browser
* [x] On iOS Simulator
