### PR TITLE
Add loading indicator to dynamic views

### DIFF
--- a/client/flutter/lib/pages/question_index.dart
+++ b/client/flutter/lib/pages/question_index.dart
@@ -50,14 +50,22 @@ class _QuestionIndexPageState extends State<QuestionIndexPage> {
 
   // TODO: Should show a spinner while loading.
   Widget _buildPage() {
-    var items = (_questions ?? []).map(_buildQuestion).toList();
+    List items = (_questions ?? []).map(_buildQuestion).toList();
 
     return PageScaffold(
       context,
       body: [
-        SliverList(
-          delegate: SliverChildListDelegate(items),
-        )
+        items.isNotEmpty
+            ? SliverList(
+                delegate: SliverChildListDelegate(items),
+              )
+            : SliverToBoxAdapter(
+                child: Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: LinearProgressIndicator(),
+                )
+
+              )
       ],
       title: widget.title,
     );
@@ -70,7 +78,10 @@ class _QuestionIndexPageState extends State<QuestionIndexPage> {
         Divider(),
         ExpansionTile(
           key: PageStorageKey<String>(questionItem.title),
-          trailing: Icon(Icons.add_circle_outline, color: Colors.black,),
+          trailing: Icon(
+            Icons.add_circle_outline,
+            color: Colors.black,
+          ),
           title: Padding(
             padding: const EdgeInsets.all(8.0),
             child: html(questionItem.title),

--- a/client/flutter/lib/pages/question_index.dart
+++ b/client/flutter/lib/pages/question_index.dart
@@ -1,5 +1,6 @@
 import 'package:WHOFlutter/api/question_data.dart';
 import 'package:WHOFlutter/components/page_scaffold.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -61,8 +62,8 @@ class _QuestionIndexPageState extends State<QuestionIndexPage> {
               )
             : SliverToBoxAdapter(
                 child: Padding(
-                  padding: const EdgeInsets.all(8.0),
-                  child: LinearProgressIndicator(),
+                  padding: const EdgeInsets.all(16.0),
+                  child: CupertinoActivityIndicator(),
                 )
 
               )

--- a/client/flutter/lib/pages/question_index.dart
+++ b/client/flutter/lib/pages/question_index.dart
@@ -62,7 +62,7 @@ class _QuestionIndexPageState extends State<QuestionIndexPage> {
               )
             : SliverToBoxAdapter(
                 child: Padding(
-                  padding: const EdgeInsets.all(16.0),
+                  padding: const EdgeInsets.all(48.0),
                   child: CupertinoActivityIndicator(),
                 )
 


### PR DESCRIPTION
**Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).**
- [x] REQUIRED: Do you have an Issue **assigned to you** within the v1 milestone for this PR?  Put the Issue number here:
- [x] Provided detailed pull request description and a succinct title (consider template below for guidance).
- [x] Tested your changes, especially after any code review iterations.
- [x] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).

## What does this PR accomplish?

Added loading indicator to `question_index.dart`, so that while the app is loading the questions the app shows that an indicator

I chose to use a CupertinoActivityIndicator because it was naturally indeterminate and a good standard for iOS apps

## Did you add any dependencies?

No

## How did you test the change?

iOS simulator

![Simulator Screen Shot - iPhone 8 Plus - 2020-03-30 at 00 01 14](https://user-images.githubusercontent.com/38309438/77884295-a4a13a80-7219-11ea-9364-5076fa403f7e.png)
![Simulator Screen Shot - iPhone 8 Plus - 2020-03-30 at 00 01 17](https://user-images.githubusercontent.com/38309438/77884298-a66afe00-7219-11ea-8f5b-e309c2cb6a70.png)
