### PR TITLE
Fix: arrow button overflowing (fixes #979)

### DIFF
--- a/client/flutter/lib/components/arrow_button.dart
+++ b/client/flutter/lib/components/arrow_button.dart
@@ -11,15 +11,16 @@ class ArrowButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return FlatButton(
-      shape: StadiumBorder(),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(35)),
       padding: EdgeInsets.symmetric(vertical: 24, horizontal: 23),
       color: this.color,
       child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: <Widget>[
-          Text(
-            title,
-            style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
+          Expanded(
+            child: Text(
+              title,
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
+            ),
           ),
           Icon(Icons.arrow_forward_ios)
         ],

--- a/content/credits.yaml
+++ b/content/credits.yaml
@@ -67,6 +67,7 @@ team:
   - Josh Holtz
   - Alexa Grafera
   - Louie Mantia
+  - Tom Gilder
 
 # Add yourself here when you first submit a contribution.
 


### PR DESCRIPTION
**Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).**
- [x] REQUIRED: Do you have an Issue **assigned to you** within the v1 milestone for this PR?  Put the Issue number here: #979 
- [x] Provided detailed pull request description and a succinct title (consider template below for guidance).
- [x] Tested your changes, especially after any code review iterations.
- [x] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).

After all boxes above are checked, request and receive an Approved review from any team member knowledgable in the area (TODO team member list).  Once approved, the team member will assign your review to a Committer or use the `needs-merge` label.

## What does this PR accomplish?

Fixes #979 - font size overflowing on buttons (see screenshots below)

## Did you add any dependencies?

No.

## How did you test the change?

Manually on iOS simulator


Before
![before](https://user-images.githubusercontent.com/756862/78940754-0a65b000-7abf-11ea-8513-8e2f1e64bc6e.png)
After
![after](https://user-images.githubusercontent.com/756862/78940766-105b9100-7abf-11ea-97ad-316eac72c8ba.png)


Before
![before 2](https://user-images.githubusercontent.com/756862/78940789-1b162600-7abf-11ea-871b-104bc5db2345.png)
After
![after 2](https://user-images.githubusercontent.com/756862/78940809-1fdada00-7abf-11ea-9abd-edf75923dc50.png)
