### PR TITLE
Comment out placeholder text in the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,17 +4,20 @@ NOTE: Please ensure you:
 * follow the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/CONTRIBUTING.md),
 * use a draft PR if you don't want the committers to review your code,
 * and make sure that all contributions are properly licensed pursuant to the LICENSE file in the root of the repository.
-
 -->
+
 ## What does this PR accomplish?
-[Title should be a short phrase ex. "Adds survey functionality"]
 
-[Detailed description can include any design decisions you want reviewers to take note of.]
+<!-- Title should be a short phrase, e.g. "Adds survey functionality". -->
 
-[List all issue numbers affected and closed by this PR.]
+<!-- Detailed description can include any design decisions you want reviewers to take note of. -->
+
+<!-- List all issue numbers affected and closed by this PR. -->
 
 ## Did you add any dependencies?
-[List each added dependency and justifications (see the Guidelines)]
+
+<!-- List each added dependency and justifications (see the Guidelines) -->
 
 ## How did you test the change?
-[If relevant, add any screenshots of your UI changes.]
+
+<!-- If relevant, add any screenshots of your UI changes. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,11 @@
+<!--
 NOTE: Please ensure you:
 * provide a detailed pull request description and a succinct title (consider template below for guidance),
 * follow the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/CONTRIBUTING.md),
 * use a draft PR if you don't want the committers to review your code,
 * and make sure that all contributions are properly licensed pursuant to the LICENSE file in the root of the repository.
 
+-->
 ## What does this PR accomplish?
 [Title should be a short phrase ex. "Adds survey functionality"]
 


### PR DESCRIPTION
## What does this PR accomplish?
This just makes it a bit smoother to create a PR. The initial placeholder text is something that the PR creator should read through when they first see the PR -- this change will make it so that they just need to read through it, and don't need to delete it.

This is also a quite standard practice across GitHub repositories -- see, for example, React's PR template: https://raw.githubusercontent.com/facebook/react/master/.github/PULL_REQUEST_TEMPLATE.md