### PR TITLE
Show a dash icon to minimize an expanded question

### DIFF
--- a/client/flutter/lib/api/question_data.dart
+++ b/client/flutter/lib/api/question_data.dart
@@ -35,8 +35,13 @@ class QuestionData {
 }
 
 class QuestionItem {
-  String title;
-  String body;
+  final String title;
+  final String body;
+  bool expanded;
 
-  QuestionItem({@required this.title, @required this.body});
+  QuestionItem(
+      {@required this.title, @required this.body, this.expanded = false})
+      : assert(title != null),
+        assert(body != null),
+        assert(expanded != null);
 }

--- a/client/flutter/lib/pages/question_index.dart
+++ b/client/flutter/lib/pages/question_index.dart
@@ -1,12 +1,10 @@
-import 'package:WHOFlutter/api/content_bundle.dart';
 import 'package:WHOFlutter/api/question_data.dart';
-import 'package:WHOFlutter/components/dialogs.dart';
 import 'package:WHOFlutter/components/page_scaffold.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
-import 'package:url_launcher/url_launcher.dart';
 import 'package:html/dom.dart' as dom;
+import 'package:url_launcher/url_launcher.dart';
 
 typedef QuestionIndexDataSource = Future<List<QuestionItem>> Function(
     BuildContext);
@@ -48,7 +46,9 @@ class _QuestionIndexPageState extends State<QuestionIndexPage> {
       return;
     }
     _questions = await widget.dataSource(context);
-    setState(() {});
+    setState(() {
+      // Updates the list
+    });
   }
 
   @override
@@ -84,18 +84,30 @@ class _QuestionIndexPageState extends State<QuestionIndexPage> {
         Divider(),
         ExpansionTile(
           key: PageStorageKey<String>(questionItem.title),
-          trailing: Icon(
-            Icons.add_circle_outline,
-            color: Colors.black,
+          trailing: AnimatedCrossFade(
+            firstChild: const Icon(
+              Icons.add_circle_outline,
+              color: Colors.black,
+            ),
+            secondChild: const Icon(
+              Icons.remove_circle_outline,
+              color: Colors.black,
+            ),
+            duration: const Duration(milliseconds: 200),
+            crossFadeState: questionItem.expanded
+                ? CrossFadeState.showSecond
+                : CrossFadeState.showFirst,
           ),
+          onExpansionChanged: (bool expanded) {
+            setState(() => questionItem.expanded = expanded);
+          },
           title: Padding(
             padding: const EdgeInsets.all(8.0),
             child: html(questionItem.title),
           ),
           children: [
             Padding(
-              padding: const EdgeInsets.only(
-                  left: 16, right: 16, top: 32, bottom: 32),
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 32),
               child: html(questionItem.body),
             )
           ],

--- a/content/credits.yaml
+++ b/content/credits.yaml
@@ -31,6 +31,7 @@ team:
   - Devon Carew
   - Clement Mouchet
   - Juan Carlos Cruz Santana
+  - Pieter Otten
   - Matt Sullivan
   - Guido Rosso
   - Luigi Rosso


### PR DESCRIPTION
- [x] Provided detailed pull request description and a succinct title (consider template below for guidance).
- [x] Tested your changes, especially after any code review iterations.
- [x] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).

## What does this PR accomplish?

Show a dash icon to minimize an expanded question.

- Used the `onExpansionChanged` from `ExpansionTile` to save expanded state in its `QuestionItem`. 
- Chose the minimize icon, but close is also an option.
- Used `AnimatedCrossFade` to make the icon switching look nice (looked off without it).

 Closes #506 

## Did you add any dependencies?

Nope.

## How did you test the change?

![issue_506_fix](https://user-images.githubusercontent.com/6347879/77931816-fd6de300-72ac-11ea-97db-f93694b4d934.gif)
