### PR TITLE
Change "Protect Yourself" page to use HTML for dynamic content.

### DIFF
--- a/client/flutter/assets/content_bundles/protect_yourself.en.yaml
+++ b/client/flutter/assets/content_bundles/protect_yourself.en.yaml
@@ -6,19 +6,19 @@ contents:
     -
       animation_name: wash_hands
       body_html: |
-        *Wash your hands* with soap and water to avoid getting sick and spreading infections to others.
+        <b>Wash your hands</b> with soap and water to avoid getting sick and spreading infections to others.
     -
       image_name: avoid_touch
       body_html: |
-        *Avoid touching* your eyes, mouth, and nose.
+        <b>Avoid touching</b> your eyes, mouth, and nose.
     -
       image_name: elbow
       body_html: |
-        *Cover your mouth and nose* with your bent elbow or tissue when you cough or sneeze.
+        <b>Cover your mouth and nose</b> with your bent elbow or tissue when you cough or sneeze.
     -
       image_name: social_distance
       body_html: |
-        *Stay more than* 1 meter (>3 feet) away from a person who is sick.
+        <b>Stay more than</b> 1 meter (>3 feet) away from a person who is sick.
     -
       image_name: mask
       body_html: |

--- a/client/flutter/lib/pages/protect_yourself.dart
+++ b/client/flutter/lib/pages/protect_yourself.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_html/flutter_html.dart';
 import 'package:who_app/api/content/schema/fact_content.dart';
 import 'package:who_app/components/dialogs.dart';
 import 'package:who_app/components/page_scaffold/page_scaffold.dart';
@@ -6,6 +7,7 @@ import 'package:who_app/constants.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:who_app/generated/l10n.dart';
+import 'package:html/dom.dart' as dom;
 
 class ProtectYourself extends StatefulWidget {
   final FactsDataSource dataSource;
@@ -55,10 +57,26 @@ class _ProtectYourselfState extends State<ProtectYourself> {
   }
 
   List<Widget> _buildCards() {
+    final TextStyle normalText = TextStyle(
+      color: Constants.textColor,
+      fontSize: 16 * MediaQuery.textScaleFactorOf(context),
+      height: 1.4,
+    );
+    final TextStyle boldText = normalText.copyWith(fontWeight: FontWeight.w700);
     return (_factContent?.items ?? []).map((fact) {
-      print("fact body = ${fact.body}, image = ${fact.imageName}");
       return _ProtectYourselfCard(
-        message: _message(fact.body),
+        message: Html(
+            data: fact.body ?? "",
+            defaultTextStyle: normalText,
+            customTextStyle: (dom.Node node, TextStyle baseStyle) {
+              if (node is dom.Element) {
+                switch (node.localName) {
+                  case "b":
+                    return baseStyle.merge(boldText);
+                }
+              }
+              return baseStyle.merge(normalText);
+            }),
         child: fact.animationName != null
             ? _getAnimation(fact.animationName)
             : _getSVG('assets/svg/${fact.imageName}.svg'),
@@ -86,53 +104,6 @@ class _ProtectYourselfState extends State<ProtectYourself> {
           ),
         ),
       );
-
-  // TODO: Change this to use HTML content styling like the other pages?
-  Text _message(String input) {
-    final TextStyle normal = TextStyle(
-      color: Constants.textColor,
-      fontSize: 16,
-      height: 1.4,
-    );
-    final TextStyle bold = TextStyle(
-      color: Constants.textColor,
-      fontSize: 16,
-      fontWeight: FontWeight.w700,
-    );
-    // Make sections delineated by asterisk * bold. For example:
-    // String text = '*This is bold* this is not';
-
-    var regex = RegExp(r'\*([^,*]+)\*');
-
-    var matched = regex.allMatches(input);
-
-    var spans = <TextSpan>[];
-    var before = 0;
-    for (var match in matched) {
-      var value = match.group(1);
-      if (before < match.start) {
-        spans.add(
-          TextSpan(
-            text: input.substring(before, match.start),
-          ),
-        );
-      }
-
-      spans.add(
-        TextSpan(text: value, style: bold),
-      );
-      before = match.end;
-    }
-
-    spans.add(
-      TextSpan(
-        text: input.substring(before),
-      ),
-    );
-    return Text.rich(
-      TextSpan(style: normal, children: spans),
-    );
-  }
 }
 
 class _ProtectYourselfCard extends StatelessWidget {
@@ -141,7 +112,7 @@ class _ProtectYourselfCard extends StatelessWidget {
     @required this.child,
   });
 
-  final Text message;
+  final Html message;
   final Widget child;
 
   @override


### PR DESCRIPTION
This PR changes the "Protect Yourself" page to use HTML for the dynamic content instead of the ad-hoc markdown syntax.  

I believe it looks identical with the exception that one line is breaking slightly differently.

<img width="882" alt="image" src="https://user-images.githubusercontent.com/852471/79888883-e52c4800-83c2-11ea-84b2-c9a6afd8186f.png">

Closes #1030 