### PR TITLE
Welcome new committers!

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,40 @@
-.github/workflows @SamMousa @brunobowden
+# Each line is a file pattern followed by one or more owners.
+# Order is important; the last matching pattern takes the most
+# precedence. 
+#
+# Security sensitive items must be at the end.
+#
+# All user entries should be alpha-sorted and lowercase.
+
+
+# These owners will be the default owners for everything in
+# the repo, unless a later match takes precedence.
+# Sadly, we have to repeat the top-level owners everywhere,
+# since we are not team-members of a GitHub Organization.
+
+* @advaydev1 @brunobowden @crazybob @hspinks @sammousa
+
+# Feature areas:
+
+# Client UI
+/client/flutter/ @advaydev1 @brunobowden @crazybob @hspinks @patniemeyer @sammousa @theswerd
+
+# Client Localization
+# Pure translation changes can be approved by @sapte91, but Client UI folks can also still approve/submit
+# as needed when mixed with code changes.
+/client/flutter/lib/generated/intl/ @advaydev1 @brunobowden @crazybob @hspinks @patniemeyer @sammousa @sapte91 @theswerd
+/client/flutter/lib/l10n/ @advaydev1 @brunobowden @crazybob @hspinks @patniemeyer @sammousa @sapte91 @theswerd
+
+# Team-wide processes
+/docs/ @advaydev1 @brunobowden @crazybob @hspinks @deanhach
+
+# Release process
+/docs/RELEASE.md @advaydev1 @brunobowden @crazybob @epicfaace @hspinks @deanhach
+
+# Server
+/server/ @advaydev1 @brunobowden @crazybob @hspinks @sammousa
+
+# Security-sensitive - always keep these at the end.
+# CI and CD
+/.github/workflows/ @sammousa @brunobowden
+/.github/CODEOWNERS @sammousa @brunobowden


### PR DESCRIPTION
Reflecting our new feature leads structure, closes #500 

The structure:
* Pat and Ben for Client
* Shilpa for L18n - pure translations can be approved by her alone, but Client UI can also keep working independently when they need to change code and strings in one PR
* Ashwin for Release process
* Bob for Server

* General committers Bruno, Bob, Sam, Hunter, and Advay have repo-wide access
* Admins Bruno or Sam must approve all changes to the approvers themselves or CI or CD.