### PR TITLE
Partial fix headers #1130; plug in temp content

### DIFF
--- a/client/flutter/lib/components/page_scaffold/page_header.dart
+++ b/client/flutter/lib/components/page_scaffold/page_header.dart
@@ -6,11 +6,11 @@ import 'package:who_app/components/updated_app_bar.dart' as uab;
 
 class PageHeader extends StatelessWidget {
   final String title;
-  final String subtitle;
 
   final EdgeInsets padding;
   final bool showBackButton;
   final bool showLogo;
+  final Color dividerColor;
 
   /// True if [PageHeader] wouldn't be announced via the screen reader if it wasn't
   /// wrapped in a [Semantics] widget. E.g. when opening a page with
@@ -19,18 +19,18 @@ class PageHeader extends StatelessWidget {
 
   PageHeader({
     @required this.title,
-    this.subtitle = "",
     this.padding = EdgeInsets.zero,
-    this.showBackButton = true,
+    this.showBackButton = false,
     this.showLogo = false,
     this.announceRouteManually = false,
+    this.dividerColor = const Color(0xffC9CDD6),
   });
 
   @override
   Widget build(BuildContext context) {
     return uab.SliverAppBar(
       leading: Container(),
-      expandedHeight: 120,
+      expandedHeight: 88,
       backgroundColor: Colors.white,
       excludeHeaderSemantics: true,
       flexibleSpace: FlexibleSpaceBar(background: _buildHeader(context)),
@@ -57,16 +57,6 @@ class PageHeader extends StatelessWidget {
           children: <Widget>[
             //Todo: Decide what to do when title text overflow
             buildTitle(this.title),
-            SizedBox(height: 4),
-            AutoSizeText(this.subtitle,
-                maxLines: 1,
-                minFontSize: 8,
-                overflow: TextOverflow.ellipsis,
-                softWrap: false,
-                style: TextStyle(
-                    color: Color(0xff3C4245),
-                    fontSize: 16,
-                    fontWeight: FontWeight.w700)),
           ],
         ),
       ),
@@ -95,7 +85,7 @@ class PageHeader extends StatelessWidget {
                 height: 1,
                 child: Container(
                   height: 1,
-                  color: Color(0xffC9CDD6),
+                  color: dividerColor,
                   width: MediaQuery.of(context).size.width,
                 ))
           ],
@@ -118,7 +108,7 @@ class PageHeader extends StatelessWidget {
           style: TextStyle(
               color: textColor,
               fontWeight: FontWeight.w900,
-              fontSize: 24,
+              fontSize: 40,
               letterSpacing: -0.5)),
     );
   }

--- a/client/flutter/lib/components/page_scaffold/page_scaffold.dart
+++ b/client/flutter/lib/components/page_scaffold/page_scaffold.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 
 class PageScaffold extends StatelessWidget {
   final String title;
-  final String subtitle;
 
   final List<Widget> body;
 
@@ -11,15 +10,16 @@ class PageScaffold extends StatelessWidget {
   final bool showBackButton;
   final bool showLogoInHeader;
   final bool announceRouteManually;
+  final Color dividerColor;
 
   PageScaffold({
     @required this.body,
     @required this.title,
-    this.subtitle = "COVID-19",
     this.padding = EdgeInsets.zero,
-    this.showBackButton = true,
+    this.showBackButton = false,
     this.showLogoInHeader = false,
     this.announceRouteManually = false,
+    this.dividerColor = const Color(0xffC9CDD6),
   });
 
   @override
@@ -33,11 +33,11 @@ class PageScaffold extends StatelessWidget {
               CustomScrollView(slivers: [
                 PageHeader(
                   title: this.title,
-                  subtitle: this.subtitle,
                   padding: this.padding,
                   showBackButton: this.showBackButton,
                   showLogo: this.showLogoInHeader,
                   announceRouteManually: announceRouteManually,
+                  dividerColor: this.dividerColor,
                 ),
                 ...this.body,
                 SliverToBoxAdapter(

--- a/client/flutter/lib/pages/main_pages/app_tab_router.dart
+++ b/client/flutter/lib/pages/main_pages/app_tab_router.dart
@@ -1,12 +1,14 @@
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:who_app/api/content/schema/advice_content.dart';
+import 'package:who_app/api/content/schema/fact_content.dart';
 import 'package:who_app/constants.dart';
 import 'package:who_app/pages/latest_numbers.dart';
-import 'package:who_app/pages/main_pages/check_up_page.dart';
 import 'package:who_app/pages/main_pages/home_page.dart';
-import 'package:who_app/pages/main_pages/learn_page.dart';
+import 'package:who_app/pages/protect_yourself.dart';
 import 'package:who_app/pages/settings_page.dart';
+import 'package:who_app/pages/travel_advice.dart';
 
 class AppTabRouter extends StatelessWidget {
   final FirebaseAnalytics analytics;
@@ -27,9 +29,9 @@ class AppTabRouter extends StatelessWidget {
           case 1:
             return LatestNumbersPage();
           case 2:
-            return LearnPage();
+            return ProtectYourself(dataSource: FactContent.protectYourself);
           case 3:
-            return CheckUpPage();
+            return TravelAdvice(dataSource: AdviceContent.travelAdvice);
           case 4:
             return SettingsPage();
 

--- a/client/flutter/lib/pages/settings_page.dart
+++ b/client/flutter/lib/pages/settings_page.dart
@@ -105,7 +105,6 @@ class _SettingsPageState extends State<SettingsPage>
   @override
   Widget build(BuildContext context) {
     return PageScaffold(
-      showBackButton: false,
       body: [
         SliverList(
             delegate: SliverChildListDelegate(

--- a/client/flutter/lib/pages/travel_advice.dart
+++ b/client/flutter/lib/pages/travel_advice.dart
@@ -31,6 +31,9 @@ class _TravelAdviceState extends State<TravelAdvice> {
       return;
     }
     Locale locale = Localizations.localeOf(context);
+    print(context);
+    print(locale);
+    print(widget);
     try {
       _adviceContent = await widget.dataSource(locale);
       await Dialogs.showUpgradeDialogIfNeededFor(context, _adviceContent);
@@ -45,6 +48,7 @@ class _TravelAdviceState extends State<TravelAdvice> {
   @override
   Widget build(BuildContext context) {
     return PageScaffold(
+        dividerColor: Constants.emergencyRed,
         announceRouteManually: true,
         body: [
           _adviceContent != null ? _buildBody() : LoadingIndicator(),


### PR DESCRIPTION
Mocks use 36, 40, and 48 font, and they are not final.  I picked the one that works the best for now.  Also travel advice can now match the mock re: header color.\

Temp content makes the app feel functional again

![ImprovedHeader](https://user-images.githubusercontent.com/11729521/80324248-cb389e00-87e4-11ea-9231-c805142a3211.gif)

<img width="334" alt="Screen Shot 2020-04-26 at 5 40 18 PM" src="https://user-images.githubusercontent.com/11729521/80324285-04710e00-87e5-11ea-87b3-259fc6481497.png">
