### PR TITLE
Add .github/CODEOWNERS to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 .github/workflows @SamMousa @brunobowden
+.github/CODEOWNERS @SamMousa @brunobowden


### PR DESCRIPTION
## What does this PR accomplish?

Add .github/CODEOWNERS to CODEOWNERS. Otherwise, someone may be able to change the CODEOWNERS file and bypass CODEOWNERS protections.
