### PR TITLE
Display Credits in-app

### DIFF
--- a/client/flutter/lib/pages/credits.dart
+++ b/client/flutter/lib/pages/credits.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:yaml/yaml.dart';
+
+/// Shows all contributors stored in `credits.yaml` under the `team` key.
+class Contributors extends StatelessWidget {
+  const Contributors({Key key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Contributors'),
+      ),
+      body: const _CreditsList(yamlKey: 'team'),
+    );
+  }
+}
+
+/// Shows all supporters stored in `credits.yaml` under the `supporters` key.
+class Supporters extends StatelessWidget {
+  const Supporters({Key key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Supporters'),
+      ),
+      body: const _CreditsList(yamlKey: 'supporters'),
+    );
+  }
+}
+
+/// Shows a list that is stored inside of `credits.yaml` with the given [yamlKey].
+class _CreditsList extends StatefulWidget {
+  const _CreditsList({
+    Key key,
+    this.yamlKey,
+  }) : super(key: key);
+
+  final String yamlKey;
+
+  @override
+  State createState() => _CreditsListState();
+}
+
+class _CreditsListState extends State<_CreditsList> {
+  List<String> _entries;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    _entries = [];
+    _loadList(DefaultAssetBundle.of(context));
+  }
+
+  Future<void> _loadList(AssetBundle assetBundle) async {
+    List<String> result = [];
+
+    try {
+      final parsedYaml =
+          loadYaml(await assetBundle.loadString('../../content/credits.yaml'));
+
+      result.addAll((parsedYaml[widget.yamlKey] as YamlList).cast<String>());
+    } catch (_) {
+      result.add('error');
+    }
+
+    setState(() {
+      _entries.addAll(result);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      children: <Widget>[
+        for (final entry in _entries)
+          ListTile(
+            title: Text(entry),
+          ),
+      ],
+    );
+  }
+}

--- a/client/flutter/lib/pages/home_page.dart
+++ b/client/flutter/lib/pages/home_page.dart
@@ -1,5 +1,6 @@
 import 'package:WHOFlutter/api/user_preferences.dart';
 import 'package:WHOFlutter/components/page_button.dart';
+import 'package:WHOFlutter/pages/credits.dart';
 import 'package:WHOFlutter/pages/question_index.dart';
 import 'package:WHOFlutter/generated/l10n.dart';
 import 'package:WHOFlutter/pages/onboarding/location_sharing.dart';
@@ -112,11 +113,29 @@ class _HomePageState extends State<HomePage> {
                 ListTile(
                   title: Text(S.of(context).homePagePageSliverListAboutTheApp),
                   trailing: Icon(Icons.arrow_forward_ios),
-                  onTap: () => showAboutDialog(
+                  onTap: () {
+                    showAboutDialog(
                       context: context,
-                      applicationLegalese: S
-                          .of(context)
-                          .homePagePageSliverListAboutTheAppDialog),
+                      applicationLegalese:
+                          S.of(context).homePagePageSliverListAboutTheAppDialog,
+                      children: <Widget>[
+                        FlatButton(
+                          textColor: Theme.of(context).primaryColor,
+                          onPressed: () {
+                            Navigator.of(context).push(MaterialPageRoute(builder: (context) => const Supporters()));
+                          },
+                          child: Text('VIEW SUPPORTERS'),
+                        ),
+                        FlatButton(
+                          textColor: Theme.of(context).primaryColor,
+                          onPressed: () {
+                            Navigator.of(context).push(MaterialPageRoute(builder: (context) => const Contributors()));
+                          },
+                          child: Text('VIEW CONTRIBUTORS'),
+                        ),
+                      ],
+                    );
+                  },
                 )
               ]),
             ),

--- a/client/flutter/pubspec.lock
+++ b/client/flutter/pubspec.lock
@@ -64,6 +64,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.16.1"
+  flare_dart:
+    dependency: transitive
+    description:
+      name: flare_dart
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.3.3"
+  flare_flutter:
+    dependency: "direct main"
+    description:
+      name: flare_flutter
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -118,7 +132,7 @@ packages:
       name: intl
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.16.0"
+    version: "0.16.1"
   matcher:
     dependency: transitive
     description:
@@ -147,6 +161,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.6.4"
+  path_drawing:
+    dependency: "direct main"
+    description:
+      name: path_drawing
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.1"
+  path_parsing:
+    dependency: transitive
+    description:
+      name: path_parsing
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.4"
   pedantic:
     dependency: "direct dev"
     description:
@@ -256,7 +284,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.11"
+    version: "0.2.15"
   typed_data:
     dependency: transitive
     description:
@@ -299,6 +327,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.8"
+  visibility_detector:
+    dependency: "direct main"
+    description:
+      name: visibility_detector
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.4"
   xml:
     dependency: transitive
     description:
@@ -306,6 +341,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.5.0"
+  yaml:
+    dependency: "direct main"
+    description:
+      name: yaml
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.0"
 sdks:
   dart: ">=2.7.0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.4 <2.0.0"
+  flutter: ">=1.12.13+hotfix.5 <2.0.0"

--- a/client/flutter/pubspec.yaml
+++ b/client/flutter/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   flare_flutter: ^2.0.1
   path_drawing: ^0.4.1
   shared_preferences: ^0.5.6
+  yaml: ^2.2.0
 
   intl: ^0.16.0
   flutter_localizations:
@@ -35,6 +36,7 @@ flutter:
   assets:
     - assets/
     - assets/animations/
+    - ../../content/credits.yaml
 
 flutter_intl:
   enabled: true

--- a/client/flutter/test/credits_test.dart
+++ b/client/flutter/test/credits_test.dart
@@ -1,0 +1,51 @@
+import 'package:WHOFlutter/pages/credits.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final binding = TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('Credits lists are fetched and displayed correctly',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: DefaultAssetBundle(
+        bundle: _TestAssetBundle(),
+        child: const Contributors(),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Peter Singer'), findsOneWidget);
+    expect(find.text('Sam Mousa'), findsOneWidget);
+    expect(find.text('creativecreatorormaybenot'), findsOneWidget);
+  });
+}
+
+class _TestAssetBundle extends AssetBundle {
+  @override
+  Future<String> loadString(String key, {bool cache = true}) async {
+    assert(key == '../../content/credits.yaml');
+
+    // This is only used for testing, which is why this is only an excerpt of the actual file.
+    return '''
+team:
+  - Peter Singer
+  - Sam Mousa
+  - creativecreatorormaybenot
+
+supporters: [] 
+''';
+  }
+
+  @override
+  Future<ByteData> load(String key) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<T> loadStructuredData<T>(
+      String key, Future<T> Function(String value) parser) {
+    throw UnimplementedError();
+  }
+}


### PR DESCRIPTION
## What does this PR accomplish?

Resolve #551: This PR adds sections to the "About the app" dialog to view the *supporters* and *contributors* of this project as specified in `credits.yaml`.

## Did you add any dependencies?

Yes, I added the [`yaml` package](https://pub.dev/packages/yaml) in order to obtain the data from `credits.yaml`.  
This package is *officially mantained by the **Dart team***.

## How did you test the change?

I added a new widget test (`credits_test.dart`) and tested manually:

[Screen capture](https://i.imgur.com/Jxu94SG.mp4)

<!-- If relevant, add any screenshots of your UI changes. -->

- [x] Provided detailed pull request description and a succinct title (consider template below for guidance).
- [x] Tested your changes, especially after any code review iterations.
- [x] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).