### PR TITLE
Require admin approval for changes to CI workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+.github/workflows @SamMousa @brunobowden

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/workflows @SamMousa @brunobowden
+.github/workflows @SamMousa @brunobowden @advayDev1

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/workflows @SamMousa @brunobowden @advayDev1
+.github/workflows @SamMousa @brunobowden


### PR DESCRIPTION
## What does this PR accomplish?

Require admin approval for changes to CI workflows by using GitHub's [CODEOWNERS functionality](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-file-location).

Once this is merged, we need to check "Require Review from Code Owners."

![image](https://user-images.githubusercontent.com/1689183/77762020-47d23400-700f-11ea-8a79-f15d1bf2b555.png)

This way, it will reduce the risk of committers extracting / leaking secrets used in CI because they cannot modify the CI workflows without admin approval (approval by @brunobowden or @SamMousa ).