### PR TITLE
Component borders weren't being shown via TalkBack on Android.

### DIFF
--- a/client/flutter/android/app/src/main/AndroidManifest.xml
+++ b/client/flutter/android/app/src/main/AndroidManifest.xml
@@ -36,7 +36,7 @@
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data
             android:name="flutterEmbedding"
-            android:value="2" />
+            android:value="1" />
         <meta-data android:name="firebase_analytics_collection_enabled" android:value="false" />
         <meta-data android:name="google_analytics_adid_collection_enabled" android:value="false" />
         <meta-data android:name="google_analytics_ssaid_collection_enabled" android:value="false" />

--- a/client/flutter/android/app/src/main/kotlin/org/who/WHOMyHealth/MainActivity.kt
+++ b/client/flutter/android/app/src/main/kotlin/org/who/WHOMyHealth/MainActivity.kt
@@ -1,12 +1,12 @@
 package org.who.WHOMyHealth
 
-import androidx.annotation.NonNull;
-import io.flutter.embedding.android.FlutterActivity
-import io.flutter.embedding.engine.FlutterEngine
+import android.os.Bundle;
+import io.flutter.app.FlutterActivity
 import io.flutter.plugins.GeneratedPluginRegistrant
 
 class MainActivity: FlutterActivity() {
-    override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
-        GeneratedPluginRegistrant.registerWith(flutterEngine);
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        GeneratedPluginRegistrant.registerWith(this)
     }
 }


### PR DESCRIPTION
**Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).**
- [x] REQUIRED: Do you have an Issue **assigned to you** within the v1 milestone for this PR?  Put the Issue number here: https://github.com/WorldHealthOrganization/app/issues/935
- [x] Provided detailed pull request description and a succinct title (consider template below for guidance).
- [x] Tested your changes, especially after any code review iterations.
- [x] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).

After all boxes above are checked, request and receive an Approved review from any team member knowledgable in the area (TODO team member list).  Once approved, the team member will assign your review to a Committer or use the `needs-merge` label.

## What does this PR accomplish?
- Closes https://github.com/WorldHealthOrganization/app/issues/935
- Reverts to the old flutter embedding system(I believe) which doesn't have this issue. I'm not aware of any drawbacks to this.
<!-- Title should be a short phrase, e.g. "Adds survey functionality". -->

<!-- Detailed description can include any design decisions you want reviewers to take note of. -->

<!-- List all issue numbers affected and closed by this PR. -->

## Did you add any dependencies?
No
<!-- List each added dependency and justifications (see the Guidelines) -->

## How did you test the change?

<!-- If relevant, add any screenshots of your UI changes. -->
No green outline was being shown previously, now it works as expected.
![Screenshot_20200407-202644](https://user-images.githubusercontent.com/33752528/78711815-88835480-790f-11ea-9403-d1187c4621bd.jpg)
