### PR TITLE
fix: accessibilty scaling of font sizes on content pages (#657)

### DIFF
--- a/client/flutter/lib/components/list_of_items.dart
+++ b/client/flutter/lib/components/list_of_items.dart
@@ -75,7 +75,7 @@ class ListItem extends StatelessWidget {
           this.titleWidget ?? Divider(),
           Text(
             this.message,
-            textScaleFactor: 1.5,
+            style: TextStyle(fontSize: 21),
             textAlign: TextAlign.center,
           ),
         ],

--- a/client/flutter/lib/pages/protect_yourself.dart
+++ b/client/flutter/lib/pages/protect_yourself.dart
@@ -19,7 +19,7 @@ const header = TextStyle(
   fontSize: 24,
 );
 
-RichText _message(String input) {
+Text _message(String input) {
   // Make sections delineated by asterisk * bold. For example:
   // String text = '*This is bold* this is not';
 
@@ -50,8 +50,8 @@ RichText _message(String input) {
       text: input.substring(before),
     ),
   );
-  return RichText(
-    text: TextSpan(style: normal, children: spans),
+  return Text.rich(
+    TextSpan(style: normal, children: spans),
   );
 }
 
@@ -122,7 +122,7 @@ class ProtectYourselfCard extends StatelessWidget {
     @required this.message,
     @required this.child,
   });
-  final RichText message;
+  final Text message;
   final Widget child;
 
   @override

--- a/client/flutter/lib/pages/question_index.dart
+++ b/client/flutter/lib/pages/question_index.dart
@@ -1,6 +1,4 @@
-import 'package:WHOFlutter/api/content_bundle.dart';
 import 'package:WHOFlutter/api/question_data.dart';
-import 'package:WHOFlutter/components/dialogs.dart';
 import 'package:WHOFlutter/components/page_scaffold.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';

--- a/client/flutter/lib/pages/question_index.dart
+++ b/client/flutter/lib/pages/question_index.dart
@@ -106,9 +106,11 @@ class _QuestionIndexPageState extends State<QuestionIndexPage> {
 
   // flutter_html supports a subset of html: https://pub.dev/packages/flutter_html
   Widget html(String html) {
+    final double textScaleFactor = MediaQuery.of(context).textScaleFactor;
+
     return Html(
       data: html,
-      defaultTextStyle: TextStyle(fontSize: 16.0),
+      defaultTextStyle: TextStyle(fontSize: 16 * textScaleFactor),
       linkStyle: const TextStyle(
         color: Colors.deepPurple,
       ),


### PR DESCRIPTION
**Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).**
- [ ] REQUIRED: Do you have an Issue **assigned to you** within the v1 milestone for this PR?  Put the Issue number here: no, but this really should be in v1 - issue #657
- [x] Provided detailed pull request description and a succinct title (consider template below for guidance).
- [x] Tested your changes, especially after any code review iterations.
- [x] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).

After all boxes above are checked, request and receive an Approved review from any team member knowledgable in the area (TODO team member list).  Once approved, the team member will assign your review to a Committer or use the `needs-merge` label.

## What does this PR accomplish?

Fixes accessibility text scaling on all content pages. Closes #657.

Three different fixes:

1. Replace use of `RichText` with `Text.rich`
2. Set font size instead of using `textScaleFactor` (`textScaleFactor` shouldn't be used just to change font size)
3. Manually changed base font size of HTML items to use device's `textScaleFactor`

## Did you add any dependencies?

No.

## How did you test the change?

Manually on iOS by changing font size.

Before:

![Simulator Screen Shot - iPhone 5s - 2020-03-31 at 00 36 37](https://user-images.githubusercontent.com/756862/77964425-b18c5f80-72e7-11ea-9384-990312b9d417.png)

After:

![Simulator Screen Shot - iPhone 5s - 2020-03-31 at 00 36 25](https://user-images.githubusercontent.com/756862/77964438-b6511380-72e7-11ea-9031-0dfaecf43078.png)


