### PR TITLE
Add our list of supported languages to the Runner info.plist.

### DIFF
--- a/client/flutter/ios/Runner/Info.plist
+++ b/client/flutter/ios/Runner/Info.plist
@@ -55,5 +55,14 @@
 	<false/>
 	<key>FIREBASE_ANALYTICS_COLLECTION_ENABLED</key>
 	<false/>
+  <key>CFBundleLocalizations</key>
+  <array>
+      <string>ar</string>
+      <string>en</string>
+      <string>es</string>
+      <string>fr</string>
+      <string>ru</string>
+      <string>zh</string>
+  </array>
 </dict>
 </plist>


### PR DESCRIPTION
This enables localization on iOS by adding the list of supported language codes to the Runner info.plist file.  I believe that only the language codes is required and not the language_country combinations.
