### PR TITLE
Update travel_advice.dart

### DIFF
--- a/client/flutter/lib/pages/travel_advice.dart
+++ b/client/flutter/lib/pages/travel_advice.dart
@@ -1,62 +1,95 @@
 import 'package:WHOFlutter/generated/l10n.dart';
 import 'package:WHOFlutter/components/list_of_items.dart';
 import 'package:flutter/material.dart';
+import 'package:WHOFlutter/constants.dart';
 
 class TravelAdvice extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return ListOfItems([
-      ListItem(
-        message: S.of(context).travelAdviceListOfItemsPageListItem1
-      ),
-      ListItem(
-        message: S.of(context).travelAdviceListOfItemsPageListItem2
-      ),
-      ListItem(
-        message:  S.of(context).travelAdviceListOfItemsPageListItem3
-      ),
-      ListItem(
-        message:  S.of(context).travelAdviceListOfItemsPageListItem4
-      ),
-      ListItem(
-        titleWidget: EmojiHeader("🧼"),
-        message:  S.of(context).travelAdviceListOfItemsPageListItem5
-      ),
-      ListItem(
-        titleWidget: EmojiHeader("👄"),
-        message:  S.of(context).travelAdviceListOfItemsPageListItem6
-      ),
-      ListItem(
-        titleWidget: EmojiHeader("💪"),
-        message:  S.of(context).travelAdviceListOfItemsPageListItem7
-      ),
-      ListItem(
-        titleWidget: EmojiHeader("↔️"),
-        message:  S.of(context).travelAdviceListOfItemsPageListItem8
-      ),
-      ListItem(
-        titleWidget: EmojiHeader("🍗"),
-        message:  S.of(context).travelAdviceListOfItemsPageListItem9
-      ),
-      ListItem(
-        titleWidget: EmojiHeader("😷"),
-        message:  S.of(context).travelAdviceListOfItemsPageListItem10
-      ),
-      ListItem(
-        message:  S.of(context).travelAdviceListOfItemsPageListItem11,
-      ),
-      ListItem(
-        titleWidget: EmojiHeader("🌡"),
-        message:  S.of(context).travelAdviceListOfItemsPageListItem12,
-      ),
-      ListItem(
-        titleWidget: EmojiHeader("🌡️"),
-        message:  S.of(context).travelAdviceListOfItemsPageListItem13,
-      ),
-      ListItem(
-        titleWidget: EmojiHeader("🤒"),
-        message:  S.of(context).travelAdviceListOfItemsPageListItem14,
-      ),
-    ], title: S.of(context).homePagePageButtonTravelAdvice);
+    return Scaffold(
+        body: ListView(
+      children: <Widget>[
+        Container(
+          color: Color(0xffD82037),
+          padding: EdgeInsets.all(26),
+          margin: EdgeInsets.only(top: 100),
+          child: Text(
+            "WHO continues to advise against the application of travel or trade restrictions to countries experiencing COVID-19 outbreaks.\n\nIt is prudent for travellers who are sick to delay or avoid travel to affected areas, in particular for elderly travellers and people with chronic diseases or underlying healh conditions. “Affected areas” are considered those countries, provinces, territories or cities experiencing ongoing transmission of COVID-19, in contract to areas reporting only imported cases.",
+            style: TextStyle(color: Colors.white),
+            textScaleFactor: 1.2,
+          ),
+        ),
+        Container(
+            padding: EdgeInsets.all(26),
+            child: Text("Travellers returning from affected areas should",
+                textScaleFactor: 2,
+                style: TextStyle(fontWeight: FontWeight.bold))),
+        HorrizontalListItem(
+            null,
+            "Self-monitor for symptoms for 14 days and follow national protocols of receiving countries.",
+            MediaQuery.of(context).size.width),
+        HorrizontalListItem(
+            null,
+            "Some countries may require returning travellers to enter quarantine.",
+            MediaQuery.of(context).size.width),
+        HorrizontalListItem(
+            null,
+            "If symptoms occur, travellers are advsed to contact local health care providers, preferably by phone, and inform them of their symptoms and travel history.",
+            MediaQuery.of(context).size.width),
+        Container(
+          padding: EdgeInsets.only(top: 43, left: 16, right: 16, bottom: 275),
+          child: FlatButton(
+            padding: EdgeInsets.all(18),
+            shape:
+                RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+            color: Constants.primaryColor,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  "General\nRecommendations",
+                  textScaleFactor: 2.1,
+                ),
+                Container(
+                  height: 20,
+                ),
+                Text(
+                  "Learn the facts about Coronavirus and how to prevent the spread",
+                  textScaleFactor: 1.1,
+                ),
+              ],
+            ),
+            onPressed: () {},
+          ),
+        )
+      ],
+    ));
   }
+}
+
+Widget HorrizontalListItem(String img, String text, double width) {
+  return Container(
+    height: 109,
+    width: width,
+    padding: EdgeInsets.all(16),
+    child: Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: <Widget>[
+        Container(
+          height: 109,
+          width: 109,
+          //Color is a placeholder for the image
+          color: Colors.blue,
+          // child: Image(image: AssetImage(img)),
+        ),
+        Container(
+          width: width - 109 - 42,
+          child: Text(
+            text,
+            textScaleFactor: 1.2,
+          ),
+        )
+      ],
+    ),
+  );
 }

--- a/client/flutter/lib/pages/travel_advice.dart
+++ b/client/flutter/lib/pages/travel_advice.dart
@@ -1,5 +1,3 @@
-import 'package:WHOFlutter/generated/l10n.dart';
-import 'package:WHOFlutter/components/list_of_items.dart';
 import 'package:flutter/material.dart';
 import 'package:WHOFlutter/constants.dart';
 


### PR DESCRIPTION
**Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).**
- [x] REQUIRED: Do you have an Issue **assigned to you** within the v1 milestone for this PR?  Put the Issue number here:
- [x] Provided detailed pull request description and a succinct title (consider template below for guidance).
- [x] Tested your changes, especially after any code review iterations.
- [x] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).

After all boxes above are checked, request and receive an Approved review from any team member knowledgable in the area (TODO team member list).  Once approved, the team member will assign your review to a Committer or use the `needs-merge` label.

## What does this PR accomplish?

Travel advise page now matches with UI specs.

There are blue containers as a placeholder for images. There are comments explaining how to change it when the images are made available

#581 

## Did you add any dependencies?

No.

## How did you test the change?

Tested on a physical android phone.
![Screenshot_20200329-190024](https://user-images.githubusercontent.com/57235796/77868381-df8e7880-71ef-11ea-8b3d-e7c899239f9a.jpg)
![Screenshot_20200329-190026](https://user-images.githubusercontent.com/57235796/77868383-e1583c00-71ef-11ea-8319-efe8295279f1.jpg)

