### PR TITLE
Add more scroll space at bottom of home screen for iOS safe area.

### DIFF
--- a/client/flutter/lib/pages/home_page.dart
+++ b/client/flutter/lib/pages/home_page.dart
@@ -170,7 +170,7 @@ class _HomePageState extends State<HomePage> {
                 textAlign: TextAlign.center,
               ), //TODO: pull these values in
               Container(
-                height: 15,
+                height: 40,
               ),
             ]),
           )


### PR DESCRIPTION
Tweak space at bottom of home screen:
<img width="936" alt="Screen Shot 2020-03-29 at 9 52 21 PM" src="https://user-images.githubusercontent.com/852471/77870715-c5609480-7207-11ea-8305-eae003d91f5a.png">
