### PR TITLE
Do no use SelectableText for the settings page

### DIFF
--- a/client/flutter/lib/pages/settings_page.dart
+++ b/client/flutter/lib/pages/settings_page.dart
@@ -50,7 +50,7 @@ class _SettingsPageState extends State<SettingsPage> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
               ListTile(
-                leading: SelectableText(
+                leading: Text(
                   S.of(context).homePagePageSliverListSettingsHeader1,
                   textAlign: TextAlign.start,
                   style: TextStyle(
@@ -70,9 +70,8 @@ class _SettingsPageState extends State<SettingsPage> {
                 ),
               ),
               Padding(
-                padding: const EdgeInsets.symmetric(
-                    horizontal: 15.0, vertical: 10.0),
-                child: SelectableText(
+                padding: const EdgeInsets.symmetric(horizontal: 15.0, vertical: 10.0),
+                child: Text(
                   S.of(context).homePagePageSliverListSettingsDataCollection,
                   style: Theme.of(context).textTheme.subhead,
                 ),

--- a/content/credits.yaml
+++ b/content/credits.yaml
@@ -51,6 +51,7 @@ team:
   - Ursula Zhao
   - Evan Pye
   - Moosphon
+  - Pieter Otten
 # Add yourself here when you first submit a contribution.
 
 # TODO: Pre-launch, review above list to add in the full team that doesn't make git commits!


### PR DESCRIPTION
- [ ] REQUIRED: Do you have an Issue **assigned to you** within the v1 milestone for this PR?  Put the Issue number here:
- [x] Provided detailed pull request description and a succinct title (consider template below for guidance).
- [x] Tested your changes, especially after any code review iterations.
- [x] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).

## What does this PR accomplish?

Do no use SelectableText for the settings page

For some reason `SelectableText` widget was used on the Settings page, making text selectable on a long-press. But the pop-up doesn't show any actions/icons to do and also there's no reason for the text to be selectable (I did not find any other screen in the app where it is).
=> Used default `Text` instead

Issue:
![Screenshot_20200331-223737](https://user-images.githubusercontent.com/6347879/78080409-74d76b80-73ae-11ea-9689-db7771acf7ea.png)


## Did you add any dependencies?

No.

## How did you test the change?

Tested on Google Pixel 2.
