### PR TITLE
Feat: add PageHeader component

### DIFF
--- a/client/flutter/lib/components/list_of_items.dart
+++ b/client/flutter/lib/components/list_of_items.dart
@@ -1,4 +1,4 @@
-import 'package:WHOFlutter/components/back_arrow.dart';
+import 'package:WHOFlutter/components/page_header.dart';
 import 'package:WHOFlutter/generated/l10n.dart';
 import 'package:flutter/material.dart';
 import 'package:share/share.dart';
@@ -21,51 +21,7 @@ class ListOfItems extends StatelessWidget {
                 backgroundColor: Colors.white,
                 brightness: Brightness.light,
                 leading: SizedBox(),
-                flexibleSpace: Row(
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: [
-                    GestureDetector(
-                      behavior: HitTestBehavior.opaque,
-                      onTap: () => Navigator.pop(context),
-                      child: Padding(
-                        padding: EdgeInsets.only(
-                          left: 25,
-                          right: 25,
-                          bottom: 20,
-                          top: 20,
-                        ),
-                        child: BackArrow(),
-                      ),
-                    ),
-                    Expanded(
-                      child: Column(
-                        mainAxisSize: MainAxisSize.max,
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Text(
-                            title,
-                            style: TextStyle(
-                              color: const Color(0xFF3D8BCC),
-                              fontSize: 30,
-                            ),
-                          ),
-                          SizedBox(height: 5),
-                          Text(
-                            S
-                                .of(context)
-                                .commonWorldHealthOrganizationCoronavirusApp,
-                            style: TextStyle(
-                              fontWeight: FontWeight.w900,
-                              color: const Color(0xFF050C1D),
-                              fontSize: 18,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ],
-                ),
+                flexibleSpace: PageHeader(context, title: this.title),
                 expandedHeight: 120,
               ),
               SliverList(

--- a/client/flutter/lib/components/page_header.dart
+++ b/client/flutter/lib/components/page_header.dart
@@ -1,0 +1,62 @@
+import 'package:WHOFlutter/components/back_arrow.dart';
+import 'package:flutter/material.dart';
+
+class PageHeader extends StatelessWidget {
+  final String title;
+  final String subtitle;
+
+  final BuildContext context;
+  final EdgeInsets padding;
+  final bool showBackButton;
+
+  PageHeader(this.context,
+      {@required this.title,
+      this.subtitle = "WHO Coronavirus App",
+      this.padding = EdgeInsets.zero,
+      this.showBackButton = true});
+
+  @override
+  Widget build(BuildContext context) {
+    return FlexibleSpaceBar(background: _buildHeader());
+  }
+
+  SafeArea _buildHeader() {
+    List<Widget> headerItems = [
+      this.showBackButton ? _buildBackArrow() : null,
+      Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(this.title,
+              textScaleFactor: 1.8,
+              style: TextStyle(
+                  color: Colors.blueAccent, fontWeight: FontWeight.bold)),
+          SizedBox(height: 4),
+          Text(this.subtitle,
+              textScaleFactor: 1.0,
+              style:
+                  TextStyle(color: Colors.black, fontWeight: FontWeight.bold)),
+        ],
+      ),
+      Image.asset('assets/images/mark.png', width: 75),
+    ];
+    headerItems.removeWhere((element) => element == null);
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24.0),
+        child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: headerItems),
+      ),
+    );
+  }
+
+  GestureDetector _buildBackArrow() {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: () => Navigator.pop(this.context),
+      child: BackArrow(),
+    );
+  }
+}

--- a/client/flutter/lib/components/page_scaffold.dart
+++ b/client/flutter/lib/components/page_scaffold.dart
@@ -1,4 +1,4 @@
-import 'package:WHOFlutter/components/back_arrow.dart';
+import 'package:WHOFlutter/components/page_header.dart';
 import 'package:flutter/material.dart';
 
 class PageScaffold extends StatelessWidget {
@@ -31,7 +31,7 @@ class PageScaffold extends StatelessWidget {
                 color: Colors.transparent,
               ),
               backgroundColor: Colors.white,
-              flexibleSpace: FlexibleSpaceBar(background: _buildHeader()),
+              flexibleSpace: PageHeader(context, title: this.title, subtitle: this.subtitle, padding: this.padding, showBackButton: this.showBackButton),
               expandedHeight: 120,
             ),
             ...this.body
@@ -39,43 +39,4 @@ class PageScaffold extends StatelessWidget {
         ));
   }
 
-  SafeArea _buildHeader() {
-    List<Widget> headerItems = [
-      this.showBackButton ? _buildBackArrow() : null,
-      Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Text(this.title,
-              textScaleFactor: 1.8,
-              style: TextStyle(
-                  color: Colors.blueAccent, fontWeight: FontWeight.bold)),
-          SizedBox(height: 4),
-          Text(this.subtitle,
-              textScaleFactor: 1.0,
-              style:
-                  TextStyle(color: Colors.black, fontWeight: FontWeight.bold)),
-        ],
-      ),
-      Image.asset('assets/images/mark.png', width: 75),
-    ];
-    headerItems.removeWhere((element) => element == null);
-    return SafeArea(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 24.0),
-        child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: headerItems),
-      ),
-    );
-  }
-
-  GestureDetector _buildBackArrow() {
-    return GestureDetector(
-      behavior: HitTestBehavior.opaque,
-      onTap: () => Navigator.pop(this.context),
-      child: BackArrow(),
-    );
-  }
 }

--- a/content/credits.yaml
+++ b/content/credits.yaml
@@ -35,6 +35,7 @@ team:
   - Guido Rosso
   - Luigi Rosso
   - Kristina Plummer
+  - Kieran Uddin
   
 # Add yourself here when you first submit a contribution.
 


### PR DESCRIPTION
New PageHeader component for consistent flexibleSpace header across pages

- [ ] REQUIRED: Do you have an Issue **assigned to you** within the v1 milestone for this PR?  Put the Issue number here: https://github.com/WorldHealthOrganization/app/issues/619
- [x] Provided detailed pull request description and a succinct title (consider template below for guidance).
- [x] Tested your changes, especially after any code review iterations.
- [x] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).

## What does this PR accomplish?

Adds new PageHeader component.

Moved _buildHeader() and _buildBackArrow() functionality from PageScaffold component into its own component  for use across pages and components for consistent header appearance and functionality in flexibleSpace.

Header is now consistent across all current pages. Which previously was not the case.

Fixes #619

## Did you add any dependencies?

No

## How did you test the change?

Tested on iOS 13.3.1 and Android 9.

![Screenshot_20200330-113628](https://user-images.githubusercontent.com/12200063/77903593-09d94800-727b-11ea-926b-12632952db61.png)

