### PR TITLE
Change CFBundleDisplayName to WHO COVID-19

### DIFF
--- a/client/flutter/ios/Runner/Info.plist
+++ b/client/flutter/ios/Runner/Info.plist
@@ -19,7 +19,7 @@
 		<key>NSLocationAlwaysAndWhenInUsageDescription</key>
 		<string>Always And In Use Permission</string>
 	<key>CFBundleDisplayName</key>
-	<string>COVID-19</string>
+	<string>WHO COVID-19</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
Otherwise, we get an error, "The bundle uses a bundle name or display name that is already taken."