### PR TITLE
🐛 Fix: CarouselView close/X button ripple effect draws over page content

### DIFF
--- a/client/flutter/lib/carousel_page.dart
+++ b/client/flutter/lib/carousel_page.dart
@@ -76,16 +76,22 @@ class CarouselView extends StatelessWidget {
                   : pageController.nextPage(
                       duration: Duration(milliseconds: 500),
                       curve: Curves.easeInOutCubic)),
-          Align(
+           Align(
               alignment: FractionalOffset.topRight,
               child: Padding(
                 padding: const EdgeInsets.only(right: 24.0),
-                child: IconButton(
+                child: Material( 
+                  child: InkWell(
+                    customBorder: CircleBorder(),
+                    child: IconButton(
                     icon: Icon(Icons.close),
                     onPressed: () {
                       Navigator.of(context).pop();
                     }),
-              )),
+                  )
+              )
+            ),
+          )
         ],
       ),
       bodyPadding: EdgeInsets.zero,

--- a/content/credits.yaml
+++ b/content/credits.yaml
@@ -24,6 +24,7 @@ team:
   - Ashwin Ramaswami
   - Benjamin Swerdlow
   - Jason Telanoff
+  - Julian Aßmann
 # Add yourself here when you first submit a contribution.
 
 # TODO: Pre-launch, review above list to add in the full team that doesn't make git commits!


### PR DESCRIPTION
- [✔️] Provided detailed pull request description and a succinct title (consider template below for guidance).
- [✔️] Tested your changes, especially after any code review iterations.
- [✔️] Included any relevant screenshots of UI updates.
- [✔️] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [✔️] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [✔️] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).

## What does this PR accomplish?
Fixes an visual error where the close button ripple effect on touch of the widget `CarouselView` was overdrawn by the page content shown. Fixes #390.

<!-- Title should be a short phrase, e.g. "Adds survey functionality". -->

<!-- Detailed description can include any design decisions you want reviewers to take note of. -->

<!-- List all issue numbers affected and closed by this PR. -->

## Did you add any dependencies?
No.

## How did you test the change?
Running the app and testing the visual change manually. See screenshots:

Before: 
![image](https://user-images.githubusercontent.com/15306765/77735250-82859d80-700a-11ea-81c5-ccc676c05362.png)
After: 
![image](https://user-images.githubusercontent.com/15306765/77736921-561f5080-700d-11ea-88df-39f4aeb1f870.png)