### PR TITLE
Client/server: Communicate location solely using S2 cell ids at L9

### DIFF
--- a/api/who/who.proto
+++ b/api/who/who.proto
@@ -24,6 +24,8 @@ message PutLocationRequest {
   // A token is a hex representation of the 64-bit S2CellId
   // in string format that will also survive JSON (which
   // lacks 64-bit number precision).
+  // The level (specificity) of the S2CellId must not exceed
+  // who.Client.MAX_S2_CELL_LEVEL.
   string s2CellIdToken = 11;
 }
 

--- a/api/who/who.proto
+++ b/api/who/who.proto
@@ -21,11 +21,10 @@ message PutDeviceTokenRequest {
 }
 
 message PutLocationRequest {
-  // While an S2 Cell id is a 64-bit unsigned integer, it is
-  // treated as a (signed) long in Java and a (signed)
-  // int in Dart.
-  // In addition, such id encodes the cell's level of granularity.
-  int64 s2CellId = 11;
+  // A token is a hex representation of the 64-bit S2CellId
+  // in string format that will also survive JSON (which
+  // lacks 64-bit number precision).
+  string s2CellIdToken = 11;
 }
 
 message GetCaseStatsResponse {

--- a/api/who/who.proto
+++ b/api/who/who.proto
@@ -21,17 +21,11 @@ message PutDeviceTokenRequest {
 }
 
 message PutLocationRequest {
-  double latitude = 2;
-  double longitude = 3;
-  // ISO 3166 Alpha-2 country code
-  string countryCode = 4;
-  // In all cases, a short name in English or a standardized code is preferred.
-  string adminArea1 = 5;
-  string adminArea2 = 6;
-  string adminArea3 = 7;
-  string adminArea4 = 8;
-  string adminArea5 = 9;
-  string locality = 10;
+  // While an S2 Cell id is a 64-bit unsigned integer, it is
+  // treated as a (signed) long in Java and a (signed)
+  // int in Dart.
+  // In addition, such id encodes the cell's level of granularity.
+  int64 s2CellId = 11;
 }
 
 message GetCaseStatsResponse {

--- a/client/flutter/android/app/src/main/AndroidManifest.xml
+++ b/client/flutter/android/app/src/main/AndroidManifest.xml
@@ -5,7 +5,6 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
   <application android:name="io.flutter.app.FlutterApplication" android:label="COVID-19" android:icon="@mipmap/ic_launcher">
     <activity android:name=".MainActivity" android:launchMode="singleTop" android:theme="@style/LaunchTheme" android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode" android:hardwareAccelerated="true" android:windowSoftInputMode="adjustResize">
       <!-- Specifies an Android theme to apply to this Activity as soon as

--- a/client/flutter/ios/Podfile.lock
+++ b/client/flutter/ios/Podfile.lock
@@ -61,10 +61,6 @@ PODS:
   - FMDB (2.7.5):
     - FMDB/standard (= 2.7.5)
   - FMDB/standard (2.7.5)
-  - geolocator (5.3.1):
-    - Flutter
-  - google_api_availability (2.0.4):
-    - Flutter
   - GoogleAppMeasurement (6.4.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 6.0)
     - GoogleUtilities/MethodSwizzler (~> 6.0)
@@ -94,8 +90,6 @@ PODS:
   - GoogleUtilities/UserDefaults (6.5.2):
     - GoogleUtilities/Logger
   - location (0.0.1):
-    - Flutter
-  - location_permissions (2.0.5):
     - Flutter
   - location_web (0.0.1):
     - Flutter
@@ -134,10 +128,7 @@ DEPENDENCIES:
   - firebase_analytics (from `.symlinks/plugins/firebase_analytics/ios`)
   - firebase_messaging (from `.symlinks/plugins/firebase_messaging/ios`)
   - Flutter (from `Flutter`)
-  - geolocator (from `.symlinks/plugins/geolocator/ios`)
-  - google_api_availability (from `.symlinks/plugins/google_api_availability/ios`)
   - location (from `.symlinks/plugins/location/ios`)
-  - location_permissions (from `.symlinks/plugins/location_permissions/ios`)
   - location_web (from `.symlinks/plugins/location_web/ios`)
   - package_info (from `.symlinks/plugins/package_info/ios`)
   - path_provider (from `.symlinks/plugins/path_provider/ios`)
@@ -178,14 +169,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/firebase_messaging/ios"
   Flutter:
     :path: Flutter
-  geolocator:
-    :path: ".symlinks/plugins/geolocator/ios"
-  google_api_availability:
-    :path: ".symlinks/plugins/google_api_availability/ios"
   location:
     :path: ".symlinks/plugins/location/ios"
-  location_permissions:
-    :path: ".symlinks/plugins/location_permissions/ios"
   location_web:
     :path: ".symlinks/plugins/location_web/ios"
   package_info:
@@ -225,14 +210,11 @@ SPEC CHECKSUMS:
   FirebaseMessaging: 4ec33842d36b3319e062e51fb8b35a74f726950d
   Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
   FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
-  geolocator: 460cc8e850b616f8c0e90944c86517d91ccbb686
-  google_api_availability: 15fa42a8cd83c0a6738507ffe6e87096f12abcb8
   GoogleAppMeasurement: 6e68a94d0eaeb1d73ef6b0ed4f7334e29d63ae29
   GoogleDataTransport: b29a21d813e906014ca16c00897827e40e4a24ab
   GoogleDataTransportCCTSupport: 6f15a89b0ca35d6fa523e1f752ef818588885988
   GoogleUtilities: ad0f3b691c67909d03a3327cc205222ab8f42e0e
   location: 3a2eed4dd2fab25e7b7baf2a9efefe82b512d740
-  location_permissions: 4a49d4e5bec5b653643e551ab77963cc99bb0e4a
   location_web: b94e7433cfe28c0f7c8923c2ee482824b32e55a7
   nanopb: 18003b5e52dab79db540fe93fe9579f399bd1ccd
   package_info: 48b108e75b8802c2d5e126f208ef540561c98aef

--- a/client/flutter/lib/api/who_service.dart
+++ b/client/flutter/lib/api/who_service.dart
@@ -23,15 +23,10 @@ class WhoService {
   }
 
   /// Put location
-  static Future<bool> putLocation({double latitude, double longitude, String countryCode, String adminArea, String subadminArea, String locality}) async {
+  static Future<bool> putLocation({int s2CellId}) async {
     Map<String, String> headers = await _getHeaders();
     var postBody = jsonEncode({
-      "latitude": latitude,
-      "longitude": longitude,
-      "countryCode": countryCode,
-      "adminArea1": adminArea,
-      "adminArea2": subadminArea,
-      "locality": locality,
+      "s2CellId": s2CellId,
     });
     var url = '$serviceUrl/putLocation';
     var response = await http.post(url, headers: headers, body: postBody);

--- a/client/flutter/lib/api/who_service.dart
+++ b/client/flutter/lib/api/who_service.dart
@@ -23,10 +23,10 @@ class WhoService {
   }
 
   /// Put location
-  static Future<bool> putLocation({int s2CellId}) async {
+  static Future<bool> putLocation({String s2CellIdToken}) async {
     Map<String, String> headers = await _getHeaders();
     var postBody = jsonEncode({
-      "s2CellId": s2CellId,
+      "s2CellIdToken": s2CellIdToken,
     });
     var url = '$serviceUrl/putLocation';
     var response = await http.post(url, headers: headers, body: postBody);

--- a/client/flutter/lib/pages/onboarding/location_sharing_page.dart
+++ b/client/flutter/lib/pages/onboarding/location_sharing_page.dart
@@ -2,8 +2,8 @@ import 'package:WHOFlutter/api/who_service.dart';
 import 'package:WHOFlutter/generated/l10n.dart';
 import 'package:WHOFlutter/pages/onboarding/permission_request_page.dart';
 import 'package:flutter/material.dart';
-import 'package:geolocator/geolocator.dart';
 import 'package:location/location.dart';
+import 'package:s2geometry/s2geometry.dart';
 
 class LocationSharingPage extends StatefulWidget {
   final VoidCallback onNext;
@@ -42,48 +42,11 @@ class _LocationSharingPageState extends State<LocationSharingPage> {
       _complete();
       if (locationReady) {
         LocationData location = await Location().getLocation();
-        final geo = Geolocator();
-        // Use en_US because these are not for display, they are for indexing.
-        final myPlaces = await geo.placemarkFromCoordinates(
-            location.latitude, location.longitude,
-            localeIdentifier: 'en_US');
-        if (myPlaces.isEmpty) {
-          print('No Reverse Geolocation place');
-          return;
-        }
-        final myPlace = myPlaces.first;
-        if (myPlace.isoCountryCode == null || myPlace.isoCountryCode.isEmpty) {
-          print('No Reverse Geolocation country');
-          // We need at least a country.
-          return;
-        }
-        var addrComponents = [myPlace.isoCountryCode];
-        [
-          myPlace.administrativeArea,
-          myPlace.subAdministrativeArea,
-          myPlace.locality,
-        ].forEach((n) {
-          if (n != null && n.isNotEmpty) {
-            addrComponents.insert(0, n);
-          }
-        });
-        final addr = addrComponents.join(', ');
 
-        final placesCityCenter =
-            await geo.placemarkFromAddress(addr, localeIdentifier: 'en_US');
-        if (placesCityCenter.isEmpty) {
-          print('No Geolocated City Center');
-          return;
-        }
-        final placeCityCenter = placesCityCenter.first;
+        S2LatLng latLng = new S2LatLng.fromDegrees(location.latitude, location.longitude);
+        S2CellId cellId = new S2CellId.fromLatLng(latLng);
 
-        await WhoService.putLocation(
-            latitude: placeCityCenter.position.latitude,
-            longitude: placeCityCenter.position.longitude,
-            countryCode: myPlace.isoCountryCode,
-            adminArea: myPlace.administrativeArea,
-            subadminArea: myPlace.subAdministrativeArea,
-            locality: myPlace.locality);
+        await WhoService.putLocation(s2CellId: cellId.id());
       }
     } catch (_) {
       _complete();

--- a/client/flutter/pubspec.lock
+++ b/client/flutter/pubspec.lock
@@ -71,13 +71,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.16.1"
-  equatable:
-    dependency: transitive
-    description:
-      name: equatable
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.1"
   firebase_analytics:
     dependency: "direct main"
     description:
@@ -154,20 +147,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  geolocator:
-    dependency: "direct main"
-    description:
-      name: geolocator
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "5.3.1"
-  google_api_availability:
-    dependency: transitive
-    description:
-      name: google_api_availability
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.4"
   html:
     dependency: transitive
     description:
@@ -217,13 +196,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.2"
-  location_permissions:
-    dependency: transitive
-    description:
-      name: location_permissions
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.5"
   location_platform_interface:
     dependency: transitive
     description:
@@ -343,6 +315,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.5"
+  s2geometry:
+    dependency: "direct main"
+    description:
+      name: s2geometry
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.1"
   share:
     dependency: "direct main"
     description:

--- a/client/flutter/pubspec.yaml
+++ b/client/flutter/pubspec.yaml
@@ -25,7 +25,6 @@ dependencies:
   shared_preferences: ^0.5.6
   firebase_messaging: ^6.0.13
   location: ^3.0.1
-  geolocator: ^5.3.1
   yaml: ^2.2.0
   http: ^0.12.0+3
   uuid: 2.0.4
@@ -35,6 +34,7 @@ dependencies:
   flutter_cache_manager: ^1.1.3
   path_provider: ^1.6.5
   fl_chart: ^0.8.7
+  s2geometry: 0.1.1
 
   intl: ^0.16.0
   flutter_localizations:

--- a/server/appengine/src/main/java/who/Client.java
+++ b/server/appengine/src/main/java/who/Client.java
@@ -20,12 +20,21 @@ import static com.googlecode.objectify.ObjectifyService.ofy;
 
   public Platform platform;
 
-  /** S2 leaf cell ID for last known location. See S2CellId. */
+
+  /** S2 cell ID for last known location. See S2CellId. */
   @Index(IfNotNull.class) public Long location;
+  // No locations of greater level (specificity) than this will be
+  // stored and indexed.  This prevents us from storing precise
+  // locations and protects the database index size.
+  // See: https://s2geometry.io/resources/s2cell_statistics.html
+  public static final int MAX_S2_CELL_LEVEL = 9;
+
+  // Lat/lng representative of the cell, not neccessarily
+  // of the device.
   public Double latitude;
   public Double longitude;
 
-  // Store denormalized location info.
+  // TODO: Store denormalized location info if/when needed.
   public String countryCode;
   public String adminArea1;
   public String adminArea2;

--- a/server/appengine/src/main/java/who/WhoServiceImpl.java
+++ b/server/appengine/src/main/java/who/WhoServiceImpl.java
@@ -3,6 +3,7 @@ package who;
 import com.google.common.base.Strings;
 import com.google.common.geometry.S2CellId;
 import com.google.common.geometry.S2LatLng;
+import present.rpc.ClientException;
 import java.io.IOException;
 
 import static com.googlecode.objectify.ObjectifyService.ofy;
@@ -18,16 +19,16 @@ public class WhoServiceImpl implements WhoService {
 
   @Override public Void putLocation(PutLocationRequest request) throws IOException {
     Client client = Client.current();
-    final location = new S2CellId(request.s2CellId);
+    S2CellId location = S2CellId.fromToken(request.s2CellIdToken);
     if (!location.isValid()) {
       throw new ClientException("Invalid s2CellId");
     }
     if (location.level() > Client.MAX_S2_CELL_LEVEL) {
       throw new ClientException("s2CellId level too high");
     }
-    client.location = location;
+    client.location = location.id();
     // Center of the cell.
-    S2LatLng point = client.location.toLatLng();
+    S2LatLng point = location.toLatLng();
     client.latitude = point.latDegrees();
     client.longitude = point.lngDegrees();
     ofy().save().entities(client);


### PR DESCRIPTION
- Removes all geocoding and its dependencies
- Switches Android permissions to coarse location, and asks at runtime for Low accuracy iOS location
- Quantizes location to S2CellId at L9 (strictly greater than 100km^2)
- Removes all other fields of location communication
- Server-side validation of s2 token being of a coarse-enough level to avoid pollution and for privacy
- New dependency: Have reviewed the specific pinned version from pub.dev.


TESTED=true with iOS and Android simulator against Dev app engine backend

Close #1040