### PR TITLE
[build break] Pin CI flutter to v1.12.13+hotfix.5

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: '12.x'
-      - run: git clone https://github.com/flutter/flutter.git --depth 1 -b stable _flutter
+      - run: git clone https://github.com/flutter/flutter.git --depth 1 -b v1.12.13+hotfix.5 _flutter
       - run: echo "::add-path::$GITHUB_WORKSPACE/_flutter/bin"
       - run: flutter pub get
         working-directory: ./client/flutter
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: '12.x'
-      - run: git clone https://github.com/flutter/flutter.git --depth 1 -b stable _flutter
+      - run: git clone https://github.com/flutter/flutter.git --depth 1 -b v1.12.13+hotfix.5 _flutter
       - run: echo "::add-path::$GITHUB_WORKSPACE/_flutter/bin"
       - run: flutter pub get
         working-directory: ./client/flutter

--- a/.github/workflows/flutter-test.yml
+++ b/.github/workflows/flutter-test.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: '12.x'
-      - run: git clone https://github.com/flutter/flutter.git --depth 1 -b stable _flutter
+      - run: git clone https://github.com/flutter/flutter.git --depth 1 -b v1.12.13+hotfix.5 _flutter
       - run: echo "::add-path::$GITHUB_WORKSPACE/_flutter/bin"
       - run: flutter pub get
         working-directory: ./client/flutter


### PR DESCRIPTION
Use the lowest permitted compatible Flutter repo instead of whatever is supposedly "stable"

Fixes this:
```
The current Flutter SDK version is 0.0.0-unknown.


Because flutter_svg 0.17.3+1 requires Flutter SDK version >=1.6.7 <2.0.0 and no versions of flutter_svg match >0.17.3+1 <0.18.0, flutter_svg ^0.17.3+1 is forbidden.

So, because WHOFlutter depends on flutter_svg ^0.17.3+1, version solving failed.

pub get failed (1; So, because WHOFlutter depends on flutter_svg ^0.17.3+1, version solving failed.)
##[error]Process completed with exit code 1.
```