### PR TITLE
fix header

### DIFF
--- a/client/flutter/lib/components/page_scaffold/page_header.dart
+++ b/client/flutter/lib/components/page_scaffold/page_header.dart
@@ -31,8 +31,7 @@ class PageHeader extends StatelessWidget {
 }
 
 class HeaderDelagate extends SliverPersistentHeaderDelegate {
-
-  final double maxHeight = 120.0;
+  final double maxHeight = 130.0;
   final double minHeight = 80.0;
 
   final String title;
@@ -61,37 +60,39 @@ class HeaderDelagate extends SliverPersistentHeaderDelegate {
   Widget _buildHeader(double currentHeight) {
     List<Widget> headerItems = [
       if (this.showBackButton) BackArrow(),
-      
       Column(
         mainAxisAlignment: MainAxisAlignment.center,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          Container(height: this.minHeight< currentHeight-20?0:20,),
           Text(this.title,
               textScaleFactor: 1.8,
               style: TextStyle(
                   color: Colors.blueAccent, fontWeight: FontWeight.bold)),
           SizedBox(height: 4),
-          if(this.minHeight< currentHeight-20) Text(this.subtitle,
-              textScaleFactor: 1.0,
-              style:
-                  TextStyle(color: Colors.black, fontWeight: FontWeight.bold)),
+          if (this.minHeight < currentHeight - 20) Text(this.subtitle,
+                textScaleFactor: 1.0,
+                style: TextStyle(
+                    color: Colors.black, fontWeight: FontWeight.bold)),
         ],
       ),
       Expanded(
         child: Container(),
       ),
-      showLogo && this.minHeight<currentHeight -20 ? Image.asset('assets/images/mark.png', width: 75) : Container(),
+      showLogo && this.minHeight < currentHeight - 20
+          ? Image.asset('assets/images/mark.png', width: 75)
+          : Container(),
     ];
     return Container(
       color: Colors.white,
-      child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 10),
+      child: SafeArea(
+         bottom: false,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24.0),
           child: Row(
               mainAxisAlignment: MainAxisAlignment.start,
               crossAxisAlignment: CrossAxisAlignment.center,
               children: headerItems),
-        
+        ),
       ),
     );
   }

--- a/client/flutter/lib/components/page_scaffold/page_header.dart
+++ b/client/flutter/lib/components/page_scaffold/page_header.dart
@@ -66,6 +66,7 @@ class HeaderDelagate extends SliverPersistentHeaderDelegate {
         mainAxisAlignment: MainAxisAlignment.center,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
+          Container(height: this.minHeight< currentHeight-20?0:20,),
           Text(this.title,
               textScaleFactor: 1.8,
               style: TextStyle(
@@ -84,14 +85,13 @@ class HeaderDelagate extends SliverPersistentHeaderDelegate {
     ];
     return Container(
       color: Colors.white,
-      child: SafeArea(
-        child: Padding(
+      child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 10),
           child: Row(
               mainAxisAlignment: MainAxisAlignment.start,
               crossAxisAlignment: CrossAxisAlignment.center,
               children: headerItems),
-        ),
+        
       ),
     );
   }

--- a/client/flutter/lib/components/page_scaffold/page_header.dart
+++ b/client/flutter/lib/components/page_scaffold/page_header.dart
@@ -32,7 +32,7 @@ class PageHeader extends StatelessWidget {
 
 class HeaderDelagate extends SliverPersistentHeaderDelegate {
   final double maxHeight = 130.0;
-  final double minHeight = 80.0;
+  final double minHeight = 100.0;
 
   final String title;
   final String subtitle;


### PR DESCRIPTION
**Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).**
- [ ] REQUIRED: Do you have an Issue **assigned to you** within the v1 milestone for this PR?  Put the Issue number here:
- [ ] Provided detailed pull request description and a succinct title (consider template below for guidance).
- [ ] Tested your changes, especially after any code review iterations.
- [ ] Included any relevant screenshots of UI updates.
- [ ] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [ ] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [ ] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).

After all boxes above are checked, request and receive an Approved review from any team member knowledgable in the area (TODO team member list).  Once approved, the team member will assign your review to a Committer or use the `needs-merge` label.

## What does this PR accomplish?

- Remove safe area
- adds padding when the appbar is shrunk

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-03-31 at 23 16 11](https://user-images.githubusercontent.com/38309438/78105274-a26be700-73a5-11ea-8345-cd39aab0bed0.png)

<!-- Title should be a short phrase, e.g. "Adds survey functionality". -->

<!-- Detailed description can include any design decisions you want reviewers to take note of. -->

<!-- List all issue numbers affected and closed by this PR. -->

## Did you add any dependencies?

<!-- List each added dependency and justifications (see the Guidelines) -->

## How did you test the change?

<!-- If relevant, add any screenshots of your UI changes. -->
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-03-31 at 23 16 09](https://user-images.githubusercontent.com/38309438/78105269-a0098d00-73a5-11ea-8804-a0e225a3067b.png)
