### PR TITLE
Feat: Add ScrollController to PageScaffold, scroll to expanded question

### DIFF
--- a/client/flutter/lib/components/page_scaffold/page_scaffold.dart
+++ b/client/flutter/lib/components/page_scaffold/page_scaffold.dart
@@ -13,6 +13,7 @@ class PageScaffold extends StatelessWidget {
   final bool showBackButton;
   final bool showShareBottomBar;
   final bool showLogoInHeader;
+  final ScrollController scrollController;
 
   PageScaffold(
     this.context, {
@@ -23,6 +24,7 @@ class PageScaffold extends StatelessWidget {
     this.padding = EdgeInsets.zero,
     this.showBackButton = true,
     this.showLogoInHeader = false,
+    this.scrollController
   });
 
   @override
@@ -33,19 +35,22 @@ class PageScaffold extends StatelessWidget {
           padding: this.padding,
           child: Stack(
             children: <Widget>[
-              CustomScrollView(slivers: [
-                PageHeader(
-                  title: this.title,
-                  subtitle: this.subtitle,
-                  padding: this.padding,
-                  showBackButton: this.showBackButton,
-                  showLogo: this.showLogoInHeader,
-                ),
-                ...this.body,
-                SliverToBoxAdapter(
-                  child: SizedBox(height: 70),
-                ),
-              ]),
+              CustomScrollView(
+                slivers: [
+                  PageHeader(
+                    title: this.title,
+                    subtitle: this.subtitle,
+                    padding: this.padding,
+                    showBackButton: this.showBackButton,
+                    showLogo: this.showLogoInHeader,
+                  ),
+                  ...this.body,
+                  SliverToBoxAdapter(
+                    child: SizedBox(height: 70),
+                  ),
+                ],
+                controller: this.scrollController
+              ),
               if (this.showShareBottomBar) ShareBar()
             ],
           ),

--- a/client/flutter/lib/pages/question_index.dart
+++ b/client/flutter/lib/pages/question_index.dart
@@ -1,4 +1,5 @@
 import 'dart:math';
+import 'dart:async';
 import 'package:WHOFlutter/api/question_data.dart';
 import 'package:WHOFlutter/components/page_scaffold/page_scaffold.dart';
 import 'package:flutter/cupertino.dart';
@@ -55,9 +56,11 @@ class _QuestionIndexPageState extends State<QuestionIndexPage> {
   }
 
   Widget _buildPage() {
+    final scrollController = ScrollController();
     List items = (_questions ?? [])
         .map((questionData) => QuestionTile(
               questionItem: questionData,
+              scrollController: scrollController
             ))
         .toList();
 
@@ -75,6 +78,7 @@ class _QuestionIndexPageState extends State<QuestionIndexPage> {
               ))
       ],
       title: widget.title,
+      scrollController: scrollController,
     );
   }
 }
@@ -82,9 +86,11 @@ class _QuestionIndexPageState extends State<QuestionIndexPage> {
 class QuestionTile extends StatefulWidget {
   const QuestionTile({
     @required this.questionItem,
+    this.scrollController
   });
 
   final QuestionItem questionItem;
+  final ScrollController scrollController;
 
   @override
   _QuestionTileState createState() => _QuestionTileState();
@@ -123,6 +129,17 @@ class _QuestionTileState extends State<QuestionTile>
               rotationController.forward();
               setState(() {
                 titleColor = Color(0xff1A458E);
+              });
+              // Timer to wait for ExpansionTile to fully expand
+              Timer(Duration(milliseconds: 500), () {
+                final RenderBox renderBox = this.context.findRenderObject();
+                final offset = renderBox.localToGlobal(Offset.zero);
+                double statusBarHeight = MediaQuery.of(context).padding.top;
+                widget.scrollController.animateTo(
+                  widget.scrollController.offset + offset.dy - statusBarHeight,
+                  duration: Duration(milliseconds: 500),
+                  curve: Curves.ease
+                );
               });
             } else {
               rotationController.reverse();


### PR DESCRIPTION
- [ ] REQUIRED: Do you have an Issue **assigned to you** within the v1 milestone for this PR?  Put the Issue number here:
- [x] Provided detailed pull request description and a succinct title (consider template below for guidance).
- [x] Tested your changes, especially after any code review iterations.
- [x] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).

## What does this PR accomplish?

Added optional ScrollController to PageScaffold component. Added as the controller parameter to the CustomScrollView.

This allows any Widget using the PageScaffold to perform scroll functions.

Used new ScrollController functionality to ensure the most recent expanded question is scrolled into view on the QuestionIndexPage.

Surrounded in 500 millisecond timer to ensure ExpansionTile is done expanding before scrolling.

Fixes #798

## Did you add any dependencies?

No

## How did you test the change?

iOS 13.1.1 and Android 9

Previously when a ExpansionTile is tapped at the bottom of the view:
![Screenshot_20200401-170018](https://user-images.githubusercontent.com/12200063/78159616-b1e93f80-743a-11ea-91c7-93c341cbaa62.png)

With new scroll functionality:
![Screenshot_20200401-170027](https://user-images.githubusercontent.com/12200063/78159628-b877b700-743a-11ea-845f-b99d03ebc11c.png)

