### PR TITLE
Roll-out feature-scoped commit access

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,43 @@
-.github/workflows @SamMousa @brunobowden
+# Each line is a file pattern followed by one or more owners.
+# Order is important; the last matching pattern takes the most
+# precedence. 
+#
+# Security sensitive items must be at the end.
+#
+# All user entries should be alpha-sorted and lowercase.
+
+# These owners will be the default owners for everything in
+# the repo, unless a later match takes precedence.
+# Sadly, we have to repeat the top-level owners everywhere,
+# since we are not team-members of a GitHub Organization.
+
+* @advaydev1 @brunobowden @crazybob @hspinks @sammousa
+
+# Feature areas:
+
+# Client UI
+/client/flutter/ @advaydev1 @brunobowden @crazybob @hspinks @patniemeyer @sammousa @theswerd
+
+# Client Localization
+# Pure translation changes can be approved by @sapte91, but Client UI folks can also still approve/submit
+# as needed when mixed with code changes.
+/client/flutter/lib/generated/intl/ @advaydev1 @brunobowden @crazybob @hspinks @patniemeyer @sammousa @sapte91 @theswerd
+/client/flutter/lib/l10n/ @advaydev1 @brunobowden @crazybob @hspinks @patniemeyer @sammousa @sapte91 @theswerd
+
+# Team-wide processes
+/docs/ @advaydev1 @brunobowden @crazybob @hspinks @deanhach
+
+# Release process
+/docs/RELEASE.md @advaydev1 @brunobowden @crazybob @epicfaace @hspinks @deanhach
+
+# Server
+/server/ @advaydev1 @brunobowden @crazybob @hspinks @sammousa
+
+# API
+/api/ @advaydev1 @brunobowden @crazybob @hspinks @sammousa
+
+# ***** Security-sensitive - always keep these at the end. *****
+
+# CI and CD, Repo admins who can access secrets.
+/.github/workflows/ @brunobowden @crazybob @sammousa
+/.github/CODEOWNERS @brunobowden @crazybob @sammousa

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,6 +29,7 @@
 
 # Release process
 /docs/RELEASE.md @advaydev1 @brunobowden @crazybob @epicfaace @hspinks @deanhach
+/docs/release/ @advaydev1 @brunobowden @crazybob @epicfaace @hspinks @deanhach
 
 # Server
 /server/ @advaydev1 @brunobowden @crazybob @hspinks @sammousa


### PR DESCRIPTION
Redo #501 in my own repo

Reflecting our new feature leads structure, closes #500

The structure:
* Pat and Ben for Client
* Shilpa for L18n - pure translations can be approved by her alone, but Client UI can also keep working independently when they need to change code and strings in one PR
* Ashwin for Release process
* Bob for Server
* General committers Bruno, Bob, Sam, Hunter, and Advay have repo-wide access
* Admins Bruno, Bob, or Sam must approve all changes to the approvers themselves or CI or CD.

Co-authored-by: Hunter Spinks <hspinks@gmail.com>