### PR TITLE
fix: allow news feed subheadings to use multiple lines

### DIFF
--- a/client/flutter/lib/components/news_feed_item.dart
+++ b/client/flutter/lib/components/news_feed_item.dart
@@ -21,14 +21,10 @@ class NewsFeedItem extends StatelessWidget {
         padding: const EdgeInsets.all(16.0),
         child: Column(
           children: <Widget>[
-            Row(
-              children: <Widget>[
-                Text(
-                  this.title,
-                  textAlign: TextAlign.start,
-                  style: TextStyle(fontWeight: FontWeight.w800, fontSize: 28),
-                ),
-              ],
+            Text(
+              this.title,
+              textAlign: TextAlign.start,
+              style: TextStyle(fontWeight: FontWeight.w800, fontSize: 56),
             ),
             SizedBox(height: 14),
             Row(

--- a/client/flutter/lib/components/news_feed_item.dart
+++ b/client/flutter/lib/components/news_feed_item.dart
@@ -24,7 +24,7 @@ class NewsFeedItem extends StatelessWidget {
             Text(
               this.title,
               textAlign: TextAlign.start,
-              style: TextStyle(fontWeight: FontWeight.w800, fontSize: 56),
+              style: TextStyle(fontWeight: FontWeight.w800, fontSize: 28),
             ),
             SizedBox(height: 14),
             Row(


### PR DESCRIPTION
**Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).**
- [x] REQUIRED: Do you have an Issue **assigned to you** within the v1 milestone for this PR?  Put the Issue number here: https://github.com/WorldHealthOrganization/app/issues/920
- [x] Provided detailed pull request description and a succinct title (consider template below for guidance).
- [x] Tested your changes, especially after any code review iterations.
- [x] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).

After all boxes above are checked, request and receive an Approved review from any team member knowledgable in the area (TODO team member list).  Once approved, the team member will assign your review to a Committer or use the `needs-merge` label.

## What does this PR accomplish?
Closes https://github.com/WorldHealthOrganization/app/issues/920
<!-- Title should be a short phrase, e.g. "Adds survey functionality". -->

<!-- Detailed description can include any design decisions you want reviewers to take note of. -->

<!-- List all issue numbers affected and closed by this PR. -->

## Did you add any dependencies?
No
<!-- List each added dependency and justifications (see the Guidelines) -->

## How did you test the change?
Increasing the text size until it overflowed.
<!-- If relevant, add any screenshots of your UI changes. -->
![Screenshot_20200407-010808](https://user-images.githubusercontent.com/33752528/78616768-1b1ee780-786d-11ea-95c4-deced74a8d02.jpg)
