### PR TITLE
Added integration widget tests for all destinations from the home_page.dart

### DIFF
--- a/client/flutter/lib/pages/home_page.dart
+++ b/client/flutter/lib/pages/home_page.dart
@@ -1,9 +1,9 @@
 import 'package:WHOFlutter/api/user_preferences.dart';
 import 'package:WHOFlutter/components/page_button.dart';
-import 'package:WHOFlutter/pages/question_index.dart';
 import 'package:WHOFlutter/generated/l10n.dart';
 import 'package:WHOFlutter/pages/onboarding/location_sharing.dart';
 import 'package:WHOFlutter/pages/protect_yourself.dart';
+import 'package:WHOFlutter/pages/question_index.dart';
 import 'package:WHOFlutter/pages/travel_advice.dart';
 import 'package:WHOFlutter/pages/who_myth_busters.dart';
 import 'package:flutter/cupertino.dart';

--- a/client/flutter/test/pages/home_page_integration_test.dart
+++ b/client/flutter/test/pages/home_page_integration_test.dart
@@ -1,0 +1,195 @@
+import 'package:WHOFlutter/components/page_button.dart';
+import 'package:WHOFlutter/generated/l10n.dart';
+import 'package:WHOFlutter/pages/home_page.dart';
+import 'package:WHOFlutter/pages/protect_yourself.dart';
+import 'package:WHOFlutter/pages/question_index.dart';
+import 'package:WHOFlutter/pages/travel_advice.dart';
+import 'package:WHOFlutter/pages/who_myth_busters.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group("$HomePage integration tests", () {
+    final translations = S('en_US');
+    final TestWidgetsFlutterBinding binding =
+        TestWidgetsFlutterBinding.ensureInitialized();
+    const surfaceSize = Size(800, 1800);
+
+    Widget sut() => MaterialApp(
+          title: "WHO",
+          localizationsDelegates: [
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            S.delegate,
+          ],
+          locale: Locale('en', ''),
+          supportedLocales: S.delegate.supportedLocales,
+          home: HomePage(),
+        );
+
+    testWidgets('Navigate to and back from $ProtectYourself', (tester) async {
+      await binding.setSurfaceSize(surfaceSize);
+      await tester.pumpWidget(sut());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(HomePage), findsOneWidget);
+      expect(find.byType(ProtectYourself), findsNothing);
+
+      await tester.tap(find.widgetWithText(
+          PageButton, translations.homePagePageButtonProtectYourself));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(HomePage), findsNothing);
+      expect(find.byType(ProtectYourself), findsOneWidget);
+
+      await tester.tap(find.byType(BackButton));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(HomePage), findsOneWidget);
+      expect(find.byType(ProtectYourself), findsNothing);
+    });
+
+    testWidgets('Navigate to and back from $ProtectYourself', (tester) async {
+      await binding.setSurfaceSize(surfaceSize);
+      await tester.pumpWidget(sut());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(HomePage), findsOneWidget);
+      expect(find.byType(ProtectYourself), findsNothing);
+
+      await tester.tap(find.widgetWithText(
+          PageButton, translations.homePagePageButtonProtectYourself));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(HomePage), findsNothing);
+      expect(find.byType(ProtectYourself), findsOneWidget);
+
+      await tester.tap(find.byType(BackButton));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(HomePage), findsOneWidget);
+      expect(find.byType(ProtectYourself), findsNothing);
+    });
+
+    testWidgets('Tapping Your questions answered will show $QuestionIndexPage',
+        (tester) async {
+      await binding.setSurfaceSize(surfaceSize);
+      await tester.pumpWidget(sut());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(HomePage), findsOneWidget);
+      expect(find.byType(QuestionIndexPage), findsNothing);
+
+      await tester.tap(find.widgetWithText(
+          PageButton, translations.homePagePageButtonYourQuestionsAnswered));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(HomePage), findsNothing);
+      expect(find.byType(QuestionIndexPage), findsOneWidget);
+
+      await tester.tap(find.byType(BackButton));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(HomePage), findsOneWidget);
+      expect(find.byType(QuestionIndexPage), findsNothing);
+    });
+
+    testWidgets('Navigate to and back from $WhoMythBusters', (tester) async {
+      await binding.setSurfaceSize(surfaceSize);
+      await tester.pumpWidget(sut());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(HomePage), findsOneWidget);
+      expect(find.byType(WhoMythBusters), findsNothing);
+
+      await tester.tap(find.widgetWithText(
+          PageButton, translations.homePagePageButtonWHOMythBusters));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(HomePage), findsNothing);
+      expect(find.byType(WhoMythBusters), findsOneWidget);
+
+      await tester.tap(find.byType(BackButton));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(HomePage), findsOneWidget);
+      expect(find.byType(WhoMythBusters), findsNothing);
+    });
+
+    testWidgets('Navigate to and from $TravelAdvice', (tester) async {
+      await binding.setSurfaceSize(surfaceSize);
+      await tester.pumpWidget(sut());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(HomePage), findsOneWidget);
+      expect(find.byType(TravelAdvice), findsNothing);
+
+      await tester.tap(find.widgetWithText(
+          PageButton, translations.homePagePageButtonTravelAdvice));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(HomePage), findsNothing);
+      expect(find.byType(TravelAdvice), findsOneWidget);
+
+      await tester.tap(find.byType(BackButton));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(HomePage), findsOneWidget);
+      expect(find.byType(TravelAdvice), findsNothing);
+    });
+
+    testWidgets('Open and close $AboutDialog', (tester) async {
+      await binding.setSurfaceSize(surfaceSize);
+      await tester.pumpWidget(sut());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(HomePage), findsOneWidget);
+      expect(find.byType(AboutDialog), findsNothing);
+
+      await tester.tap(find.widgetWithText(
+          ListTile, translations.homePagePageSliverListAboutTheApp));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AboutDialog), findsOneWidget);
+
+      final MaterialLocalizations materialLocalizations =
+          MaterialLocalizations.of(tester.element(find.byType(AboutDialog)));
+      await tester.tap(find.widgetWithText(
+          FlatButton, materialLocalizations.closeButtonLabel));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AboutDialog), findsNothing);
+    });
+
+    testWidgets('Navigating to $LicensePage from $AboutDialog', (tester) async {
+      await binding.setSurfaceSize(surfaceSize);
+      await tester.pumpWidget(RepaintBoundary(child: sut()));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(HomePage), findsOneWidget);
+
+      await tester.tap(find.widgetWithText(
+          ListTile, translations.homePagePageSliverListAboutTheApp));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AboutDialog), findsOneWidget);
+
+      final MaterialLocalizations materialLocalizations =
+          MaterialLocalizations.of(tester.element(find.byType(AboutDialog)));
+      await tester.tap(find.widgetWithText(
+          FlatButton, materialLocalizations.viewLicensesButtonLabel));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(LicensePage), findsOneWidget);
+      expect(find.byType(HomePage), findsNothing);
+      expect(find.byType(AboutDialog), findsNothing);
+
+      await tester.tap(find.byType(BackButton));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(HomePage), findsOneWidget);
+      expect(find.byType(AboutDialog), findsOneWidget);
+    });
+  });
+}

--- a/client/flutter/test/pages/who_myth_busters_test.dart
+++ b/client/flutter/test/pages/who_myth_busters_test.dart
@@ -1,10 +1,9 @@
-import 'package:flutter/cupertino.dart';
+import 'package:WHOFlutter/generated/l10n.dart';
+import 'package:WHOFlutter/pages/who_myth_busters.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:WHOFlutter/generated/l10n.dart';
-import 'package:WHOFlutter/pages/who_myth_busters.dart';
 
 void main() {
   final TestWidgetsFlutterBinding binding =

--- a/content/credits.yaml
+++ b/content/credits.yaml
@@ -30,6 +30,7 @@ team:
   - Daniel Timbrell
   - Devon Carew
   - Clement Mouchet
+  - Pieter Otten
 # Add yourself here when you first submit a contribution.
 
 # TODO: Pre-launch, review above list to add in the full team that doesn't make git commits!


### PR DESCRIPTION
- [x] Provided detailed pull request description and a succinct title (consider template below for guidance).
- [x] Tested your changes, especially after any code review iterations.
- [x] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).

## What does this PR accomplish?

Integration-like widget test for routing to all pages from the home_page.dart are now covered. 

Closes https://github.com/WorldHealthOrganization/app/issues/513

## Did you add any dependencies?

Nope

## How did you test the change?

All tests are green ✅ 