### PR TITLE
[content] Use Mythbusters content on Mythbusters screen

### DIFF
--- a/client/flutter/assets/content_bundles/mythbusters.en.yaml
+++ b/client/flutter/assets/content_bundles/mythbusters.en.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 content_version: 1
 contents:
-  type: mythbusters
+  type: qa
   items:
     - title_html: |
         COVID-19 virus can be transmitted in areas with hot and humid climates

--- a/client/flutter/lib/api/question_data.dart
+++ b/client/flutter/lib/api/question_data.dart
@@ -8,9 +8,7 @@ class QuestionData {
   }
 
   static Future<List<QuestionItem>> whoMythbusters(BuildContext context) async {
-    // TODO: Switch after merge
-    //return _load(context, "myth_busters");
-    return _load(context, "your_questions_answered");
+    return _load(context, "mythbusters");
   }
 
   /// Load a content bundle and interpret it as question data.


### PR DESCRIPTION
**Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).**
- [x] REQUIRED: Do you have an Issue **assigned to you** within the v1 milestone for this PR?  Put the Issue number here:
- [x] Provided detailed pull request description and a succinct title (consider template below for guidance).
- [x] Tested your changes, especially after any code review iterations.
- [x] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).

## What does this PR accomplish?

Points the Mythbusters screen to the Mythbusters content

## Did you add any dependencies?

N/A

## How did you test the change?

* [x] iOS Simulator

<img width="485" alt="Screen Shot 2020-03-30 at 11 23 46 PM" src="https://user-images.githubusercontent.com/1484366/77993720-8c92ef00-72dd-11ea-9252-4165a3969a34.png">
