### PR TITLE
Add left and right arrows to the carousel page

### DIFF
--- a/client/flutter/lib/carousel_page.dart
+++ b/client/flutter/lib/carousel_page.dart
@@ -7,9 +7,8 @@ import 'package:page_view_indicator/page_view_indicator.dart';
 class CarouselSlide extends StatelessWidget {
   final Widget titleWidget;
   final String message;
-  final BuildContext context;
 
-  CarouselSlide(this.context, {this.titleWidget, this.message = ""});
+  CarouselSlide({this.titleWidget, this.message = ""});
 
   @override
   Widget build(BuildContext context) {
@@ -45,14 +44,20 @@ class CarouselSlide extends StatelessWidget {
   }
 }
 
-class CarouselView extends StatelessWidget {
+class CarouselView extends StatefulWidget {
   final List<CarouselSlide> items;
 
   CarouselView(this.items);
 
-  final pageIndexNotifier = ValueNotifier<int>(0);
+  @override
+  _CarouselViewState createState() => _CarouselViewState();
+}
 
-  PageController pageController = new PageController();
+class _CarouselViewState extends State<CarouselView> {
+  final _kPageTransitionDuration = const Duration(milliseconds: 300);
+
+  final pageIndexNotifier = ValueNotifier<int>(0);
+  final pageController = PageController(initialPage: 0);
 
   @override
   Widget build(BuildContext context) {
@@ -62,7 +67,49 @@ class CarouselView extends StatelessWidget {
           PageView(
             controller: pageController,
             onPageChanged: (i) => pageIndexNotifier.value = i,
-            children: this.items,
+            children: this.widget.items,
+          ),
+          ValueListenableBuilder(
+            valueListenable: pageIndexNotifier,
+            builder: (BuildContext context, int page, Widget child) {
+              return Visibility(
+                visible: page > 0,
+                child: child,
+              );
+            },
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: IconButton(
+                icon: Icon(Icons.chevron_left, size: 36),
+                onPressed: () {
+                  pageController.previousPage(
+                    duration: _kPageTransitionDuration,
+                    curve: Curves.fastOutSlowIn
+                  );
+                },
+              ),
+            ),
+          ),
+          ValueListenableBuilder(
+            valueListenable: pageIndexNotifier,
+            builder: (BuildContext context, int page, Widget child) {
+              return Visibility(
+                visible: page < widget.items.length - 1,
+                child: child,
+              );
+            },
+            child: Align(
+              alignment: Alignment.centerRight,
+              child: IconButton(
+                icon: Icon(Icons.chevron_right, size: 36),
+                onPressed: () {
+                  pageController.nextPage(
+                    duration: _kPageTransitionDuration,
+                    curve: Curves.fastOutSlowIn
+                  );
+                },
+              ),
+            ),
           ),
           Align(
             alignment: FractionalOffset.bottomCenter,
@@ -70,18 +117,13 @@ class CarouselView extends StatelessWidget {
                 padding: EdgeInsets.only(bottom: 20),
                 child: pageViewIndicator(context)),
           ),
-          GestureDetector(
-              onTap: () => pageController.page == this.items.length - 1
-                  ? null
-                  : pageController.nextPage(
-                      duration: Duration(milliseconds: 500),
-                      curve: Curves.easeInOutCubic)),
           Align(
               alignment: FractionalOffset.topRight,
               child: Padding(
                 padding: const EdgeInsets.only(right: 24.0),
                 child: IconButton(
                     icon: Icon(Icons.close),
+                    color: Colors.grey,
                     onPressed: () {
                       Navigator.of(context).pop();
                     }),
@@ -103,7 +145,7 @@ class CarouselView extends StatelessWidget {
             scrollDirection: Axis.horizontal,
             child: PageViewIndicator(
               pageIndexNotifier: pageIndexNotifier,
-              length: this.items.length,
+              length: this.widget.items.length,
               normalBuilder: (animationController, index) => Circle(
                 size: 8.0,
                 color: Colors.grey,

--- a/client/flutter/lib/pages/protect_yourself.dart
+++ b/client/flutter/lib/pages/protect_yourself.dart
@@ -6,26 +6,26 @@ class ProtectYourself extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return CarouselView([
-      CarouselSlide(context,
+      CarouselSlide(
           titleWidget: EmojiHeader("🧼"), message: S.of(context).washHands),
-      CarouselSlide(context,
+      CarouselSlide(
           titleWidget: EmojiHeader("👄"),
           message: "Avoid touching your eyes, mouth, and nose"),
-      CarouselSlide(context,
+      CarouselSlide(
           titleWidget: EmojiHeader("💪"),
           message:
               "Cover your mouth and nose with your bent elbow or tissue when you cough or sneeze"),
-      CarouselSlide(context,
+      CarouselSlide(
           titleWidget: EmojiHeader("🚷"), message: "Avoid crowded places"),
-      CarouselSlide(context,
+      CarouselSlide(
           titleWidget: EmojiHeader("🏠"),
           message: "Stay at home if you feel unwell - even with a slight fever and cough"),
 
-      CarouselSlide(context,
+      CarouselSlide(
           titleWidget: EmojiHeader("🤒"),
           message: "If you have a fever, cough and difficulty breathing, seek medical care early but call by phone first!"),
 
-      CarouselSlide(context,
+      CarouselSlide(
           titleWidget: EmojiHeader("ℹ️"),
           message: "Stay aware of the latest information from WHO"),
     ]);

--- a/client/flutter/lib/pages/travel_advice.dart
+++ b/client/flutter/lib/pages/travel_advice.dart
@@ -7,67 +7,53 @@ class TravelAdvice extends StatelessWidget {
   Widget build(BuildContext context) {
     return CarouselView([
       CarouselSlide(
-        context,
         message: "WHO continues to advise against the application of travel or trade restrictions to countries experiencing COVID-19 outbreaks…"
       ),
       CarouselSlide(
-        context,
         message: "It is prudent for travellers who are sick to delay or avoid travel to affected areas, in particular for elderly travellers and people with chronic diseases or underlying health conditions…"
       ),
       CarouselSlide(
-        context,
         message: "“Affected areas” are considered those countries, provinces, territories or cities experiencing ongoing transmission of COVID-19, in contrast to areas reporting only imported cases…"
       ),
       CarouselSlide(
-        context,
         message: "General recommendations for all travellers include…"
       ),
       CarouselSlide(
-        context,
         titleWidget: EmojiHeader("🧼"),
         message: "Wash your hands frequently"
       ),
       CarouselSlide(
-        context,
         titleWidget: EmojiHeader("👄"),
         message: "Avoid touching your eyes, mouth and nose"
       ),
       CarouselSlide(
-        context,
         titleWidget: EmojiHeader("💪"),
         message: "Cover your mouth and nose with your bent elbow or tissue when you cough or sneeze"
       ),
       CarouselSlide(
-        context,
         titleWidget: EmojiHeader("↔️"),
         message: "Stay more than 1 meter (3 feet) away from a person who is sick"
       ),
       CarouselSlide(
-        context,
         titleWidget: EmojiHeader("🍗"),
         message: "Follow proper food hygiene practices"
       ),
       CarouselSlide(
-        context,
         titleWidget: EmojiHeader("😷"),
         message: "Only wear a mask if you are ill with COVID-19 symptoms (especially coughing) or looking after someone who may have COVID-19"
       ),
       CarouselSlide(
-        context,
         message: "Travellers returning from affected areas should:",
       ),
       CarouselSlide(
-        context,
         titleWidget: EmojiHeader("🌡"),
         message: "Self-monitor for symptoms for 14 days and follow national protocols of receiving countries. Some countries may require returning travellers to enter quarantine",
       ),
       CarouselSlide(
-        context,
         titleWidget: EmojiHeader("🌡️"),
         message: "Thermal scanners CAN detect if people have a fever but CANNOT detect whether or not someone has the coronavirus",
       ),
       CarouselSlide(
-        context,
         titleWidget: EmojiHeader("🤒"),
         message: "If symptoms occur, such as fever, or cough or difficulty breathing, travellers are advised to contact local health care providers, preferably by phone, and inform them of their symptoms and their travel history",
       ),

--- a/client/flutter/lib/pages/who_myth_busters.dart
+++ b/client/flutter/lib/pages/who_myth_busters.dart
@@ -7,87 +7,74 @@ class WhoMythBusters extends StatelessWidget {
   Widget build(BuildContext context) {
     return CarouselView([
       CarouselSlide(
-        context,
         titleWidget: EmojiHeader("🧠"),
         message:
             "There is a lot of false information around. These are the facts",
       ),
       CarouselSlide(
-        context,
         titleWidget: EmojiHeader("🔢"),
         message:
             "People of all ages CAN be infected by the coronavirus. Older people, and people with pre-existing medical conditions (such as asthma, diabetes, heart disease) appear to be more vulnerable to becoming severely ill with the virus",
       ),
-      CarouselSlide(context,
+      CarouselSlide(
           titleWidget: EmojiHeader("❄️"),
           message: "Cold weather and snow CANNOT kill the coronavirus"),
       CarouselSlide(
-        context,
         titleWidget: EmojiHeader("☀️"),
         message:
             "The coronavirus CAN be transmitted in areas with hot and humid climates",
       ),
       CarouselSlide(
-        context,
         titleWidget: EmojiHeader("🦟"),
         message: "The coronavirus CANNOT be transmitted through mosquito bites",
       ),
       CarouselSlide(
-        context,
         titleWidget: EmojiHeader("🐶"),
         message:
             "There is NO evidence that companion animals/pets such as dogs or cats can transmit the coronavirus",
       ),
-      CarouselSlide(context,
+      CarouselSlide(
           titleWidget: EmojiHeader("🛀"),
           message: "Taking a hot bath DOES NOT prevent the coronavirus"),
-      CarouselSlide(context,
+      CarouselSlide(
           titleWidget: EmojiHeader("💨"),
           message: "Hand dryers are NOT effective in killing the coronavirus"),
       CarouselSlide(
-        context,
         titleWidget: EmojiHeader("🟣"),
         message:
             "Ultraviolet light SHOULD NOT be used for sterilization and can cause skin irritation",
       ),
       CarouselSlide(
-        context,
         titleWidget: EmojiHeader("🌡️"),
         message:
             "Thermal scanners CAN detect if people have a fever but CANNOT detect whether or not someone has the coronavirus",
       ),
       CarouselSlide(
-        context,
         titleWidget: EmojiHeader("💦"),
         message:
             "Spraying alcohol or chlorine all over your body WILL NOT kill viruses that have already entered your body",
       ),
       CarouselSlide(
-        context,
         titleWidget: EmojiHeader("💉"),
         message:
             "Vaccines against pneumonia, such as pneumococcal vaccine and Haemophilus influenzae type b (Hib) vaccine, DO NOT provide protection against the coronavirus",
       ),
       CarouselSlide(
-        context,
         titleWidget: EmojiHeader("👃"),
         message:
             "There is NO evidence that regularly rinsing the nose with saline has protected people from infection with the coronavirus",
       ),
       CarouselSlide(
-        context,
         titleWidget: EmojiHeader("🧄"),
         message:
             "Garlic is healthy but there is NO evidence from the current outbreak that eating garlic has protected people from the coronavirus",
       ),
       CarouselSlide(
-        context,
         titleWidget: EmojiHeader("💊"),
         message:
             "Antibiotics DO NOT work against viruses, antibiotics only work against bacteria",
       ),
       CarouselSlide(
-        context,
         titleWidget: EmojiHeader("🧪"),
         message:
             "To date, there is NO specific medicine recommended to prevent or treat the coronavirus",

--- a/client/flutter/pubspec.lock
+++ b/client/flutter/pubspec.lock
@@ -200,7 +200,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.11"
+    version: "0.2.15"
   typed_data:
     dependency: transitive
     description:

--- a/client/flutter/test/carousel_page_test.dart
+++ b/client/flutter/test/carousel_page_test.dart
@@ -1,0 +1,48 @@
+import 'package:WHOFlutter/carousel_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('page changing', () {
+    testWidgets('can change page via chevrons', (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: CarouselView(
+          <CarouselSlide>[
+            CarouselSlide(message: 'page 1'),
+            CarouselSlide(message: 'page 2'),
+            CarouselSlide(message: 'page 3'),
+          ]
+        ),
+      ));
+
+      // Can't go back from page 1. No left chevron.
+      expect(find.byIcon(Icons.chevron_left), findsNothing);
+      expect(find.byIcon(Icons.chevron_right), findsOneWidget);
+      expect(find.text('page 1'), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.chevron_right));
+      await tester.pumpAndSettle();
+
+      // Both chevrons are present on page 2.
+      expect(find.byIcon(Icons.chevron_left), findsOneWidget);
+      expect(find.byIcon(Icons.chevron_right), findsOneWidget);
+      expect(find.text('page 2'), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.chevron_right));
+      await tester.pumpAndSettle();
+
+      // Can't go forward any further on last page.
+      expect(find.byIcon(Icons.chevron_left), findsOneWidget);
+      expect(find.byIcon(Icons.chevron_right), findsNothing);
+      expect(find.text('page 3'), findsOneWidget);
+
+      // Check that going back works too.
+      await tester.tap(find.byIcon(Icons.chevron_left));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.chevron_left), findsOneWidget);
+      expect(find.byIcon(Icons.chevron_right), findsOneWidget);
+      expect(find.text('page 2'), findsOneWidget);
+    });
+  });
+}

--- a/content/credits.yaml
+++ b/content/credits.yaml
@@ -24,6 +24,7 @@ team:
   - Ashwin Ramaswami
   - Benjamin Swerdlow
   - Jason Telanoff
+  - Xiao Yu
 # Add yourself here when you first submit a contribution.
 
 # TODO: Pre-launch, review above list to add in the full team that doesn't make git commits!


### PR DESCRIPTION
## What does this PR accomplish?

Resolves https://github.com/WorldHealthOrganization/app/issues/242

@viviancromwell I don't have access to your actual updated specs anywhere (https://github.com/WorldHealthOrganization/app/issues/129 doesn't seem to have it), so I'm just following your updates verbally. 

Also fixes a few nit bugs along the way:

- Passing in a BuildContext to a StatelessWidget's constructor isn't right unless you're trying some specific tree surgery type operations which isn't the case here. You generally want to access the BuildContext for the Element your widget is associated with (which is passed in during build).
- Holding state in a StatelessWidget (CarouselView) isn't right. Currently we're lucky in that no parent is causing a rebuild of the CarouselView. If there were, we'd keep building a new pageController. 

## Did you add any dependencies?

No

## How did you test the change?

Added widget test. 

![flutter_01](https://user-images.githubusercontent.com/156888/77725597-19bf0680-6fb3-11ea-9ef0-83d414691960.png)

