### PR TITLE
Refixes #651. Adds Flexible and FittedBox in page_header.dart

### DIFF
--- a/client/flutter/lib/components/page_scaffold/page_header.dart
+++ b/client/flutter/lib/components/page_scaffold/page_header.dart
@@ -31,25 +31,30 @@ class PageHeader extends StatelessWidget {
     List<Widget> headerItems = [
       if (this.showBackButton) BackArrow(),
       
-      Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Text(this.title,
-              textScaleFactor: 1.8,
-              style: TextStyle(
-                  color: Colors.blueAccent, fontWeight: FontWeight.bold)),
-          SizedBox(height: 4),
-          Text(this.subtitle,
-              textScaleFactor: 1.0,
-              style:
-                  TextStyle(color: Colors.black, fontWeight: FontWeight.bold)),
-        ],
-      ),
       Expanded(
-        child: Container(),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            FittedBox(
+//              fit:BoxFit.fitWidth,
+              child: Text(this.title,
+                  textScaleFactor: 1.8,
+                  style: TextStyle(
+                      color: Colors.blueAccent, fontWeight: FontWeight.bold)),
+            ),
+            SizedBox(height: 4),
+            FittedBox(
+              child: Text(this.subtitle,
+                  textScaleFactor: 1.0,
+                  style:
+                      TextStyle(color: Colors.black, fontWeight: FontWeight.bold)),
+            ),
+          ],
+        ),
       ),
-      if(this.showLogo)Image.asset('assets/images/mark.png', width: 75)
+
+      if(this.showLogo)Image.asset('assets/images/mark.png', width: 75) else Container(width: 0,height: 0,)
     ];
     return Material(
       color: Colors.white,


### PR DESCRIPTION
**Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).**
- [x] REQUIRED: Do you have an Issue **assigned to you** within the v1 milestone for this PR?  Put the Issue number here: #651 
- [x] Provided detailed pull request description and a succinct title (consider template below for guidance).
- [x] Tested your changes, especially after any code review iterations.
- [x] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).

After all boxes above are checked, request and receive an Approved review from any team member knowledgable in the area (TODO team member list).  Once approved, the team member will assign your review to a Committer or use the `needs-merge` label.

## What does this PR accomplish?
This PR re-fixes the issue described in #651 because I am not sure who changed it but the flexible and fittedbox widgets were taken out and so there was overflow on smaller screens. I added those two without changing other things in the code. 
@patniemeyer  and @theswerd reviewed the last PR so they would know about this.  


![Screenshot_1585778404](https://user-images.githubusercontent.com/10944487/78199648-ecaaa200-7451-11ea-96a3-fcc48c3032a0.png)


<!-- Title should be a short phrase, e.g. "Adds survey functionality". -->

<!-- Detailed description can include any design decisions you want reviewers to take note of. -->

<!-- List all issue numbers affected and closed by this PR. -->

## Did you add any dependencies?
No
<!-- List each added dependency and justifications (see the Guidelines) -->

## How did you test the change?

I tested it on Android Pixel 3a
![Screenshot_1585784902](https://user-images.githubusercontent.com/10944487/78199526-93427300-7451-11ea-9149-464d0593cc21.png)

And on Nexus 4 inches
![Screenshot_1585784910](https://user-images.githubusercontent.com/10944487/78199545-a0f7f880-7451-11ea-9c84-992fc57b344a.png)

I couldn't test on the web because it gave me errors.

<!-- If relevant, add any screenshots of your UI changes. -->
