### PR TITLE
Remove context from pagescaffold, it is unused

### DIFF
--- a/client/flutter/lib/components/page_scaffold/page_scaffold.dart
+++ b/client/flutter/lib/components/page_scaffold/page_scaffold.dart
@@ -8,14 +8,13 @@ class PageScaffold extends StatelessWidget {
 
   final List<Widget> body;
 
-  final BuildContext context; // TODO: Remove this
   final EdgeInsets padding;
   final bool showBackButton;
   final bool showShareBottomBar;
   final bool showLogoInHeader;
 
   PageScaffold(
-    this.context, {
+    {
     @required this.body,
     @required this.title,
     this.showShareBottomBar = false,

--- a/client/flutter/lib/pages/about_page.dart
+++ b/client/flutter/lib/pages/about_page.dart
@@ -18,7 +18,7 @@ class AboutPage extends StatelessWidget {
         .of(context)
         .commonWorldHealthOrganizationCoronavirusCopyright(DateTime.now().year);
 
-    return PageScaffold(context,
+    return PageScaffold(
         body: [
           SliverList(
               delegate: SliverChildListDelegate([

--- a/client/flutter/lib/pages/home_page.dart
+++ b/client/flutter/lib/pages/home_page.dart
@@ -38,7 +38,7 @@ class HomePage extends StatelessWidget {
 
     final divider = Container(height: 1, color: Color(0xffC9CDD6));
 
-    return PageScaffold(context,
+    return PageScaffold(
         title: S.of(context).homePagePageTitle,
         subtitle: S.of(context).homePagePageSubTitle,
         showBackButton: false,

--- a/client/flutter/lib/pages/latest_numbers.dart
+++ b/client/flutter/lib/pages/latest_numbers.dart
@@ -33,7 +33,7 @@ class LatestNumbers extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PageScaffold(context,
+    return PageScaffold(
         title: S.of(context).latestNumbersPageTitle,
         showShareBottomBar: false,
         body: [

--- a/client/flutter/lib/pages/news_feed.dart
+++ b/client/flutter/lib/pages/news_feed.dart
@@ -9,7 +9,6 @@ class NewsFeed extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PageScaffold(
-      context,
       body: [
         SliverList(
             delegate: SliverChildListDelegate([

--- a/client/flutter/lib/pages/protect_yourself.dart
+++ b/client/flutter/lib/pages/protect_yourself.dart
@@ -100,7 +100,7 @@ class ProtectYourself extends StatelessWidget {
   Widget build(BuildContext context) {
     final localized = S.of(context);
 
-    return PageScaffold(context,
+    return PageScaffold(
         title: S.of(context).protectYourselfTitle,
         showShareBottomBar: false,
         body: [

--- a/client/flutter/lib/pages/question_index.dart
+++ b/client/flutter/lib/pages/question_index.dart
@@ -63,7 +63,6 @@ class _QuestionIndexPageState extends State<QuestionIndexPage> {
         .toList();
 
     return PageScaffold(
-      context,
       body: [
         items.isNotEmpty
             ? SliverList(

--- a/client/flutter/lib/pages/settings_page.dart
+++ b/client/flutter/lib/pages/settings_page.dart
@@ -43,7 +43,6 @@ class _SettingsPageState extends State<SettingsPage> {
   @override
   Widget build(BuildContext context) {
     return PageScaffold(
-      context,
       body: [
         SliverList(
             delegate: SliverChildListDelegate(

--- a/client/flutter/lib/pages/travel_advice.dart
+++ b/client/flutter/lib/pages/travel_advice.dart
@@ -8,7 +8,7 @@ import 'package:flutter_html/flutter_html.dart';
 class TravelAdvice extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return PageScaffold(context,
+    return PageScaffold(
         showShareBottomBar: false,
         body: [
           SliverList(

--- a/client/flutter/lib/pages/who_myth_busters.dart
+++ b/client/flutter/lib/pages/who_myth_busters.dart
@@ -7,7 +7,7 @@ import 'package:flutter/material.dart';
 class WhoMythBusters extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return PageScaffold(context,
+    return PageScaffold(
         showShareBottomBar: true,
         body: [
           SliverList(


### PR DESCRIPTION
**Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).**
- [ ] REQUIRED: Do you have an Issue **assigned to you** within the v1 milestone for this PR?  Put the Issue number here:
- [ ] Provided detailed pull request description and a succinct title (consider template below for guidance).
- [ ] Tested your changes, especially after any code review iterations.
- [ ] Included any relevant screenshots of UI updates.
- [ ] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [ ] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [ ] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).

After all boxes above are checked, request and receive an Approved review from any team member knowledgable in the area (TODO team member list).  Once approved, the team member will assign your review to a Committer or use the `needs-merge` label.

## What does this PR accomplish?

Makes page scaffold no longer take context

- Context is unused
- Outside context could cause an error

## Did you add any dependencies?

No

## How did you test the change?

iOS simulator