### PR TITLE
Add loading indicator to "Protect Yourself" page and refactor widget.

### DIFF
--- a/client/flutter/lib/components/loading_indicator.dart
+++ b/client/flutter/lib/components/loading_indicator.dart
@@ -10,9 +10,8 @@ class LoadingIndicator extends StatelessWidget {
   Widget build(BuildContext context) {
     return SliverToBoxAdapter(
         child: Padding(
-          padding: const EdgeInsets.only(top: 48.0),
-          child: CupertinoActivityIndicator(),
-        ));
+      padding: const EdgeInsets.only(top: 48.0),
+      child: CupertinoActivityIndicator(),
+    ));
   }
 }
-

--- a/client/flutter/lib/components/loading_indicator.dart
+++ b/client/flutter/lib/components/loading_indicator.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class LoadingIndicator extends StatelessWidget {
+  const LoadingIndicator({
+    Key key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return SliverToBoxAdapter(
+        child: Padding(
+          padding: const EdgeInsets.all(48.0),
+          child: CupertinoActivityIndicator(),
+        ));
+  }
+}
+

--- a/client/flutter/lib/components/loading_indicator.dart
+++ b/client/flutter/lib/components/loading_indicator.dart
@@ -10,7 +10,7 @@ class LoadingIndicator extends StatelessWidget {
   Widget build(BuildContext context) {
     return SliverToBoxAdapter(
         child: Padding(
-          padding: const EdgeInsets.all(48.0),
+          padding: const EdgeInsets.only(top: 48.0),
           child: CupertinoActivityIndicator(),
         ));
   }

--- a/client/flutter/lib/pages/protect_yourself.dart
+++ b/client/flutter/lib/pages/protect_yourself.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_html/flutter_html.dart';
 import 'package:who_app/api/content/schema/fact_content.dart';
 import 'package:who_app/components/dialogs.dart';
+import 'package:who_app/components/loading_indicator.dart';
 import 'package:who_app/components/page_scaffold/page_scaffold.dart';
 import 'package:who_app/components/rive_animation.dart';
 import 'package:who_app/constants.dart';
@@ -50,10 +51,14 @@ class _ProtectYourselfState extends State<ProtectYourself> {
   @override
   Widget build(BuildContext context) {
     return PageScaffold(
-        title: S.of(context).protectYourselfTitle,
-        announceRouteManually: true,
-        body: [SliverList(delegate: SliverChildListDelegate(_buildCards()))]);
+      title: S.of(context).protectYourselfTitle,
+      announceRouteManually: true,
+      body: [_factContent != null ? _buildBody() : LoadingIndicator()],
+    );
   }
+
+  SliverList _buildBody() =>
+      SliverList(delegate: SliverChildListDelegate(_buildCards()));
 
   List<Widget> _buildCards() {
     final TextStyle normalText = TextStyle(

--- a/client/flutter/lib/pages/protect_yourself.dart
+++ b/client/flutter/lib/pages/protect_yourself.dart
@@ -53,7 +53,9 @@ class _ProtectYourselfState extends State<ProtectYourself> {
     return PageScaffold(
       title: S.of(context).protectYourselfTitle,
       announceRouteManually: true,
-      body: [_factContent != null ? _buildBody() : LoadingIndicator()],
+      body: [
+        _factContent != null ? _buildBody() : LoadingIndicator(),
+      ],
     );
   }
 

--- a/client/flutter/lib/pages/question_index.dart
+++ b/client/flutter/lib/pages/question_index.dart
@@ -73,7 +73,7 @@ class _QuestionIndexPageState extends State<QuestionIndexPage> {
       body: [
         items.isNotEmpty
             ? SliverList(delegate: SliverChildListDelegate(items))
-            : LoadingIndicator()
+            : LoadingIndicator(),
       ],
       title: widget.title,
     );

--- a/client/flutter/lib/pages/question_index.dart
+++ b/client/flutter/lib/pages/question_index.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 import 'package:who_app/api/content/schema/question_content.dart';
 import 'package:who_app/components/dialogs.dart';
+import 'package:who_app/components/loading_indicator.dart';
 import 'package:who_app/components/page_scaffold/page_scaffold.dart';
 import 'package:who_app/constants.dart';
 import 'package:flutter/cupertino.dart';
@@ -71,14 +72,8 @@ class _QuestionIndexPageState extends State<QuestionIndexPage> {
       announceRouteManually: true,
       body: [
         items.isNotEmpty
-            ? SliverList(
-                delegate: SliverChildListDelegate(items),
-              )
-            : SliverToBoxAdapter(
-                child: Padding(
-                padding: const EdgeInsets.all(48.0),
-                child: CupertinoActivityIndicator(),
-              ))
+            ? SliverList(delegate: SliverChildListDelegate(items))
+            : LoadingIndicator()
       ],
       title: widget.title,
     );

--- a/client/flutter/lib/pages/travel_advice.dart
+++ b/client/flutter/lib/pages/travel_advice.dart
@@ -46,7 +46,9 @@ class _TravelAdviceState extends State<TravelAdvice> {
   Widget build(BuildContext context) {
     return PageScaffold(
         announceRouteManually: true,
-        body: [_adviceContent != null ? _buildBody() : LoadingIndicator()],
+        body: [
+          _adviceContent != null ? _buildBody() : LoadingIndicator(),
+        ],
         title: S.of(context).homePagePageButtonTravelAdvice);
   }
 

--- a/client/flutter/lib/pages/travel_advice.dart
+++ b/client/flutter/lib/pages/travel_advice.dart
@@ -1,6 +1,7 @@
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:who_app/api/content/schema/advice_content.dart';
 import 'package:who_app/components/dialogs.dart';
+import 'package:who_app/components/loading_indicator.dart';
 import 'package:who_app/components/page_scaffold/page_scaffold.dart';
 import 'package:who_app/constants.dart';
 import 'package:who_app/generated/l10n.dart';
@@ -45,13 +46,11 @@ class _TravelAdviceState extends State<TravelAdvice> {
   Widget build(BuildContext context) {
     return PageScaffold(
         announceRouteManually: true,
-        body: [
-          _adviceContent != null ? _buildBody(context) : _buildLoading(),
-        ],
+        body: [_adviceContent != null ? _buildBody() : LoadingIndicator()],
         title: S.of(context).homePagePageButtonTravelAdvice);
   }
 
-  SliverList _buildBody(BuildContext context) {
+  SliverList _buildBody() {
     return SliverList(
         delegate: SliverChildListDelegate([
       Container(
@@ -97,14 +96,6 @@ class _TravelAdviceState extends State<TravelAdvice> {
         height: 28,
       ),
     ]));
-  }
-
-  SliverToBoxAdapter _buildLoading() {
-    return SliverToBoxAdapter(
-        child: Padding(
-      padding: const EdgeInsets.all(48.0),
-      child: CupertinoActivityIndicator(),
-    ));
   }
 
   List<Widget> _getItems(BuildContext context) {


### PR DESCRIPTION
This PR adds a loading indicator to the protect yourself pages and refactors the widget so that it is used in the same way across pages.


<img width="578" alt="image" src="https://user-images.githubusercontent.com/852471/79890125-a5fef680-83c4-11ea-97ad-76b717bafe80.png">
