### PR TITLE
[chore] Add automatic PR labeler workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,5 @@
 client:
-  - client/flutter/**
+  - client/**
 
 docs:
   - docs/**

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,15 @@
+client:
+  - client/flutter/**
+
+docs:
+  - docs/**
+
+server:
+  - server/**
+
+string-change:
+  - client/flutter/assets/content_bundles/**
+  - client/flutter/lib/l10n/*.arb
+
+tests:
+  - client/flutter/test/**

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,6 +4,9 @@ client:
 docs:
   - docs/**
 
+ops:
+  - .github/**
+
 server:
   - server/**
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,10 @@
+name: Pull Request Labeler
+on: pull_request
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v3-preview
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,5 +6,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@v3-preview
+      continue-on-error: true
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
**Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).**
- [x] ~REQUIRED: Do you have an Issue **assigned to you** within the v1 milestone for this PR?  Put the Issue number here:~
- [x] Provided detailed pull request description and a succinct title (consider template below for guidance).
- [x] ~Tested your changes, especially after any code review iterations.~
- [x] ~Included any relevant screenshots of UI updates.~
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).

## What does this PR accomplish?

Adds a GitHub action to automatically label PRs opened with relevant labels. Currently supports `client`, `docs`, `ops`, `server`, `string-change`, and `tests` labels (see `.github/labeler.yml` in this PR for the configuration).

## Did you add any dependencies?

* [`actions/labeler`](https://github.com/actions/labeler) GitHub Action added - officially-supported action from the GitHub team

## How did you test the change?

N/A
