### PR TITLE
Unpin header for v2

### DIFF
--- a/client/flutter/lib/components/page_scaffold/page_header.dart
+++ b/client/flutter/lib/components/page_scaffold/page_header.dart
@@ -19,46 +19,14 @@ class PageHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SliverPersistentHeader(
-        pinned: true,
-        delegate: HeaderDelagate(
-            title: this.title,
-            subtitle: this.subtitle,
-            padding: this.padding,
-            showBackButton: this.showBackButton,
-            showLogo: this.showLogo));
-  }
-}
-
-class HeaderDelagate extends SliverPersistentHeaderDelegate {
-
-  final double maxHeight = 120.0;
-  final double minHeight = 80.0;
-
-  final String title;
-  final String subtitle;
-
-  final EdgeInsets padding;
-  final bool showBackButton;
-  final bool showLogo;
-
-  HeaderDelagate({
-    @required this.title,
-    @required this.subtitle,
-    @required this.padding,
-    @required this.showBackButton,
-    @required this.showLogo,
-  });
-  @override
-  Widget build(
-      BuildContext context, double shrinkOffset, bool overlapsContent) {
-    return LayoutBuilder(builder: (context, constraints) {
-      final double currentHeight = constraints.maxHeight;
-      return _buildHeader(currentHeight);
-    });
+    return SliverAppBar(
+      expandedHeight: 120,
+      backgroundColor: Colors.white,
+      flexibleSpace: FlexibleSpaceBar(background:_buildHeader()),
+    );
   }
 
-  Widget _buildHeader(double currentHeight) {
+  Widget _buildHeader() {
     List<Widget> headerItems = [
       if (this.showBackButton) BackArrow(),
       
@@ -71,7 +39,7 @@ class HeaderDelagate extends SliverPersistentHeaderDelegate {
               style: TextStyle(
                   color: Colors.blueAccent, fontWeight: FontWeight.bold)),
           SizedBox(height: 4),
-          if(this.minHeight< currentHeight-20) Text(this.subtitle,
+          Text(this.subtitle,
               textScaleFactor: 1.0,
               style:
                   TextStyle(color: Colors.black, fontWeight: FontWeight.bold)),
@@ -80,7 +48,7 @@ class HeaderDelagate extends SliverPersistentHeaderDelegate {
       Expanded(
         child: Container(),
       ),
-      showLogo && this.minHeight<currentHeight -20 ? Image.asset('assets/images/mark.png', width: 75) : Container(),
+      if(this.showLogo)Image.asset('assets/images/mark.png', width: 75)
     ];
     return Container(
       color: Colors.white,
@@ -96,12 +64,4 @@ class HeaderDelagate extends SliverPersistentHeaderDelegate {
     );
   }
 
-  @override
-  bool shouldRebuild(SliverPersistentHeaderDelegate _) => true;
-
-  @override
-  double get maxExtent => this.maxHeight;
-
-  @override
-  double get minExtent => this.minHeight;
 }


### PR DESCRIPTION
**Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).**
- [ ] REQUIRED: Do you have an Issue **assigned to you** within the v1 milestone for this PR?  Put the Issue number here:
- [ ] Provided detailed pull request description and a succinct title (consider template below for guidance).
- [ ] Tested your changes, especially after any code review iterations.
- [ ] Included any relevant screenshots of UI updates.
- [ ] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [ ] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [ ] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).

After all boxes above are checked, request and receive an Approved review from any team member knowledgable in the area (TODO team member list).  Once approved, the team member will assign your review to a Committer or use the `needs-merge` label.

## What does this PR accomplish?

Unpins the header

## Did you add any dependencies?

No

## How did you test the change?

iOS simulator

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-03-31 at 23 59 51](https://user-images.githubusercontent.com/38309438/78108182-b9153c80-73ab-11ea-8fd6-900fb6667b72.png)
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-03-31 at 23 59 53](https://user-images.githubusercontent.com/38309438/78108186-badf0000-73ab-11ea-843f-3153b745727b.png)
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-04-01 at 00 00 03](https://user-images.githubusercontent.com/38309438/78108207-c5999500-73ab-11ea-924b-39bf9537bf6e.png)
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-04-01 at 00 00 13](https://user-images.githubusercontent.com/38309438/78108214-c8948580-73ab-11ea-9d89-a8cf6fecde08.png)
