### PR TITLE
Run client build on pull_request

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -4,6 +4,11 @@ on:
     paths:
       - '.github/workflows/**'
       - 'client/flutter/**'
+  pull_request:
+    branches: [ master ]
+    paths:
+      - '.github/workflows/**'
+      - 'client/flutter/**'
 jobs:
   buildios:
     name: Build iOS

--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -8,7 +8,10 @@ on:
     branches: [ master ]
     paths:
       - '.github/workflows/**'
-      - 'client/flutter/**'
+      - 'client/flutter/pubspec.yaml'
+      - 'client/flutter/pubspec.lock'
+      - 'client/flutter/ios/**'
+      - 'client/flutter/android/**'
 jobs:
   buildios:
     name: Build iOS


### PR DESCRIPTION
## What does this PR accomplish?

Run flutter build on PRs that touch Flutter packages or any files within the `ios` or `android` directory. Changes to these files have a larger probability of breaking the build, which is not normally run on PR checks for efficiency purposes.