### PR TITLE
feat: update style of the ExpansionTiles on questions page based on its state

### DIFF
--- a/client/flutter/lib/pages/question_index.dart
+++ b/client/flutter/lib/pages/question_index.dart
@@ -94,7 +94,8 @@ class _QuestionTileState extends State<QuestionTile>
     with TickerProviderStateMixin {
   AnimationController rotationController;
 
-  Color titleColor;
+  Color _titleColor;
+  Color _iconColor;
 
   @override
   void initState() {
@@ -105,7 +106,8 @@ class _QuestionTileState extends State<QuestionTile>
         lowerBound: 0,
         upperBound: pi / 4);
 
-    titleColor = Colors.black;
+    _titleColor = Colors.black;
+    _iconColor = Color(0xff3C4245);
   }
 
   @override
@@ -118,14 +120,22 @@ class _QuestionTileState extends State<QuestionTile>
           onExpansionChanged: (expanded) {
             if (expanded) {
               rotationController.forward();
+
+              _iconColor = Color(0xff1A458E);
+              _titleColor = Color(0xff1A458E);
             } else {
               rotationController.reverse();
+
+              _iconColor = Color(0xff3C4245);
+              _titleColor = Colors.black;
             }
+
+            setState(() {});
           },
           key: PageStorageKey<String>(widget.questionItem.title),
           trailing: AnimatedBuilder(
             animation: rotationController,
-            child: Icon(Icons.add_circle_outline, color: Color(0xff3C4245)),
+            child: Icon(Icons.add_circle_outline, color: _iconColor),
             builder: (context, child) {
               return Transform.rotate(
                 angle: rotationController.value,
@@ -139,6 +149,7 @@ class _QuestionTileState extends State<QuestionTile>
             data: widget.questionItem.title,
             defaultTextStyle: _titleStyle.copyWith(
               fontSize: 16 * MediaQuery.of(context).textScaleFactor,
+              color: _titleColor
             ),),
           ),
           children: [


### PR DESCRIPTION
**Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).**
- [x] REQUIRED: Do you have an Issue **assigned to you** within the v1 milestone for this PR?  Put the Issue number here: 
- [x] Provided detailed pull request description and a succinct title (consider template below for guidance).
- [x] Tested your changes, especially after any code review iterations.
- [x] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [ ] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).

After all boxes above are checked, request and receive an Approved review from any team member knowledgable in the area (TODO team member list).  Once approved, the team member will assign your review to a Committer or use the `needs-merge` label.

## What does this PR accomplish ?
Updates style of the ExpansionTiles on questions page based on its state

If ExpansionTile's state is expanded, question title and close icon color will change to #1A458E.

This pull request fixes #755.

## Did you add any dependencies?

## How did you test the change?
Closed
![closed](https://www.dropbox.com/s/k97jz6li1alh9ky/exptile_closed.png?raw=1)
Expanded
![expanded](https://www.dropbox.com/s/45zjsyxsezten8e/exptile_open.png?raw=1)
