### PR TITLE
Fix app bar height

### DIFF
--- a/client/flutter/lib/components/list_of_items.dart
+++ b/client/flutter/lib/components/list_of_items.dart
@@ -66,7 +66,7 @@ class ListOfItems extends StatelessWidget {
                     ),
                   ],
                 ),
-                expandedHeight: 200,
+                expandedHeight: 120,
               ),
               SliverList(
                 delegate: SliverChildListDelegate(this.listOfItems),


### PR DESCRIPTION
- [ ] REQUIRED: Do you have an Issue **assigned to you** within the v1 milestone for this PR?  Put the Issue number here: No issue; updating UI to match Figma
- [x] Provided detailed pull request description and a succinct title (consider template below for guidance).
- [x] Tested your changes, especially after any code review iterations.
- [x] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).

## What does this PR accomplish?
App bar height was 80 pixels taller than all other app bars.

This code updates the app bar to be the same height as the others

## How did you test the change?

iOS simulator

![Simulator Screen Shot - iPhone 8 Plus - 2020-03-30 at 00 08 25](https://user-images.githubusercontent.com/38309438/77884789-97d11680-721a-11ea-8fe0-6bd413870e72.png)
