### PR TITLE
Client-side caching of server content

### DIFF
--- a/client/flutter/ios/Podfile.lock
+++ b/client/flutter/ios/Podfile.lock
@@ -58,6 +58,9 @@ PODS:
     - GoogleUtilities/UserDefaults (~> 6.5)
     - Protobuf (>= 3.9.2, ~> 3.9)
   - Flutter (1.0.0)
+  - FMDB (2.7.5):
+    - FMDB/standard (= 2.7.5)
+  - FMDB/standard (2.7.5)
   - geolocator (5.3.1):
     - Flutter
   - google_api_availability (2.0.4):
@@ -103,6 +106,10 @@ PODS:
   - nanopb/encode (0.3.9011)
   - package_info (0.0.1):
     - Flutter
+  - path_provider (0.0.1):
+    - Flutter
+  - path_provider_macos (0.0.1):
+    - Flutter
   - PromisesObjC (1.2.8)
   - Protobuf (3.11.4)
   - share (0.5.2):
@@ -113,6 +120,9 @@ PODS:
     - Flutter
   - shared_preferences_web (0.0.1):
     - Flutter
+  - sqflite (0.0.1):
+    - Flutter
+    - FMDB (~> 2.7.2)
   - url_launcher (0.0.1):
     - Flutter
   - url_launcher_macos (0.0.1):
@@ -130,10 +140,13 @@ DEPENDENCIES:
   - location_permissions (from `.symlinks/plugins/location_permissions/ios`)
   - location_web (from `.symlinks/plugins/location_web/ios`)
   - package_info (from `.symlinks/plugins/package_info/ios`)
+  - path_provider (from `.symlinks/plugins/path_provider/ios`)
+  - path_provider_macos (from `.symlinks/plugins/path_provider_macos/ios`)
   - share (from `.symlinks/plugins/share/ios`)
   - shared_preferences (from `.symlinks/plugins/shared_preferences/ios`)
   - shared_preferences_macos (from `.symlinks/plugins/shared_preferences_macos/ios`)
   - shared_preferences_web (from `.symlinks/plugins/shared_preferences_web/ios`)
+  - sqflite (from `.symlinks/plugins/sqflite/ios`)
   - url_launcher (from `.symlinks/plugins/url_launcher/ios`)
   - url_launcher_macos (from `.symlinks/plugins/url_launcher_macos/ios`)
   - url_launcher_web (from `.symlinks/plugins/url_launcher_web/ios`)
@@ -149,6 +162,7 @@ SPEC REPOS:
     - FirebaseInstallations
     - FirebaseInstanceID
     - FirebaseMessaging
+    - FMDB
     - GoogleAppMeasurement
     - GoogleDataTransport
     - GoogleDataTransportCCTSupport
@@ -176,6 +190,10 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/location_web/ios"
   package_info:
     :path: ".symlinks/plugins/package_info/ios"
+  path_provider:
+    :path: ".symlinks/plugins/path_provider/ios"
+  path_provider_macos:
+    :path: ".symlinks/plugins/path_provider_macos/ios"
   share:
     :path: ".symlinks/plugins/share/ios"
   shared_preferences:
@@ -184,6 +202,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/shared_preferences_macos/ios"
   shared_preferences_web:
     :path: ".symlinks/plugins/shared_preferences_web/ios"
+  sqflite:
+    :path: ".symlinks/plugins/sqflite/ios"
   url_launcher:
     :path: ".symlinks/plugins/url_launcher/ios"
   url_launcher_macos:
@@ -204,6 +224,7 @@ SPEC CHECKSUMS:
   FirebaseInstanceID: 7ee0d6777013bb952f377b41965bf132b6a075be
   FirebaseMessaging: 4ec33842d36b3319e062e51fb8b35a74f726950d
   Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
+  FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
   geolocator: 460cc8e850b616f8c0e90944c86517d91ccbb686
   google_api_availability: 15fa42a8cd83c0a6738507ffe6e87096f12abcb8
   GoogleAppMeasurement: 6e68a94d0eaeb1d73ef6b0ed4f7334e29d63ae29
@@ -215,12 +236,15 @@ SPEC CHECKSUMS:
   location_web: b94e7433cfe28c0f7c8923c2ee482824b32e55a7
   nanopb: 18003b5e52dab79db540fe93fe9579f399bd1ccd
   package_info: 48b108e75b8802c2d5e126f208ef540561c98aef
+  path_provider: fb74bd0465e96b594bb3b5088ee4a4e7bb1f2a9d
+  path_provider_macos: f760a3c5b04357c380e2fddb6f9db6f3015897e0
   PromisesObjC: c119f3cd559f50b7ae681fa59dc1acd19173b7e6
   Protobuf: 176220c526ad8bd09ab1fb40a978eac3fef665f7
   share: bae0a282aab4483288913fc4dc0b935d4b491f2e
   shared_preferences: 430726339841afefe5142b9c1f50cb6bd7793e01
   shared_preferences_macos: f3f29b71ccbb56bf40c9dd6396c9acf15e214087
   shared_preferences_web: 141cce0c3ed1a1c5bf2a0e44f52d31eeb66e5ea9
+  sqflite: 4001a31ff81d210346b500c55b17f4d6c7589dd0
   url_launcher: a1c0cc845906122c4784c542523d8cacbded5626
   url_launcher_macos: fd7894421cd39320dce5f292fc99ea9270b2a313
   url_launcher_web: e5527357f037c87560776e36436bf2b0288b965c

--- a/client/flutter/lib/api/content_loading.dart
+++ b/client/flutter/lib/api/content_loading.dart
@@ -4,7 +4,6 @@ import 'package:WHOFlutter/api/endpoints.dart';
 import 'package:WHOFlutter/components/dialogs.dart';
 import 'package:WHOFlutter/generated/l10n.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
-import 'package:http/http.dart' as http;
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';
@@ -89,7 +88,7 @@ class ContentLoading {
   /// Load a localized content bundle from the network, throwing an exception if not found.
   Future<ContentBundle> _loadFromNetwork(String name, String suffix) async {
     var url = '$baseContentURL/${_fileName(name, suffix)}';
-    var headers = {"Accept": "application/yaml"};
+    final headers = {"Accept": "application/yaml"};
     File file = await WhoCacheManager()
         .getSingleFile(url, headers: headers)
         .timeout(networkTimeout);
@@ -132,7 +131,7 @@ class WhoCacheManager extends BaseCacheManager {
   // expired file before returning, rather than favoring the cached version.
   @override
   Future<File> getSingleFile(String url, {Map<String, String> headers}) async {
-    var cacheFile = await getFileFromCache(url);
+    final cacheFile = await getFileFromCache(url);
     if (cacheFile != null) {
       if (cacheFile.validTill.isBefore(DateTime.now())) {
         // Wait for the refreshed file.
@@ -142,7 +141,7 @@ class WhoCacheManager extends BaseCacheManager {
     }
     try {
       print("Downloading file: $url");
-      var download = await webHelper.downloadFile(url, authHeaders: headers);
+      final download = await webHelper.downloadFile(url, authHeaders: headers);
       return download.file;
     } catch (e) {
       print("Error downloading file: $url, $e");

--- a/client/flutter/lib/api/content_loading.dart
+++ b/client/flutter/lib/api/content_loading.dart
@@ -1,11 +1,15 @@
+import 'dart:io';
 
 import 'package:WHOFlutter/api/endpoints.dart';
 import 'package:WHOFlutter/components/dialogs.dart';
 import 'package:WHOFlutter/generated/l10n.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:http/http.dart' as http;
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:flutter/material.dart';
+import 'package:path_provider/path_provider.dart';
 import 'content_bundle.dart';
+import 'package:path/path.dart' as paths;
 
 class ContentLoading {
   static final networkLoadingEnabled = true;
@@ -85,12 +89,14 @@ class ContentLoading {
   /// Load a localized content bundle from the network, throwing an exception if not found.
   Future<ContentBundle> _loadFromNetwork(String name, String suffix) async {
     var url = '$baseContentURL/${_fileName(name, suffix)}';
-    var response = await http.get(url,
-        headers: {"Accept": "application/yaml"}).timeout(networkTimeout);
-    if (response.statusCode != 200) {
-      throw Exception("Error status code: ${response.statusCode}");
+    var headers = {"Accept": "application/yaml"};
+    File file = await WhoCacheManager()
+        .getSingleFile(url, headers: headers)
+        .timeout(networkTimeout);
+    if (file == null) {
+      throw Exception("File not retrieved from network or cache: $url");
     }
-    return ContentBundle.fromBytes(response.bodyBytes);
+    return ContentBundle.fromBytes(file.readAsBytesSync());
   }
 
   /// Load a localized content bundle from local assets, throwing an exception if not found.
@@ -103,5 +109,50 @@ class ContentLoading {
   /// Format the filename. e.g. screen_name.en_US.yaml
   String _fileName(String name, String suffix) {
     return '${name}.$suffix.yaml';
+  }
+}
+
+class WhoCacheManager extends BaseCacheManager {
+  static const key = "whoCache";
+
+  static WhoCacheManager _instance;
+
+  // Attempting to change the maxAgeCacheObject parameter here has no effect
+  // on http content, for which the manager uses the cache control max-age header.
+  WhoCacheManager._init() : super(key);
+
+  factory WhoCacheManager() {
+    if (_instance == null) {
+      _instance = WhoCacheManager._init();
+    }
+    return _instance;
+  }
+
+  // This changes the behavior of the base method to wait for an update of the
+  // expired file before returning, rather than favoring the cached version.
+  @override
+  Future<File> getSingleFile(String url, {Map<String, String> headers}) async {
+    var cacheFile = await getFileFromCache(url);
+    if (cacheFile != null) {
+      if (cacheFile.validTill.isBefore(DateTime.now())) {
+        // Wait for the refreshed file.
+        await webHelper.downloadFile(url, authHeaders: headers);
+      }
+      return cacheFile.file;
+    }
+    try {
+      print("Downloading file: $url");
+      var download = await webHelper.downloadFile(url, authHeaders: headers);
+      return download.file;
+    } catch (e) {
+      print("Error downloading file: $url, $e");
+      return null;
+    }
+  }
+
+  // Store files in the temporary system path (default behavior)
+  Future<String> getFilePath() async {
+    var directory = await getTemporaryDirectory();
+    return paths.join(directory.path, key);
   }
 }

--- a/client/flutter/lib/api/content_loading.dart
+++ b/client/flutter/lib/api/content_loading.dart
@@ -95,7 +95,7 @@ class ContentLoading {
     if (file == null) {
       throw Exception("File not retrieved from network or cache: $url");
     }
-    return ContentBundle.fromBytes(file.readAsBytesSync());
+    return ContentBundle.fromBytes(await file.readAsBytes());
   }
 
   /// Load a localized content bundle from local assets, throwing an exception if not found.

--- a/client/flutter/lib/api/content_loading.dart
+++ b/client/flutter/lib/api/content_loading.dart
@@ -135,7 +135,12 @@ class WhoCacheManager extends BaseCacheManager {
     if (cacheFile != null) {
       if (cacheFile.validTill.isBefore(DateTime.now())) {
         // Wait for the refreshed file.
-        await webHelper.downloadFile(url, authHeaders: headers);
+        try {
+          await webHelper.downloadFile(url, authHeaders: headers);
+        } catch (err) {
+          print(
+              "Error refreshing expired file, returning cached version: $url");
+        }
       }
       return cacheFile.file;
     }

--- a/client/flutter/pubspec.lock
+++ b/client/flutter/pubspec.lock
@@ -111,6 +111,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_cache_manager:
+    dependency: "direct main"
+    description:
+      name: flutter_cache_manager
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.3"
   flutter_html:
     dependency: "direct main"
     description:
@@ -273,6 +280,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.4"
+  path_provider:
+    dependency: "direct main"
+    description:
+      name: path_provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.6.5"
+  path_provider_macos:
+    dependency: transitive
+    description:
+      name: path_provider_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.4"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   pedantic:
     dependency: "direct dev"
     description:
@@ -355,6 +383,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.5.5"
+  sqflite:
+    dependency: transitive
+    description:
+      name: sqflite
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.0"
+  sqflite_common:
+    dependency: transitive
+    description:
+      name: sqflite_common
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0+1"
   stack_trace:
     dependency: transitive
     description:
@@ -376,6 +418,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.5"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.0"
   term_glyph:
     dependency: transitive
     description:

--- a/client/flutter/pubspec.yaml
+++ b/client/flutter/pubspec.yaml
@@ -32,6 +32,8 @@ dependencies:
   package_info: '>=0.4.0+16 <2.0.0'
   flutter_svg: ^0.17.3+1
   auto_size_text: 2.1.0
+  flutter_cache_manager: ^1.1.3
+  path_provider: ^1.6.5
 
   intl: ^0.16.0
   flutter_localizations:


### PR DESCRIPTION
This PR adds client side caching of the yaml files using the `flutter_cache_manager` package.  Cache expiration is controlled by the server cache control max-age response header (currently 10 minutes).  

I tested this by logging when the files were downloaded vs returned from the cache.  I also did a negative test by breaking the URL in order to see that the fallback behavior was still applied.

This PR adds two package: `https://pub.dev/packages/flutter_cache_manager` and  `https://pub.dev/packages/path_provider`.  The `path_provider` was already a (transitive) dependency of our project and is not new.