### PR TITLE
Add scripts to swap in prod firebase config before cutting a release branch

### DIFF
--- a/config/GoogleService-Info.plist
+++ b/config/GoogleService-Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CLIENT_ID</key>
+	<string>936622942451-bhjm61j553i0soe10b7vou3ebratp6bn.apps.googleusercontent.com</string>
+	<key>REVERSED_CLIENT_ID</key>
+	<string>com.googleusercontent.apps.936622942451-bhjm61j553i0soe10b7vou3ebratp6bn</string>
+	<key>API_KEY</key>
+	<string>AIzaSyDmkF34SinD9jM10VSmZ6nj04KKtdWESII</string>
+	<key>GCM_SENDER_ID</key>
+	<string>936622942451</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>int.who.WHOMyHealth</string>
+	<key>PROJECT_ID</key>
+	<string>who-myhealth-production</string>
+	<key>STORAGE_BUCKET</key>
+	<string>who-myhealth-production.appspot.com</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<false></false>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<false></false>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:936622942451:ios:26bf3dfe5d0bb7f1076f86</string>
+	<key>DATABASE_URL</key>
+	<string>https://who-myhealth-production.firebaseio.com</string>
+</dict>
+</plist>

--- a/config/deploy-prod.sh
+++ b/config/deploy-prod.sh
@@ -1,0 +1,4 @@
+# Copies production firebase configs to the right spot.
+# Run this before cutting a release branch.
+cp config/google-services.json client/flutter/android/app
+cp config/GoogleService-Info.plist client/flutter/ios/Runner

--- a/config/google-services.json
+++ b/config/google-services.json
@@ -1,0 +1,47 @@
+{
+  "project_info": {
+    "project_number": "936622942451",
+    "firebase_url": "https://who-myhealth-production.firebaseio.com",
+    "project_id": "who-myhealth-production",
+    "storage_bucket": "who-myhealth-production.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:936622942451:android:145c5bb2454415ee076f86",
+        "android_client_info": {
+          "package_name": "org.who.WHOMyHealth"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "936622942451-uuscl0i30v69r33m0ktp4mirdm7r807h.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyB4t5psAYF9GAfeOIvopOKHOoRE4yUWDx8"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "936622942451-uuscl0i30v69r33m0ktp4mirdm7r807h.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "936622942451-bhjm61j553i0soe10b7vou3ebratp6bn.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "int.who.WHOMyHealth"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}


### PR DESCRIPTION
## What does this PR accomplish?

deploy-prod.sh can be run right before cutting a release branch so that the right
firebase config can be swapped in. We can also modify this to make other changes
that may need to be modified from dev -> prod.

for #730

<!-- Title should be a short phrase, e.g. "Adds survey functionality". -->

<!-- Detailed description can include any design decisions you want reviewers to take note of. -->

<!-- List all issue numbers affected and closed by this PR. -->

## Did you add any dependencies?

<!-- List each added dependency and justifications (see the Guidelines) -->

## How did you test the change?

<!-- If relevant, add any screenshots of your UI changes. -->