### PR TITLE
Fix: make animation from home page smoother (closes #993)

### DIFF
--- a/client/flutter/lib/components/swipeable_open_container.dart
+++ b/client/flutter/lib/components/swipeable_open_container.dart
@@ -750,38 +750,41 @@ class _OpenContainerRoute extends ModalRoute<void> {
                         fit: StackFit.passthrough,
                         children: <Widget>[
                           // Closed child fading out.
-                          FittedBox(
-                            fit: BoxFit.fitWidth,
-                            alignment: Alignment.topLeft,
-                            child: SizedBox(
-                              width: _rectTween.begin.width,
-                              height: _rectTween.begin.height,
-                              child: hideableKey.currentState.isInTree
-                                  ? null
-                                  : Opacity(
-                                      opacity: closedOpacityTween
-                                          .evaluate(animation),
-                                      child: Builder(
-                                        key: closedBuilderKey,
-                                        builder: (BuildContext context) {
-                                          // Use dummy "open container" callback
-                                          // since we are in the process of opening.
-                                          return closedBuilder(context, () {});
-                                        },
-                                      ),
-                                    ),
+                          Opacity(
+                            opacity: closedOpacityTween.evaluate(animation),
+                            child: Container(
+                              color: closedColor,
+                              child: FittedBox(
+                                fit: BoxFit.fitWidth,
+                                alignment: Alignment.topLeft,
+                                child: SizedBox(
+                                  width: _rectTween.begin.width,
+                                  height: _rectTween.begin.height,
+                                  child: hideableKey.currentState.isInTree
+                                      ? null
+                                      : Builder(
+                                          key: closedBuilderKey,
+                                          builder: (BuildContext context) {
+                                            // Use dummy "open container" callback
+                                            // since we are in the process of opening.
+                                            return closedBuilder(
+                                                context, () {});
+                                          },
+                                        ),
+                                ),
+                              ),
                             ),
                           ),
 
                           // Open child fading in.
-                          FittedBox(
-                            fit: BoxFit.fitWidth,
-                            alignment: Alignment.topLeft,
-                            child: SizedBox(
-                              width: _rectTween.end.width,
-                              height: _rectTween.end.height,
-                              child: Opacity(
-                                opacity: openOpacityTween.evaluate(animation),
+                          Opacity(
+                            opacity: openOpacityTween.evaluate(animation),
+                            child: FittedBox(
+                              fit: BoxFit.fitWidth,
+                              alignment: Alignment.topLeft,
+                              child: SizedBox(
+                                width: _rectTween.end.width,
+                                height: _rectTween.end.height,
                                 child: Builder(
                                   key: _openBuilderKey,
                                   builder: (BuildContext context) {

--- a/content/credits.yaml
+++ b/content/credits.yaml
@@ -68,7 +68,6 @@ team:
   - Tom Gilder
   - Alexa Grafera
   - Louie Mantia
-  - Tom Gilder
 
 # Add yourself here when you first submit a contribution.
 


### PR DESCRIPTION
**Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).**
- [x] REQUIRED: Do you have an Issue **assigned to you** within the v1 milestone for this PR?  Put the Issue number here: #993
- [x] Provided detailed pull request description and a succinct title (consider template below for guidance).
- [x] Tested your changes, especially after any code review iterations.
- [x] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).

After all boxes above are checked, request and receive an Approved review from any team member knowledgable in the area (TODO team member list).  Once approved, the team member will assign your review to a Committer or use the `needs-merge` label.

## What does this PR accomplish?

Makes the transition from home page to subpages much nicer.

When swiping back from iOS everything now lines up.

It also removes me from being in the credits twice :-)

Closes #993 

<!-- Title should be a short phrase, e.g. "Adds survey functionality". -->

<!-- Detailed description can include any design decisions you want reviewers to take note of. -->

<!-- List all issue numbers affected and closed by this PR. -->

## Did you add any dependencies?

No

<!-- List each added dependency and justifications (see the Guidelines) -->

## How did you test the change?

Manually

<!-- If relevant, add any screenshots of your UI changes. -->


![slidey slide](https://user-images.githubusercontent.com/756862/79073212-f94eb600-7ced-11ea-938a-17949cd7e8c4.gif)
