### PR TITLE
docs: add Android Studio to dependencies in build doc

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -1,6 +1,6 @@
 # Building the App for App Store Submission
 
-These instructions will assume that you have the up-to-date [`git`](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), [Flutter](https://flutter.dev/docs/get-started/install), and [CocoaPods](https://guides.cocoapods.org/using/getting-started.html#installation) already installed.
+These instructions will assume that you have the up-to-date [`git`](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), [Flutter](https://flutter.dev/docs/get-started/install), [Android Studio](https://developer.android.com/studio/index.html), and [CocoaPods](https://guides.cocoapods.org/using/getting-started.html#installation) already installed.
   * _Note: this was tested using CocoaPods version `1.9.1`_
 
 ## Clone the Repo

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -1,6 +1,6 @@
 # Building the App for App Store Submission
 
-These instructions will assume that you have the up-to-date [`git`](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), [Flutter](https://flutter.dev/docs/get-started/install), [Android Studio](https://developer.android.com/studio/index.html), and [CocoaPods](https://guides.cocoapods.org/using/getting-started.html#installation) already installed.
+These instructions will assume that you have the up-to-date [`git`](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), [Flutter](https://flutter.dev/docs/get-started/install), [Android Studio](https://developer.android.com/studio/index.html), [XCode](https://developer.apple.com/xcode/), and [CocoaPods](https://guides.cocoapods.org/using/getting-started.html#installation) already installed.  You must use a macOS system to build the iOS app.
   * _Note: this was tested using CocoaPods version `1.9.1`_
 
 ## Clone the Repo


### PR DESCRIPTION
## What does this PR accomplish?

Notes that Android Studio is a requirement to build.

(Actually I think it's really just the Android toolchain that comes with it)

## Did you add any dependencies?

N/A

## How did you test the change?

N/A
