### PR TITLE
This fixes the build for the flutter stable channel XCode 11.4 

### DIFF
--- a/client/flutter/ios/Runner.xcodeproj/project.pbxproj
+++ b/client/flutter/ios/Runner.xcodeproj/project.pbxproj
@@ -13,7 +13,7 @@
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
-		E9382794DE648730A15099E7 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0392D8DA7F4C49EFA05FA11C /* Pods_Runner.framework */; };
+		EA50E207F99087AEDE84A2E5 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0392D8DA7F4C49EFA05FA11C /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -54,7 +54,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E9382794DE648730A15099E7 /* Pods_Runner.framework in Frameworks */,
+				EA50E207F99087AEDE84A2E5 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -232,7 +232,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed\n/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" thin\n";
 		};
 		74F92DA83F7EA6BE959DAC9E /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
The build was not working with flutter stable channel.  I followed the migration doc related to XCode 11.4 here:  https://flutter.dev/docs/development/ios-project-migration.  I'm not sure why this issue suddenly presented itself or how our CI build is working around it but I confirmed that a clean checkout on a new machine with XCode 11.3 was not working, nor was it working on my XCode 11.4 environment.  This appears to have fixed it.