### PR TITLE
fix: increase contrast of onboarding skip button

### DIFF
--- a/client/flutter/lib/pages/onboarding/permission_request_page.dart
+++ b/client/flutter/lib/pages/onboarding/permission_request_page.dart
@@ -99,7 +99,7 @@ class PermissionRequestPage extends StatelessWidget {
                         child: Text(
                           S.of(context).commonPermissionRequestPageButtonSkip,
                           style: TextStyle(
-                            color: Color(0xffC9CDD6),
+                            color: Color(0xFF6E7691),
                             fontSize: 18,
                           ),
                         ),


### PR DESCRIPTION
**Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).**
- [x] REQUIRED: Do you have an Issue **assigned to you** within the v1 milestone for this PR?  Put the Issue number here: https://github.com/WorldHealthOrganization/app/issues/940
- [x] Provided detailed pull request description and a succinct title (consider template below for guidance).
- [x] Tested your changes, especially after any code review iterations.
- [x] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).

After all boxes above are checked, request and receive an Approved review from any team member knowledgable in the area (TODO team member list).  Once approved, the team member will assign your review to a Committer or use the `needs-merge` label.

## What does this PR accomplish?
- Closes https://github.com/WorldHealthOrganization/app/issues/940
- Increases the contrast ratio of the skip button on the onboarding page from 1.59:1 to 4.5:1
#C9CDD6 to #6E7691
<!-- Title should be a short phrase, e.g. "Adds survey functionality". -->

<!-- Detailed description can include any design decisions you want reviewers to take note of. -->

<!-- List all issue numbers affected and closed by this PR. -->

## Did you add any dependencies?
No
<!-- List each added dependency and justifications (see the Guidelines) -->

## How did you test the change?
Running on my Android device
<!-- If relevant, add any screenshots of your UI changes. -->
Before:
![Screenshot_20200408-160216__01](https://user-images.githubusercontent.com/33752528/78799878-a6ee5c00-79b2-11ea-9ffe-729881a6d4d3.jpg)
After:
![Screenshot_20200408-155751__01](https://user-images.githubusercontent.com/33752528/78799914-b372b480-79b2-11ea-820b-d2aff7e11bba.jpg)
