### PR TITLE
Recreate WHO logo for legal page using localized text and mark image.

### DIFF
--- a/client/flutter/lib/constants.dart
+++ b/client/flutter/lib/constants.dart
@@ -14,3 +14,7 @@ double contentScale(BuildContext context) {
   const short = 480.0;
   return ((height - short) / (tall - short)).clamp(0.0, 1.0);
 }
+
+double contentScaleFrom(BuildContext context, double low, double high) {
+  return low + contentScale(context) * (high-low);
+}

--- a/client/flutter/lib/pages/onboarding/legal_landing_page.dart
+++ b/client/flutter/lib/pages/onboarding/legal_landing_page.dart
@@ -19,14 +19,46 @@ class LegalLandingPage extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            Image.asset("assets/WHO.jpg"),
-            SizedBox(height: 20,),
-            Text(S.of(context).legalLandingPageTitle, style: TextStyle(color: Color(0xff008DC9), fontSize: 15, fontWeight: FontWeight.w600), textAlign: TextAlign.center,),
-            SizedBox(height: 70,),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8.0),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: <Widget>[
+                  Image.asset('assets/images/mark.png',
+                      width: contentScaleFrom(context, 90, 120)),
+                  SizedBox(width: contentScaleFrom(context, 5, 10)),
+                  Flexible(
+                    child: Text(S.of(context).commonWorldHealthOrganization,
+                        textScaleFactor: contentScaleFrom(context, 1.7, 2.7),
+                        textAlign: TextAlign.center,
+                        style: TextStyle(
+                            height: 1.0,
+                            fontWeight: FontWeight.bold,
+                            color: Color(0xff008DC9))),
+                  )
+                ],
+              ),
+            ),
+            SizedBox(
+              height: 20,
+            ),
+            Text(
+              S.of(context).legalLandingPageTitle,
+              style: TextStyle(
+                  color: Color(0xff008DC9),
+                  fontSize: 15,
+                  fontWeight: FontWeight.w600),
+              textAlign: TextAlign.center,
+            ),
+            SizedBox(
+              height: 70,
+            ),
             PageButton(
               Constants.primaryColor,
               S.of(context).legalLandingPageButtonGetStarted,
-              ()=>this.onboardingPage.pageController.nextPage(duration: Duration(milliseconds: 500), curve: Curves.easeInOut),
+              () => this.onboardingPage.pageController.nextPage(
+                  duration: Duration(milliseconds: 500),
+                  curve: Curves.easeInOut),
               verticalPadding: 24,
               mainAxisAlignment: MainAxisAlignment.center,
               crossAxisAlignment: CrossAxisAlignment.center,
@@ -37,32 +69,21 @@ class LegalLandingPage extends StatelessWidget {
             ),
             RichText(
               textAlign: TextAlign.center,
-              text: TextSpan(
-                style: TextStyle(color: Colors.grey),
-                children: [
-                  TextSpan(
-                    text: S.of(context).legalLandingPageButtonAgree
-                  ),
-                  LinkTextSpan(
+              text: TextSpan(style: TextStyle(color: Colors.grey), children: [
+                TextSpan(text: S.of(context).legalLandingPageButtonAgree),
+                LinkTextSpan(
                     text: S.of(context).LegalLandingPageTermsOfServiceLinkText,
                     style: TextStyle(decoration: TextDecoration.underline),
                     url: S.of(context).legalLandingPageTermsOfServiceLinkUrl,
-                    onLinkTap: (v)=>launch(v)
-                  ),
-                   TextSpan(
-                    text: S.of(context).legalLandingPageAnd
-                  ),LinkTextSpan(
+                    onLinkTap: (v) => launch(v)),
+                TextSpan(text: S.of(context).legalLandingPageAnd),
+                LinkTextSpan(
                     text: S.of(context).legalLandingPagePrivacyPolicyLinkText,
                     style: TextStyle(decoration: TextDecoration.underline),
                     url: S.of(context).legalLandingPagePrivacyPolicyLinkUrl,
-                    onLinkTap: (v)=>launch(v)
-                  ),
-                   TextSpan(
-                    text: "."
-                  ),
-                ]
-
-              ),
+                    onLinkTap: (v) => launch(v)),
+                TextSpan(text: "."),
+              ]),
             ),
           ],
         ),


### PR DESCRIPTION
This replaces the static WHO.jpg on the legal page with localized text and the graphic-only `mark` asset.  I'm not certain of the best approach for this that would still allow the text to wrap so I have implemented it this way as a first pass.  The text may still break inelegantly in other languages.  Normally we'd have a localized image asset for this I guess...

This is what it looks like on large and small screens after the conversion:

<img width="817" alt="image" src="https://user-images.githubusercontent.com/852471/78083817-33c66380-737c-11ea-9f60-c8ead688bec6.png">
