### PR TITLE
:iphone: refactor(carousel_page): use auto scrolling carousel indicator

### DIFF
--- a/client/flutter/lib/carousel_page.dart
+++ b/client/flutter/lib/carousel_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:WHOFlutter/constants.dart';
 import 'package:WHOFlutter/page_scaffold.dart';
 import 'package:flutter/rendering.dart';
-import 'package:page_view_indicator/page_view_indicator.dart';
+import 'package:scrolling_page_indicator/scrolling_page_indicator.dart';
 
 class CarouselSlide extends StatelessWidget {
   final Widget titleWidget;
@@ -46,7 +46,7 @@ class CarouselView extends StatelessWidget {
 
   CarouselView(this.items);
 
-  final pageIndexNotifier = ValueNotifier<int>(0);
+  final pageController = PageController();
 
   @override
   Widget build(BuildContext context) {
@@ -54,7 +54,7 @@ class CarouselView extends StatelessWidget {
       body: Stack(
         children: <Widget>[
           PageView(
-            onPageChanged: (i) => pageIndexNotifier.value = i,
+            controller: pageController,
             children: this.items,
           ),
           Align(
@@ -81,35 +81,18 @@ class CarouselView extends StatelessWidget {
 
   Widget pageViewIndicator(BuildContext context) {
     var width = MediaQuery.of(context).size.width;
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: <Widget>[
-        Container(
-          constraints: BoxConstraints(maxWidth: width * 0.75),
-          child: SingleChildScrollView(
-            scrollDirection: Axis.horizontal,
-            child: PageViewIndicator(
-              pageIndexNotifier: pageIndexNotifier,
-              length: this.items.length,
-              normalBuilder: (animationController, index) => Circle(
-                size: 8.0,
-                color: Colors.grey,
-              ),
-              highlightedBuilder: (animationController, index) =>
-                  ScaleTransition(
-                scale: CurvedAnimation(
-                  parent: animationController,
-                  curve: Curves.ease,
-                ),
-                child: Circle(
-                  size: 10.0,
-                  color: Constants.primaryColor,
-                ),
-              ),
-            ),
-          ),
-        ),
-      ],
+    return Container(
+      constraints: BoxConstraints(maxWidth: width * 0.75),
+      child: ScrollingPageIndicator(
+        dotColor: Colors.grey,
+        dotSelectedColor: Constants.primaryColor,
+        dotSize: 8,
+        dotSelectedSize: 10,
+        dotSpacing: 24,
+        visibleDotCount: 7,
+        controller: pageController,
+        itemCount: items.length,
+      ),
     );
   }
 }

--- a/client/flutter/pubspec.lock
+++ b/client/flutter/pubspec.lock
@@ -105,13 +105,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.8"
-  page_view_indicator:
-    dependency: "direct main"
-    description:
-      name: page_view_indicator
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.4"
   path:
     dependency: transitive
     description:
@@ -147,6 +140,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.5"
+  scrolling_page_indicator:
+    dependency: "direct main"
+    description:
+      name: scrolling_page_indicator
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.2"
   share:
     dependency: "direct main"
     description:

--- a/client/flutter/pubspec.yaml
+++ b/client/flutter/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
 
   share: ^0.6.3+6
   url_launcher: ^5.4.2
-  page_view_indicator: ^2.0.4
+  scrolling_page_indicator: ^0.1.2
   intl: ^0.16.0
   flutter_localizations:
     sdk: flutter

--- a/content/credits.yaml
+++ b/content/credits.yaml
@@ -24,6 +24,7 @@ team:
   - Ashwin Ramaswami
   - Benjamin Swerdlow
   - Jason Telanoff
+  - Khaleel Shaheen
 # Add yourself here when you first submit a contribution.
 
 # TODO: Pre-launch, review above list to add in the full team that doesn't make git commits!


### PR DESCRIPTION
Remove `page_view_indicator` package and use `scrolling_page_indicator` instead. This is a better user experience when there is many pages than the screen width can show.

<!--
NOTE: Please ensure you:
* provide a detailed pull request description and a succinct title (consider template below for guidance),
* follow the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md),
* use a draft PR if you don't want the committers to review your code,
* and make sure that all contributions are properly licensed pursuant to the LICENSE file in the root of the repository.
-->

## What does this PR accomplish?
Adds auto scrolling carousel.

This PR solves the issue when there is lot's of pages, and hence page indicator circles, than the screen width can show.

Now, it shows an auto scrolling page progress indicator, similar to Instagram's carousel indicator

Issues affected:
#320 
#325 

## Did you add any dependencies?
I removed `page_view_indicator` package.
I added `scrolling_page_indicator`

## How did you test the change?
Tested on Android and iOS emulators.
Tested on Android device.

![image](https://user-images.githubusercontent.com/9870509/77703219-f69c5300-6fc2-11ea-83ae-6dd92eaa89f5.png)
![image](https://user-images.githubusercontent.com/9870509/77703254-103d9a80-6fc3-11ea-8741-7229b8c2c962.png)

