### PR TITLE
feat(news): implement web view for news and press

### DIFF
--- a/THIRD_PARTY_LICENSE
+++ b/THIRD_PARTY_LICENSE
@@ -15,3 +15,33 @@ This repository may contain code licensed as follows:
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+===
+
+    Copyright 2017 Hadrien Lejard. All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+        * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+        * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following disclaimer
+    in the documentation and/or other materials provided with the
+    distribution.
+        * Neither the name of Hadrien Lejard nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/client/flutter/lib/components/web_view_widget.dart
+++ b/client/flutter/lib/components/web_view_widget.dart
@@ -1,0 +1,31 @@
+import 'package:WHOFlutter/constants.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_webview_plugin/flutter_webview_plugin.dart';
+
+class WebViewWidget extends StatefulWidget {
+  final String externalUrl;
+  final String title;
+
+  WebViewWidget({Key key, @required this.title, @required this.externalUrl})
+      : super(key: key);
+
+  @override
+  _WebViewWidgetState createState() => _WebViewWidgetState();
+}
+
+class _WebViewWidgetState extends State<WebViewWidget> {
+  @override
+  Widget build(BuildContext context) {
+    return WebviewScaffold(
+        url: widget.externalUrl,
+        withJavascript: true,
+        withZoom: false,
+        hidden: true,
+        appBar: AppBar(title: Text(widget.title), elevation: 1),
+        initialChild: Container(
+            color: Constants.backgroundColor,
+            child: const Center(
+              child: Text('Loading...'),
+            )));
+  }
+}

--- a/client/flutter/lib/components/web_view_widget.dart
+++ b/client/flutter/lib/components/web_view_widget.dart
@@ -20,7 +20,7 @@ class _WebViewWidgetState extends State<WebViewWidget> {
         url: widget.externalUrl,
         withJavascript: true,
         withZoom: false,
-        hidden: true,
+        hidden: false,
         appBar: AppBar(title: Text(widget.title), elevation: 1),
         initialChild: Container(
             color: Constants.backgroundColor,

--- a/client/flutter/lib/generated/l10n.dart
+++ b/client/flutter/lib/generated/l10n.dart
@@ -92,6 +92,15 @@ class S {
     );
   }
 
+  String get homePageButtonNewsAndPress {
+    return Intl.message(
+      'News and Press',
+      name: 'homePageButtonNewsAndPress',
+      desc: '',
+      args: [],
+    );
+  }
+
   String get homePagePageSliverListShareTheApp {
     return Intl.message(
       'Share The App',

--- a/client/flutter/lib/pages/home_page.dart
+++ b/client/flutter/lib/pages/home_page.dart
@@ -1,6 +1,5 @@
 import 'package:WHOFlutter/api/user_preferences.dart';
 import 'package:WHOFlutter/components/page_button.dart';
-import 'package:WHOFlutter/components/web_view_widget.dart';
 import 'package:WHOFlutter/pages/news_and_press.dart';
 import 'package:WHOFlutter/pages/question_index.dart';
 import 'package:WHOFlutter/generated/l10n.dart';

--- a/client/flutter/lib/pages/home_page.dart
+++ b/client/flutter/lib/pages/home_page.dart
@@ -1,5 +1,7 @@
 import 'package:WHOFlutter/api/user_preferences.dart';
 import 'package:WHOFlutter/components/page_button.dart';
+import 'package:WHOFlutter/components/web_view_widget.dart';
+import 'package:WHOFlutter/pages/news_and_press.dart';
 import 'package:WHOFlutter/pages/question_index.dart';
 import 'package:WHOFlutter/generated/l10n.dart';
 import 'package:WHOFlutter/pages/onboarding/location_sharing.dart';
@@ -60,6 +62,7 @@ class _HomePageState extends State<HomePage> {
                 StaggeredTile.count(1, 1),
                 StaggeredTile.count(2, 1),
                 StaggeredTile.count(2, .5),
+                StaggeredTile.count(2, .5),
               ],
               children: [
                 PageButton(
@@ -90,13 +93,21 @@ class _HomePageState extends State<HomePage> {
                   centerVertical: true,
                 ),
                 PageButton(
-                  Color(0xffba4344),
-                  S.of(context).homePagePageButtonTravelAdvice,
+                  Color(0xff008dc9),
+                  S.of(context).homePageButtonNewsAndPress,
                   () => Navigator.of(context)
-                      .push(MaterialPageRoute(builder: (c) => TravelAdvice())),
+                      .push(MaterialPageRoute(builder: (c) => NewsAndPress())),
                   borderRadius: 50,
                   centerVertical: true,
                 ),
+                PageButton(
+                  Color(0xffba4344),
+                  S.of(context).homePagePageButtonTravelAdvice,
+                      () => Navigator.of(context)
+                      .push(MaterialPageRoute(builder: (c) => TravelAdvice())),
+                  borderRadius: 50,
+                  centerVertical: true,
+                )
               ],
               mainAxisSpacing: 15.0,
               crossAxisSpacing: 15.0,

--- a/client/flutter/lib/pages/news_and_press.dart
+++ b/client/flutter/lib/pages/news_and_press.dart
@@ -1,0 +1,14 @@
+import 'package:WHOFlutter/components/web_view_widget.dart';
+import 'package:flutter/material.dart';
+
+class NewsAndPress extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: WebViewWidget(
+        title: "News and Press",
+        externalUrl: "https://www.who.int/news-room/releases",
+      ),
+    );
+  }
+}

--- a/client/flutter/pubspec.lock
+++ b/client/flutter/pubspec.lock
@@ -64,6 +64,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.16.1"
+  flare_dart:
+    dependency: transitive
+    description:
+      name: flare_dart
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.3.3"
+  flare_flutter:
+    dependency: "direct main"
+    description:
+      name: flare_flutter
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -98,6 +112,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_webview_plugin:
+    dependency: "direct main"
+    description:
+      name: flutter_webview_plugin
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.10+2"
   html:
     dependency: transitive
     description:
@@ -147,6 +168,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.6.4"
+  path_drawing:
+    dependency: "direct main"
+    description:
+      name: path_drawing
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.1"
+  path_parsing:
+    dependency: transitive
+    description:
+      name: path_parsing
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.4"
   pedantic:
     dependency: "direct dev"
     description:
@@ -299,6 +334,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.8"
+  visibility_detector:
+    dependency: "direct main"
+    description:
+      name: visibility_detector
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.4"
   xml:
     dependency: transitive
     description:
@@ -308,4 +350,4 @@ packages:
     version: "3.5.0"
 sdks:
   dart: ">=2.7.0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.4 <2.0.0"
+  flutter: ">=1.12.13+hotfix.5 <2.0.0"

--- a/client/flutter/pubspec.yaml
+++ b/client/flutter/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   flare_flutter: ^2.0.1
   path_drawing: ^0.4.1
   shared_preferences: ^0.5.6
+  flutter_webview_plugin: ^0.3.10+2
 
   intl: ^0.16.0
   flutter_localizations:

--- a/content/credits.yaml
+++ b/content/credits.yaml
@@ -34,6 +34,7 @@ team:
   - Matt Sullivan
   - Guido Rosso
   - Luigi Rosso
+  - Rave Arevalo
   
 # Add yourself here when you first submit a contribution.
 


### PR DESCRIPTION
**Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).**
- [x] Provided detailed pull request description and a succinct title (consider template below for guidance).
- [x] Tested your changes, especially after any code review iterations.
- [x] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).

## What does this PR accomplish?

This PR is a proposal on how to handle news and press as a web view.

Related to:
#522

## Did you add any dependencies?

* flutter_webview_plugin 0.3.10+2 - To support web view on the app.

## How did you test the change?

* Clicked on the News and Press
* Verified that https://www.who.int/news-room/releases loads in the app as a web view.

![Screenshot_1585459710](https://user-images.githubusercontent.com/8315544/77842250-c1f6ea00-71c2-11ea-88ce-89280609a806.png)
![Screenshot_1585459713](https://user-images.githubusercontent.com/8315544/77842251-c3c0ad80-71c2-11ea-99aa-865e7ae6276a.png)
![Screenshot_1585460368](https://user-images.githubusercontent.com/8315544/77842253-c4594400-71c2-11ea-8375-66c73ae75bcd.png)
