### PR TITLE
[feat] Use auto text size for header text to fix overflow

### DIFF
--- a/client/flutter/lib/components/page_scaffold/page_header.dart
+++ b/client/flutter/lib/components/page_scaffold/page_header.dart
@@ -1,5 +1,6 @@
 import './back_arrow.dart';
 import 'package:flutter/material.dart';
+import 'package:auto_size_text/auto_size_text.dart';
 
 class PageHeader extends StatelessWidget {
   final String title;
@@ -36,8 +37,9 @@ class PageHeader extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
           //Todo: Decide what to do when title text overflow
-          Text(this.title,
+          AutoSizeText(this.title,
               maxLines: 1,
+              minFontSize: 8,
               overflow: TextOverflow.fade,
               softWrap: false,
               style: TextStyle(
@@ -46,8 +48,9 @@ class PageHeader extends StatelessWidget {
                   fontSize: 24,
                   letterSpacing: -0.5)),
           SizedBox(height: 4),
-          Text(this.subtitle,
+          AutoSizeText(this.subtitle,
               maxLines: 1,
+              minFontSize: 8,
               overflow: TextOverflow.ellipsis,
               softWrap: false,
               style: TextStyle(

--- a/client/flutter/pubspec.lock
+++ b/client/flutter/pubspec.lock
@@ -22,6 +22,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.4.0"
+  auto_size_text:
+    dependency: "direct main"
+    description:
+      name: auto_size_text
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.0"
   boolean_selector:
     dependency: transitive
     description:

--- a/client/flutter/pubspec.yaml
+++ b/client/flutter/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
   uuid: 2.0.4
   package_info: '>=0.4.0+16 <2.0.0'
   flutter_svg: ^0.17.3+1
+  auto_size_text: 2.1.0
 
   intl: ^0.16.0
   flutter_localizations:


### PR DESCRIPTION
**Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).**
- [x] REQUIRED: Do you have an Issue ~**assigned to you**~ within the v1 milestone for this PR?  Put the Issue number here:
- [x] Provided detailed pull request description and a succinct title (consider template below for guidance).
- [x] Tested your changes, especially after any code review iterations.
- [x] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).

## What does this PR accomplish?

Uses the `auto_text_size` package to automatically size the text in the header title and subtitle.

Closes #651 

## Did you add any dependencies?

* [`auto_text_size`](https://pub.dev/packages/auto_size_text): **not** from a verified dev, but has >200 likes on pub.dev, and @advayDev1 did a cursory review of v2.1.0 for security

## How did you test the change?

* [x] iOS Simulator

<details>
<summary>iPhone 8 screenshots</summary>

<img width="492" alt="Screen Shot 2020-04-05 at 9 48 00 PM" src="https://user-images.githubusercontent.com/1484366/78524285-5f848780-7788-11ea-9a06-c0f6984588f2.png">
<img width="492" alt="Screen Shot 2020-04-05 at 9 46 33 PM" src="https://user-images.githubusercontent.com/1484366/78524289-63180e80-7788-11ea-8767-c93f627e9eb4.png">
<img width="492" alt="Screen Shot 2020-04-05 at 9 44 56 PM" src="https://user-images.githubusercontent.com/1484366/78524292-63b0a500-7788-11ea-8505-a951124688d1.png">
</details>
