### PR TITLE
[feat] Cron for pipeline stats from WHO

### DIFF
--- a/api/who/who.proto
+++ b/api/who/who.proto
@@ -40,6 +40,7 @@ message GetCaseStatsResponse {
 
 // Statistics in a single or aggregate jurisdiction.
 message CaseStats {
+  JurisdictionType jurisdictionType = 7;
   // empty for global stats
   string jurisdiction = 1;
 
@@ -51,6 +52,12 @@ message CaseStats {
   int64 recoveries = 5;
 
   string attribution = 6;
+}
+
+enum JurisdictionType {
+  GLOBAL = 0;
+  WHO_REGION = 1;
+  COUNTRY = 2;
 }
 
 enum Platform {

--- a/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
+++ b/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
@@ -1,0 +1,61 @@
+package who;
+
+import com.google.gson.JsonParser;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public class RefreshCaseStatsServlet extends HttpServlet {
+  private static final String WHO_CASE_STATS_URL = "https://dashboards-dev.sprinklr.com/data/9043/global-covid19-who-gis.json";
+
+  private static final OkHttpClient HTTP_CLIENT = new OkHttpClient();
+
+  private String getDashboardContents() throws IOException {
+    Request request = new Request.Builder()
+        .url(WHO_CASE_STATS_URL)
+        .build();
+    try (Response response = HTTP_CLIENT.newCall(request).execute()) {
+      return response.body().string();
+    }
+  }
+
+  @Override protected void doGet(HttpServletRequest request, HttpServletResponse response)
+          throws IOException {
+    // App Engine strips all external X-* request headers, so we can trust this is set by App Engine.
+    // https://cloud.google.com/appengine/docs/flexible/java/scheduling-jobs-with-cron-yaml#validating_cron_requests
+    if (Environment.isProduction() && !"true".equals(request.getHeader("X-Appengine-Cron"))) {
+      response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Cron access only");
+      return;
+    }
+
+    String jsonString = getDashboardContents();
+    JsonObject root = new JsonParser().parse(jsonString).getAsJsonObject();
+    JsonArray rows = root.getAsJsonArray("rows");
+    long cases = 0L, deaths = 0L;
+    // Given that each row has heterogeneous elements, not sure there is much benefit
+    // to using gson with reflection here.
+    for (JsonElement country : rows) {
+      JsonArray row = country.getAsJsonArray();
+      cases += row.get(5).getAsLong();
+      deaths += row.get(3).getAsLong();
+    }
+
+    CaseStats.Builder global = new CaseStats.Builder()
+        .jurisdictionType(JurisdictionType.GLOBAL)
+        .jurisdiction("")
+        .cases(cases)
+        .deaths(deaths)
+        .lastUpdated(root.getAsJsonPrimitive("createdTime").getAsLong())
+        .recoveries(-1L)
+        .attribution("WHO");
+
+    StoredCaseStats.save(global.build());
+  }
+}

--- a/server/appengine/src/main/java/who/StoredCaseStats.java
+++ b/server/appengine/src/main/java/who/StoredCaseStats.java
@@ -1,0 +1,59 @@
+package who;
+
+import com.googlecode.objectify.annotation.Cache;
+import com.googlecode.objectify.annotation.Entity;
+import com.googlecode.objectify.annotation.Id;
+
+import static com.googlecode.objectify.ObjectifyService.ofy;
+
+@Entity @Cache(expirationSeconds=120)
+public class StoredCaseStats {
+  // $jurisdictionType:$jurisdiction
+  @Id String jurisdictionKey;
+
+  // The protobuf itself lacks a no-arg constructor so
+  // we have to copy all the fields here.
+
+  public JurisdictionType jurisdictionType;
+
+  public String jurisdiction;
+
+  public Long lastUpdated;
+
+  public Long cases;
+
+  public Long deaths;
+
+  public Long recoveries;
+
+  public String attribution;
+
+  public static void save(CaseStats stats) {
+    StoredCaseStats s = new StoredCaseStats();
+    s.jurisdictionType = stats.jurisdictionType;
+    s.jurisdiction = stats.jurisdiction;
+    s.lastUpdated = stats.lastUpdated;
+    s.cases = stats.cases;
+    s.deaths = stats.deaths;
+    s.recoveries = stats.recoveries;
+    s.attribution = stats.attribution;
+    s.jurisdictionKey = stats.jurisdictionType.getValue() + ":" + stats.jurisdiction;
+    ofy().save().entities(s).now();
+  }
+
+  public static CaseStats load(JurisdictionType type, String jurisdiction) {
+    StoredCaseStats ret = ofy().load().type(StoredCaseStats.class).id(type.getValue() + ":" + jurisdiction).now();
+    if (ret == null) {
+      return null;
+    }
+    return new CaseStats.Builder()
+      .jurisdictionType(ret.jurisdictionType)
+      .jurisdiction(ret.jurisdiction)
+      .lastUpdated(ret.lastUpdated)
+      .cases(ret.cases)
+      .deaths(ret.deaths)
+      .recoveries(ret.recoveries)
+      .attribution(ret.attribution)
+      .build();
+  }
+}

--- a/server/appengine/src/main/java/who/WhoServiceImpl.java
+++ b/server/appengine/src/main/java/who/WhoServiceImpl.java
@@ -28,20 +28,10 @@ public class WhoServiceImpl implements WhoService {
   // 10 mins
   private static final long STATS_TTL_SECONDS = 60 * 10;
 
-  @Override public GetCaseStatsResponse getCaseStats(Void request) {
-      
-    // TODO: Get from data source.
+  @Override public GetCaseStatsResponse getCaseStats(Void request) throws IOException {
+    CaseStats global = StoredCaseStats.load(JurisdictionType.GLOBAL, "");
     return new GetCaseStatsResponse.Builder()
-      .globalStats(new CaseStats.Builder()
-        .cases(1136851L)
-        .deaths(62955L)
-        // 2020-04-05 18:00 CET
-        .lastUpdated(1586102400000L)
-        // TODO: Unsure whether we can get an efficient query for recoveries in real-time.
-        .recoveries(-1L)
-        .attribution("WHO")
-        .build()
-      )
+      .globalStats(global)
       .ttl(STATS_TTL_SECONDS)
       .build();
   }

--- a/server/appengine/src/main/java/who/WhoServletModule.java
+++ b/server/appengine/src/main/java/who/WhoServletModule.java
@@ -31,6 +31,10 @@ public class WhoServletModule extends ServletModule {
 
     // Register Objectify entities
     ObjectifyService.register(Client.class);
+    ObjectifyService.register(StoredCaseStats.class);
+
+    // Internal cron jobs using Objectify but not requiring Clients.
+    serve("/internal/cron/refreshCaseStats").with(new RefreshCaseStatsServlet());
 
     // Set up Present RPC
     filter("/*").through(WhoRpcFilter.class);

--- a/server/appengine/src/main/webapp/WEB-INF/cron.yaml
+++ b/server/appengine/src/main/webapp/WEB-INF/cron.yaml
@@ -1,0 +1,4 @@
+cron:
+- description: "refresh case stats from WHO dashboard"
+  url: /internal/cron/refreshCaseStats
+  schedule: every 5 minutes


### PR DESCRIPTION
Every 5 minutes refresh case stats from new WHO pipeline (0.003 RPS load)

Closes #928

Not sure if this is where cron.yaml is supposed to live in Java standard AE... @crazybob and do we have to deploy it separately from the WAR?

Test:
```
$ curl -i  -H 'X-Appengine-Cron: true' -X GET     http://localhost:8080/internal/cron/refreshCaseStats
HTTP/1.1 200 OK
Server: Development/1.0
Date: Tue, 07 Apr 2020 23:46:04 GMT
Cache-Control: no-cache
Expires: Mon, 01 Jan 1990 00:00:00 GMT
Content-Length: 0


$ curl -i     -H 'Content-Type: application/json' -H 'Who-Client-ID: 00000000-0000-0000-0000-000000000000' -H 'Who-Platform: IOS' -X POST -d ''     http://localhost:8080/WhoService/getCaseStats
HTTP/1.1 200 OK
Content-Type: application/json
Server: Development/1.0
Date: Tue, 07 Apr 2020 23:46:10 GMT
Cache-Control: no-cache
Expires: Mon, 01 Jan 1990 00:00:00 GMT
Content-Length: 168

{"globalStats":{"jurisdictionType":"GLOBAL","jurisdiction":"","lastUpdated":1586303096433,"cases":1282931,"deaths":72776,"recoveries":-1,"attribution":"WHO"},"ttl":600
```