### PR TITLE
Fix missing visual feedback for `PageButton` with light background

### DIFF
--- a/client/flutter/lib/page_button.dart
+++ b/client/flutter/lib/page_button.dart
@@ -29,6 +29,8 @@ class PageButton extends StatelessWidget {
         padding: EdgeInsets.all(16.0 + 16.0 * (scale - 1.0)),
         onPressed: onPressed,
         color: lightColor ? Colors.white : Constants.primaryColor,
+        splashColor:
+            (lightColor ? Constants.primaryColor : Colors.white).withAlpha(66),
         child: Text(
           title,
           textScaleFactor: scale * 1.2,
@@ -39,4 +41,3 @@ class PageButton extends StatelessWidget {
     );
   }
 }
-

--- a/content/credits.yaml
+++ b/content/credits.yaml
@@ -24,6 +24,7 @@ team:
   - Ashwin Ramaswami
   - Benjamin Swerdlow
   - Jason Telanoff
+  - Dustin Catap
 # Add yourself here when you first submit a contribution.
 
 # TODO: Pre-launch, review above list to add in the full team that doesn't make git commits!


### PR DESCRIPTION
<!--
NOTE: Please ensure you:
* provide a detailed pull request description and a succinct title (consider template below for guidance),
* follow the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md),
* use a draft PR if you don't want the committers to review your code,
* and make sure that all contributions are properly licensed pursuant to the LICENSE file in the root of the repository.
-->

## What does this PR accomplish?
Fix missing touch feedback for `PageButton` with light background.

When `lightcolor` is `true`, it uses the `primaryColor` as the splash color, otherwise it uses `Colors.white`. Both of these colors will be applied with an alpha of `26%`.


## Did you add any dependencies?
No

## How did you test the change?
 Tested on Samsung S10 (Android 29).

Old:
<img src="https://user-images.githubusercontent.com/56006524/77716967-48bc9300-701a-11ea-98f2-9b979eb10186.gif" width="512"/>

New:
<img src="https://user-images.githubusercontent.com/56006524/77717060-7a355e80-701a-11ea-8dfd-401f18ce7229.gif" width="512" />

