### PR TITLE
[WHO-56] Reduce Ionic Security Permissions to minimum

### DIFF
--- a/client/ionic/android/app/src/main/AndroidManifest.xml
+++ b/client/ionic/android/app/src/main/AndroidManifest.xml
@@ -44,21 +44,5 @@
 
     <!-- TODO: Review requires permissions: https://github.com/WorldHealthOrganization/app/issues/56 -->
     <!-- Permissions -->
-
     <uses-permission android:name="android.permission.INTERNET" />
-    <!-- Camera, Photos, input file -->
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <!-- Geolocation API -->
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-feature android:name="android.hardware.location.gps" />
-    <!-- Network API -->
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <!-- Navigator.getUserMedia -->
-    <!-- Video -->
-    <uses-permission android:name="android.permission.CAMERA" />
-    <!-- Audio -->
-    <uses-permission android:name="android.permission.RECORD_AUDIO" />
-    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
 </manifest>


### PR DESCRIPTION
<!--
NOTE: Please ensure you:
* provide a detailed pull request description and a succinct title (consider template below for guidance),
* follow the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/CONTRIBUTING.md),
* use a draft PR if you don't want the committers to review your code,
* and make sure that all contributions are properly licensed pursuant to the LICENSE file in the root of the repository.
-->

## What does this PR accomplish?

Reduces Ionic security permissions to minimum required.

No permissions are required for this build.

closes:

https://github.com/WorldHealthOrganization/app/issues/56

## Did you add any dependencies?

- no dependencies added

## How did you test the change?

- ionic build
- ionic capacitor copy android
- npx cap update android
- ionic capacitor run android -l --external

Clicked through the app and it worked on the simulator
