### PR TITLE
Fix late locale initialization on iOS

### DIFF
--- a/client/flutter/ios/Runner/AppDelegate.swift
+++ b/client/flutter/ios/Runner/AppDelegate.swift
@@ -8,11 +8,22 @@ import Flutter
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
-    
+    // Work-around for https://github.com/flutter/flutter/issues/39032
+    // This is safe to remove once the fix for that is available in the SDK
+    // used by this application.
+    guard let controller = window?.rootViewController as? FlutterViewController else {
+      fatalError("rootViewController is not type FlutterViewController")
+    }
+    let engine = controller.engine!
+    let currentLocale = NSLocale.current
+    if (currentLocale.languageCode != nil) {
+      engine.localizationChannel?.invokeMethod("setLocale", arguments: [currentLocale.languageCode!, currentLocale.regionCode ?? "", currentLocale.scriptCode ?? "", currentLocale.variantCode ?? ""])
+    }
+
     if #available(iOS 10.0, *) {
       UNUserNotificationCenter.current().delegate = self as? UNUserNotificationCenterDelegate
     }
-    
+
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 }


### PR DESCRIPTION
**Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).**
- [x] REQUIRED: Do you have an Issue **assigned to you** within the v1 milestone for this PR?  Put the Issue number here: https://github.com/WorldHealthOrganization/app/issues/776
- [x] Provided detailed pull request description and a succinct title (consider template below for guidance).
- [x] Tested your changes, especially after any code review iterations.
- [ ] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).

After all boxes above are checked, request and receive an Approved review from any team member knowledgable in the area (TODO team member list).  Once approved, the team member will assign your review to a Committer or use the `needs-merge` label.

## What does this PR accomplish?

Fixes https://github.com/WorldHealthOrganization/app/issues/776 by setting the locale as soon as the app launches. There is a bug currently in Flutter that will be fixed by https://github.com/flutter/engine/pull/17473, but that will take some time to roll through dev/beta/stable.  In the mean time, this fix is safe and will cooperate fine even once the issue is fixed upstream.  Once https://github.com/flutter/engine/pull/17473 has rolled into the SDK used by this application, the code added here is safe to remove.

## Did you add any dependencies?

No

## How did you test the change?

Manually.