### PR TITLE
P1 - Set status bar color black by default

### DIFF
--- a/client/flutter/lib/main.dart
+++ b/client/flutter/lib/main.dart
@@ -86,6 +86,7 @@ class _MyAppState extends State<MyApp> {
         primaryColor: Constants.primaryColor,
         accentColor: Constants.textColor,
         brightness: Brightness.light,
+        appBarTheme: AppBarTheme(brightness: Brightness.light),
         buttonTheme: ButtonThemeData(
             buttonColor: Constants.primaryColor,
             textTheme: ButtonTextTheme.accent),


### PR DESCRIPTION
Set app bar brightness to light

**Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).**
- [x] REQUIRED: Do you have an Issue **assigned to you** within the v1 milestone for this PR?  Put the Issue number here: [#763](https://github.com/WorldHealthOrganization/app/issues/763)
- [x] Provided detailed pull request description and a succinct title (consider template below for guidance).
- [x] Tested your changes, especially after any code review iterations.
- [ ] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [ ] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).

After all boxes above are checked, request and receive an Approved review from any team member knowledgable in the area (TODO team member list).  Once approved, the team member will assign your review to a Committer or use the `needs-merge` label.

## What does this PR accomplish?
Sets status bar dark by default. Fixes [#763](https://github.com/WorldHealthOrganization/app/issues/763), 
<!-- Title should be a short phrase, e.g. "Adds survey functionality". -->


<!-- Detailed description can include any design decisions you want reviewers to take note of. -->

<!-- List all issue numbers affected and closed by this PR. -->

## Did you add any dependencies?

No

<!-- List each added dependency and justifications (see the Guidelines) -->

## How did you test the change?

Tried on Android and iOS simulators, both light and dark mode and real iOS devices

<!-- If relevant, add any screenshots of your UI changes. -->
