### PR TITLE
Replace invalid slack invite link

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -6,7 +6,7 @@ The goal of this document is to give you a starting point for where to find the 
 
 First thing's first - in order to keep track of everyone working on the project, please add yourself to the project roster: https://docs.google.com/spreadsheets/d/1jt4xrXWUnsh8DmtawNV4XGBj8RAdgn-d7ckgL2qEXPM/edit#gid=0
 
-Next - join the [Slack](https://join.slack.com/t/who-app/shared_invite/zt-cylowls6-Q7iQPvTAenkN_Yb9MLxVIw) and introduce yourself in the #intros channel! To avoid confusion, please include your GitHub username and timezone in your Slack display name, e.g. `Hunter Spinks, hspinks, PST`.
+Next - join the [Slack](https://join.slack.com/t/who-app/shared_invite/zt-cx6ycppt-ccqPJ7ZSGy3~77gSByexJw) and introduce yourself in the #intros channel! To avoid confusion, please include your GitHub username and timezone in your Slack display name, e.g. `Hunter Spinks, hspinks, PST`.
 
 If you need access to issues & tasks on GitHub, please add your GitHub username to [this ticket](https://github.com/WorldHealthOrganization/app/issues/99) and [Sam Mousa](https://github.com/SamMousa) can add you with the appropriate roles.
 
@@ -19,7 +19,7 @@ We have a regular, daily all-hands over Zoom at 11am PDT. Details on the standup
 Where to find answers to your questions:
 
 * GitHub Issues: https://github.com/WorldHealthOrganization/app/issues
-* Slack: https://join.slack.com/t/who-app/shared_invite/zt-cylowls6-Q7iQPvTAenkN_Yb9MLxVIw
+* Slack: https://join.slack.com/t/who-app/shared_invite/zt-cx6ycppt-ccqPJ7ZSGy3~77gSByexJw
 * Initial project brief (will be updated): https://docs.google.com/document/d/1isNMLpwI2iUY92KPwJHfY7kQnpN3oCuUl6c94J7Qmhs
 * Rough engineering backlog: https://github.com/WorldHealthOrganization/app/projects/1
 * Most up-to-date app design spec: https://github.com/WorldHealthOrganization/app/issues/129


### PR DESCRIPTION
<!--
NOTE: Please ensure you:
* provide a detailed pull request description and a succinct title (consider template below for guidance),
* follow the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/CONTRIBUTING.md),
* use a draft PR if you don't want the committers to review your code,
* and make sure that all contributions are properly licensed pursuant to the LICENSE file in the root of the repository.
-->

## What does this PR accomplish?

Replace the invalid slack invite link with a working one. Relates to #245.

## Did you add any dependencies?

N/A

## How did you test the change?

Tested by opening links in an incognito tab to verify that the invite works.
