### PR TITLE
Address home page text overflow on small devices.

### DIFF
--- a/client/flutter/lib/constants.dart
+++ b/client/flutter/lib/constants.dart
@@ -6,11 +6,11 @@ class Constants {
   static Color textColor = Color(0xffffffff);
 }
 
-// Return a scaling factor between 1.0 and 2.0 for screens heights ranging
-// over a fixed short and tall range.
+// Return a scaling factor between 0.0 and 1.0 for screens heights ranging
+// from a fixed short to tall range.
 double contentScale(BuildContext context) {
   var height = MediaQuery.of(context).size.height;
-  const tall = 812.0;
+  const tall = 896.0;
   const short = 480.0;
-  return ((height - short) / (tall - short)).clamp(1.0, 2.0);
+  return ((height - short) / (tall - short)).clamp(0.0, 1.0);
 }

--- a/client/flutter/lib/pages/home_page.dart
+++ b/client/flutter/lib/pages/home_page.dart
@@ -1,4 +1,5 @@
 import 'package:WHOFlutter/components/question_index.dart';
+import 'package:WHOFlutter/constants.dart';
 import 'package:WHOFlutter/generated/l10n.dart';
 import 'package:WHOFlutter/pages/protect_yourself.dart';
 import 'package:WHOFlutter/pages/travel_advice.dart';
@@ -131,15 +132,16 @@ class PageButton extends StatelessWidget {
             children: <Widget>[
               Text(
                 this.title,
-                textScaleFactor: 1.5,
+                textScaleFactor: 1.0 + 0.5 * contentScale(context),
                 textAlign: TextAlign.left,
                 style: TextStyle(fontWeight: FontWeight.w900),
               ),
+              SizedBox(height: 4),
               this.description.isNotEmpty
                   ? Text(
                       this.description,
                       textAlign: TextAlign.left,
-                      textScaleFactor: 1.35,
+                      textScaleFactor: 0.9 + 0.45 * contentScale(context),
                       style: TextStyle(fontWeight: FontWeight.w400),
                     )
                   : Container()


### PR DESCRIPTION

<img width="844" alt="Screen Shot 2020-03-28 at 3 33 35 PM" src="https://user-images.githubusercontent.com/852471/77833252-f2c71880-7109-11ea-805d-5ffe456c2029.png">
