### PR TITLE
update info plist to fix push notification permissions

### DIFF
--- a/client/flutter/ios/Runner/Info.plist
+++ b/client/flutter/ios/Runner/Info.plist
@@ -19,7 +19,7 @@
 		<key>NSLocationAlwaysAndWhenInUsageDescription</key>
 		<string>Always And In Use Permission</string>
 	<key>CFBundleDisplayName</key>
-	<string>WHO COVID-19</string>
+	<string>COVID-19</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/client/flutter/ios/Runner/Info.plist
+++ b/client/flutter/ios/Runner/Info.plist
@@ -19,7 +19,7 @@
 		<key>NSLocationAlwaysAndWhenInUsageDescription</key>
 		<string>Always And In Use Permission</string>
 	<key>CFBundleDisplayName</key>
-	<string>COVID-19</string>
+	<string>WHO COVID-19</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
@@ -35,6 +35,10 @@
 		<string>fetch</string>
 		<string>processing</string>
 		<string>remote-notification</string>
+	</array>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>


### PR DESCRIPTION
## What does this PR accomplish?

Update info plist to fix app push notification permissions

Fixes error,

```
Missing Info.plist value. The Info.plist key 'BGTaskSchedulerPermittedIdentifiers' must contain a list of identifiers used to submit and handle tasks when 'UIBackgroundModes' has a value of 'processing'. For more information, refer to the Information Property List Key Reference at https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Introduction/Introduction.html.
```

See https://github.com/FirebaseExtended/flutterfire/issues/1694 for the fix

## Did you add any dependencies?

<!-- List each added dependency and justifications (see the Guidelines) -->

## How did you test the change?

<!-- If relevant, add any screenshots of your UI changes. -->
