### PR TITLE
switch to Cupertino

### DIFF
--- a/client/flutter/lib/pages/main_pages/learn_page.dart
+++ b/client/flutter/lib/pages/main_pages/learn_page.dart
@@ -6,7 +6,6 @@ import 'package:who_app/components/dialogs.dart';
 import 'package:who_app/components/loading_indicator.dart';
 import 'package:who_app/components/page_scaffold/page_header.dart';
 import 'package:who_app/components/page_scaffold/page_scaffold.dart';
-import 'package:flutter/material.dart';
 import 'package:who_app/components/themed_text.dart';
 import 'package:who_app/constants.dart';
 import 'package:who_app/pages/main_pages/routes.dart';
@@ -21,8 +20,8 @@ class LearnPage extends StatefulWidget {
 }
 
 class _LearnPageState extends State<LearnPage> {
-  final header =
-      TextStyle(color: Colors.black, fontSize: 24, fontWeight: FontWeight.w800);
+  final header = TextStyle(
+      color: CupertinoColors.black, fontSize: 24, fontWeight: FontWeight.w800);
   IndexContent _content;
 
   @override
@@ -128,16 +127,12 @@ class _MenuItem extends StatelessWidget {
         left: 24,
         right: 24,
       ),
-      child: Card(
-        margin: EdgeInsets.zero,
-        elevation: 0,
-        color: color,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.all(
-            Radius.circular(8),
-          ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.all(
+          Radius.circular(8),
         ),
-        child: FlatButton(
+        child: CupertinoButton(
+          color: color,
           padding: const EdgeInsets.all(24),
           onPressed: () {
             return Navigator.of(context, rootNavigator: true)


### PR DESCRIPTION
### Switch Learn Page button from Material `FlatButton` to Cupertino `CupertinoButton`


#### Screenshots
<details>
<summary>Screenshots</summary>
iOS:
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-04-29 at 23 30 36](https://user-images.githubusercontent.com/38309438/80679296-72ca0080-8a71-11ea-8e85-316cf7852e9a.png)
Android:
![Screenshot_1588230125](https://user-images.githubusercontent.com/38309438/80681591-d8b88700-8a75-11ea-906f-a2fae71c0371.png)

</details>

<!--
#### Did you add any dependencies?
List each added dependency and justifications (see the Guidelines)
* [`package_name`](package-url): justification for including the package
-->

<!--
#### How did you test the change?
* [ ] iOS Simulator
* [ ] Android Emulator
* [ ] iOS Device
* [ ] Android Device
* [ ] `curl` to a dev App Engine server
-->

<!-- FILL OUT THE CHECKLIST BELOW -->

---

#### Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).

- [ ] REQUIRED: Do you have an Issue **assigned to you** for this PR?
- [x] Provided detailed pull request description and a succinct title
- [x] Tested your changes, especially after any code review iterations.
- [x] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).
