### PR TITLE
[feat] Home index content bundle

### DIFF
--- a/client/flutter/assets/content_bundles/home_index.en.yaml
+++ b/client/flutter/assets/content_bundles/home_index.en.yaml
@@ -1,0 +1,28 @@
+schema_version: 1
+content_version: 1
+contents:
+  type: index
+  promo:
+    promo_type: protect_yourself
+    title: Protect Yourself
+    subtitle: See what your symptoms could mean and what you can do to move forward.
+    button_text: Learn more
+    href: /protect-yourself
+  items:
+    -
+      item_type: recent_numbers
+      title: Recent Numbers
+      button_text: 'See all ›'
+      href: /recent-numbers
+    -
+      item_type: protect_yourself
+      title: Protect Yourself
+      button_text: 'Learn more ›'
+      href: /protect-yourself
+    -
+      item_type: information_card
+      title: Get the Facts
+      subtitle: Spraying alcohol or chlorine all over your body does not kill the new coronavirus.
+      href: /get-the-facts
+      button_text: Learn more
+

--- a/client/flutter/lib/api/content/schema/index_content.dart
+++ b/client/flutter/lib/api/content/schema/index_content.dart
@@ -73,10 +73,8 @@ class IndexPromo {
     switch (this.promoType) {
       case 'check_your_symptoms':
         return IndexPromoType.CheckYourSymptoms;
-        break;
       case 'protect_yourself':
         return IndexPromoType.ProtectYourself;
-        break;
     }
     return IndexPromoType.DefaultType;
   }
@@ -108,13 +106,10 @@ class IndexItem {
     switch (this.itemType) {
       case 'recent_numbers':
         return IndexItemType.recent_numbers;
-        break;
       case 'protect_yourself':
         return IndexItemType.protect_yourself;
-        break;
       case 'information_card':
         return IndexItemType.information_card;
-        break;
     }
     return IndexItemType.unknown;
   }

--- a/client/flutter/lib/api/content/schema/index_content.dart
+++ b/client/flutter/lib/api/content/schema/index_content.dart
@@ -14,6 +14,11 @@ class IndexContent extends ContentBase {
   List<IndexItem> items;
   IndexPromo promo;
 
+  static Future<IndexContent> homeIndex(Locale locale) async {
+    var bundle = await ContentLoading().load(locale, "home_index");
+    return IndexContent(bundle);
+  }
+
   static Future<IndexContent> learnIndex(Locale locale) async {
     var bundle = await ContentLoading().load(locale, "learn_index");
     return IndexContent(bundle);
@@ -24,6 +29,7 @@ class IndexContent extends ContentBase {
       final yamlPromo = bundle.contentPromo;
       if (yamlPromo != null) {
         this.promo = IndexPromo(
+          promoType: yamlPromo['promo_type'],
           buttonText: yamlPromo['button_text'],
           title: yamlPromo['title'],
           subtitle: yamlPromo['subtitle'],
@@ -32,9 +38,11 @@ class IndexContent extends ContentBase {
       }
       this.items = bundle.contentItems
           .map((item) => IndexItem(
+                itemType: item['item_type'],
                 title: item['title'],
                 subtitle: item['subtitle'],
                 link: RouteLink.fromUri(item['href']),
+                buttonText: item['button_text'],
               ))
           .toList();
     } catch (err) {
@@ -44,7 +52,10 @@ class IndexContent extends ContentBase {
   }
 }
 
+enum IndexPromoType { CheckYourSymptoms, ProtectYourself, DefaultType }
+
 class IndexPromo {
+  final String promoType;
   final String title;
   final String subtitle;
   final RouteLink link;
@@ -55,17 +66,56 @@ class IndexPromo {
     @required this.subtitle,
     @required this.link,
     @required this.buttonText,
+    this.promoType,
   });
+
+  IndexPromoType get type {
+    switch (this.promoType) {
+      case 'check_your_symptoms':
+        return IndexPromoType.CheckYourSymptoms;
+        break;
+      case 'protect_yourself':
+        return IndexPromoType.ProtectYourself;
+        break;
+    }
+    return IndexPromoType.DefaultType;
+  }
+}
+
+enum IndexItemType {
+  recent_numbers,
+  protect_yourself,
+  information_card,
+  unknown
 }
 
 class IndexItem {
+  final String itemType;
   final String title;
   final String subtitle;
   final RouteLink link;
+  final String buttonText;
 
   IndexItem({
-    @required this.title,
-    @required this.subtitle,
-    @required this.link,
+    this.itemType,
+    this.title,
+    this.subtitle,
+    this.link,
+    this.buttonText,
   });
+
+  IndexItemType get type {
+    switch (this.itemType) {
+      case 'recent_numbers':
+        return IndexItemType.recent_numbers;
+        break;
+      case 'protect_yourself':
+        return IndexItemType.protect_yourself;
+        break;
+      case 'information_card':
+        return IndexItemType.information_card;
+        break;
+    }
+    return IndexItemType.unknown;
+  }
 }

--- a/client/flutter/lib/api/linking.dart
+++ b/client/flutter/lib/api/linking.dart
@@ -1,17 +1,21 @@
-import 'package:meta/meta.dart';
-
 class RouteLink {
-  String route;
-  Map<String, String> args;
+  Uri _url;
 
-  RouteLink({
-    @required this.route,
-    @required this.args,
-  });
+  String get route => _url.path;
+  Map<String, String> get args => _url.queryParameters ?? {};
+  bool get isExternal {
+    try {
+      return _url.origin != null;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  String get url => _url.toString();
+
+  RouteLink();
 
   RouteLink.fromUri(String uri) {
-    final url = Uri.parse(uri);
-    route = url.path;
-    args = url.queryParameters ?? {};
+    _url = Uri.parse(uri);
   }
 }

--- a/client/flutter/lib/api/linking.dart
+++ b/client/flutter/lib/api/linking.dart
@@ -1,21 +1,36 @@
+import 'package:flutter/cupertino.dart';
+import 'package:url_launcher/url_launcher.dart';
+
 class RouteLink {
   Uri _url;
+  String route;
+  Map<String, String> args;
 
-  String get route => _url.path;
-  Map<String, String> get args => _url.queryParameters ?? {};
   bool get isExternal {
     try {
-      return _url.origin != null;
+      return _url?.origin != null;
     } catch (error) {
       return false;
     }
   }
 
-  String get url => _url.toString();
+  String get url => _url?.toString();
 
-  RouteLink();
+  RouteLink({
+    @required this.route,
+    @required this.args,
+  });
+
+  Future open(BuildContext context) {
+    return this.isExternal
+        ? launch(this.url)
+        : Navigator.of(context, rootNavigator: true)
+            .pushNamed(this.route, arguments: this.args);
+  }
 
   RouteLink.fromUri(String uri) {
     _url = Uri.parse(uri);
+    route = _url.path;
+    args = _url.queryParameters ?? {};
   }
 }

--- a/client/flutter/lib/components/home_page_sections/home_page_header.dart
+++ b/client/flutter/lib/components/home_page_sections/home_page_header.dart
@@ -138,9 +138,7 @@ class HomePageHeader extends StatelessWidget {
                         style: TextStyle(color: Constants.primaryColor),
                       ),
                       onPressed: () {
-                        return Navigator.of(context, rootNavigator: true)
-                            .pushNamed(this.link.route,
-                                arguments: this.link.args);
+                        return this.link.open(context);
                       },
                     ),
                   ),

--- a/client/flutter/lib/components/home_page_sections/home_page_header.dart
+++ b/client/flutter/lib/components/home_page_sections/home_page_header.dart
@@ -1,42 +1,32 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:who_app/api/content/schema/index_content.dart';
+import 'package:who_app/api/linking.dart';
 import 'package:who_app/components/themed_text.dart';
 import 'package:who_app/constants.dart';
 import 'package:who_app/generated/l10n.dart';
 
 class HomePageHeader extends StatelessWidget {
-  final HeaderType headerType;
+  final IndexPromoType headerType;
+  final String title;
+  final String subtitle;
+  final String buttonText;
+  final RouteLink link;
 
-  const HomePageHeader(this.headerType);
-
-  String title(BuildContext context) {
-    switch (this.headerType) {
-      case HeaderType.CheckYourSymptoms:
-        return "Check your symptoms";
-      case HeaderType.ProtectYourself:
-        return "Protect Yourself";
-      default:
-        return "Check your symptoms";
-    }
-  }
-
-  String buttonText(BuildContext context) {
-    switch (this.headerType) {
-      case HeaderType.CheckYourSymptoms:
-        return "Check now";
-      case HeaderType.ProtectYourself:
-        return "Learn more";
-      default:
-        return "Check now";
-    }
-  }
+  const HomePageHeader({
+    @required this.headerType,
+    @required this.title,
+    @required this.subtitle,
+    @required this.buttonText,
+    @required this.link,
+  });
 
   String get svgAssetName {
     switch (this.headerType) {
-      // case HeaderType.CheckYourSymptoms:
+      // case IndexPromoType.CheckYourSymptoms:
       //   return "assets/svg/home_page_header/check_your_symptoms.svg";
-      // case HeaderType.ProtectYourself:
+      // case IndexPromoType.ProtectYourself:
       //   return "assets/svg/home_page_header/protect_yourself.svg";
       default:
         return null;
@@ -45,9 +35,9 @@ class HomePageHeader extends StatelessWidget {
 
   Color get backgroundColor {
     switch (this.headerType) {
-      case HeaderType.CheckYourSymptoms:
+      case IndexPromoType.CheckYourSymptoms:
         return Constants.primaryDarkColor;
-      case HeaderType.ProtectYourself:
+      case IndexPromoType.ProtectYourself:
         return Color(0xff4ACA8C);
       default:
         return Constants.primaryDarkColor;
@@ -108,7 +98,7 @@ class HomePageHeader extends StatelessWidget {
                 height: 32,
               ),
               ThemedText(
-                this.title(context),
+                this.title,
                 variant: TypographyVariant.title,
                 style: TextStyle(
                   color: CupertinoColors.white,
@@ -116,7 +106,7 @@ class HomePageHeader extends StatelessWidget {
                 textAlign: TextAlign.left,
               ),
               ThemedText(
-                "See what your symptoms could mean and what you can do to move forward.",
+                this.subtitle,
                 variant: TypographyVariant.body,
                 style: TextStyle(
                   color: CupertinoColors.white,
@@ -143,11 +133,15 @@ class HomePageHeader extends StatelessWidget {
                       ),
                       color: CupertinoColors.white,
                       child: ThemedText(
-                        this.buttonText(context),
+                        this.buttonText,
                         variant: TypographyVariant.button,
                         style: TextStyle(color: Constants.primaryColor),
                       ),
-                      onPressed: () {},
+                      onPressed: () {
+                        return Navigator.of(context, rootNavigator: true)
+                            .pushNamed(this.link.route,
+                                arguments: this.link.args);
+                      },
                     ),
                   ),
                 ],
@@ -182,9 +176,4 @@ class HeaderClipper extends CustomClipper<Path> {
   bool shouldReclip(CustomClipper<Path> path) {
     return true;
   }
-}
-
-enum HeaderType {
-  CheckYourSymptoms,
-  ProtectYourself,
 }

--- a/client/flutter/lib/components/home_page_sections/home_page_information_card.dart
+++ b/client/flutter/lib/components/home_page_sections/home_page_information_card.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/cupertino.dart';
-import 'package:url_launcher/url_launcher.dart';
 import 'package:who_app/api/linking.dart';
 import 'package:who_app/components/themed_text.dart';
 import 'package:who_app/constants.dart';
@@ -65,10 +64,7 @@ class HomePageInformationCard extends StatelessWidget {
                       ),
                     ),
                     onPressed: () {
-                      return this.link.isExternal
-                          ? launch(this.link.url)
-                          : Navigator.of(context, rootNavigator: true)
-                              .pushNamed(this.link.route, arguments: link.args);
+                      return this.link.open(context);
                     },
                   )
                 ],

--- a/client/flutter/lib/components/home_page_sections/home_page_information_card.dart
+++ b/client/flutter/lib/components/home_page_sections/home_page_information_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/cupertino.dart';
+import 'package:url_launcher/url_launcher.dart';
 import 'package:who_app/api/linking.dart';
 import 'package:who_app/components/themed_text.dart';
 import 'package:who_app/constants.dart';
@@ -64,8 +65,10 @@ class HomePageInformationCard extends StatelessWidget {
                       ),
                     ),
                     onPressed: () {
-                      return Navigator.of(context, rootNavigator: true)
-                          .pushNamed(this.link.route, arguments: link.args);
+                      return this.link.isExternal
+                          ? launch(this.link.url)
+                          : Navigator.of(context, rootNavigator: true)
+                              .pushNamed(this.link.route, arguments: link.args);
                     },
                   )
                 ],

--- a/client/flutter/lib/components/home_page_sections/home_page_protect_yourself.dart
+++ b/client/flutter/lib/components/home_page_sections/home_page_protect_yourself.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/cupertino.dart';
 import 'package:who_app/api/content/schema/fact_content.dart';
-import 'package:who_app/components/loading_indicator.dart';
 import 'package:who_app/components/protect_yourself_card.dart';
 import 'package:who_app/constants.dart';
 
@@ -51,7 +50,12 @@ class _HomePageProtectYourself extends State<HomePageProtectYourself> {
   @override
   Widget build(BuildContext context) {
     if (_factContent == null) {
-      return LoadingIndicator();
+      return Padding(
+        padding: EdgeInsets.all(64.0),
+        child: Center(
+          child: CupertinoActivityIndicator(),
+        ),
+      );
     }
 
     // TODO: better handle schema version changes

--- a/client/flutter/lib/pages/main_pages/app_tab_router.dart
+++ b/client/flutter/lib/pages/main_pages/app_tab_router.dart
@@ -20,7 +20,9 @@ class AppTabRouter extends StatelessWidget {
       tabBuilder: (BuildContext context, int index) {
         switch (index) {
           case 0:
-            return wrapTabView((context) => HomePage());
+            return wrapTabView((context) => HomePage(
+                  dataSource: IndexContent.homeIndex,
+                ));
           case 1:
             return wrapTabView((context) => RecentNumbersPage());
           case 2:

--- a/client/flutter/lib/pages/main_pages/home_page.dart
+++ b/client/flutter/lib/pages/main_pages/home_page.dart
@@ -208,8 +208,7 @@ class _HomePageSectionHeader extends StatelessWidget {
               ),
             ),
             onPressed: () {
-              return Navigator.of(context, rootNavigator: true)
-                  .pushNamed(this.link.route, arguments: this.link.args);
+              return this.link.open(context);
             },
           ),
         ],

--- a/client/flutter/lib/pages/main_pages/home_page.dart
+++ b/client/flutter/lib/pages/main_pages/home_page.dart
@@ -90,16 +90,12 @@ class _HomePageState extends State<HomePage> {
     switch (item.type) {
       case IndexItemType.information_card:
         return _buildInfoCard(item);
-        break;
       case IndexItemType.protect_yourself:
         return _buildProtectYourself(item);
-        break;
       case IndexItemType.recent_numbers:
         return _buildRecentNumbers(item);
-        break;
       case IndexItemType.unknown:
         return null;
-        break;
     }
     return null;
   }

--- a/client/flutter/lib/pages/main_pages/home_page.dart
+++ b/client/flutter/lib/pages/main_pages/home_page.dart
@@ -1,62 +1,151 @@
 import 'package:flutter/cupertino.dart';
 import 'package:who_app/api/content/schema/fact_content.dart';
+import 'package:who_app/api/content/schema/index_content.dart';
 import 'package:who_app/api/linking.dart';
+import 'package:who_app/components/dialogs.dart';
 import 'package:who_app/components/home_page_sections/home_page_donate.dart';
 import 'package:who_app/components/home_page_sections/home_page_header.dart';
 import 'package:who_app/components/home_page_sections/home_page_information_card.dart';
 import 'package:who_app/components/home_page_sections/home_page_protect_yourself.dart';
 import 'package:who_app/components/home_page_sections/home_page_recent_numbers.dart';
+import 'package:who_app/components/loading_indicator.dart';
 import 'package:who_app/components/page_scaffold/page_scaffold.dart';
 import 'package:who_app/components/themed_text.dart';
 import 'package:who_app/constants.dart';
 
-class HomePage extends StatelessWidget {
+class HomePage extends StatefulWidget {
+  final IndexDataSource dataSource;
+
+  const HomePage({@required this.dataSource, Key key}) : super(key: key);
+
+  @override
+  State<StatefulWidget> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  IndexContent _content;
+
+  @override
+  void didChangeDependencies() async {
+    super.didChangeDependencies();
+    await _loadIndex();
+  }
+
+  Future _loadIndex() async {
+    if (_content != null) {
+      return;
+    }
+    Locale locale = Localizations.localeOf(context);
+    try {
+      _content = await widget.dataSource(locale);
+      await Dialogs.showUpgradeDialogIfNeededFor(context, _content);
+    } catch (err) {
+      print("Error loading home index data: $err");
+    }
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return PageScaffold(
       showHeader: false,
       color: Constants.greyBackgroundColor,
-      body: [
-        _HomePageSection(
-          content: HomePageHeader(HeaderType.ProtectYourself),
+      beforeHeader: _buildPromo(),
+      body: _buildBody(),
+    );
+  }
+
+  List<Widget> _buildPromo() {
+    List<Widget> preHeader = [];
+    IndexPromo p = _content?.promo;
+    if (p != null) {
+      preHeader.add(_HomePageSection(
+        content: HomePageHeader(
+          headerType: p.type,
+          title: p.title,
+          subtitle: p.subtitle,
+          buttonText: p.buttonText,
+          link: p.link,
         ),
-        _HomePageSection(
-          padding: EdgeInsets.only(top: 56.0),
-          header: _HomePageSectionHeader(
-            // TODO: localize
-            title: 'Recent Numbers',
-            linkText: 'See all ›',
-            link: RouteLink.fromUri('/recent-numbers'),
-          ),
-          content: HomePageRecentNumbers(),
-        ),
-        _HomePageSection(
-          padding: EdgeInsets.only(top: 44.0),
-          header: _HomePageSectionHeader(
-            // TODO: Localize
-            title: 'Protect Yourself',
-            linkText: 'Learn more ›',
-            link: RouteLink.fromUri('/protect-yourself'),
-          ),
-          content: HomePageProtectYourself(
-            dataSource: FactContent.protectYourself,
-          ),
-        ),
-        _HomePageSection(
-          padding: EdgeInsets.only(top: 72.0),
-          content: HomePageInformationCard(
-            title: 'Get the Facts',
-            subtitle:
-                'Spraying alcohol or chlorine all over your body does not kill the new coronavirus.',
-            buttonText: 'Learn more',
-            link: RouteLink.fromUri('/get-the-facts'),
-          ),
-        ),
-        _HomePageSection(
-          padding: EdgeInsets.only(top: 64.0),
-          content: HomePageDonate(),
-        ),
-      ],
+      ));
+    }
+    return preHeader;
+  }
+
+  List<Widget> _buildBody() {
+    List<IndexItem> items = _content?.items;
+    if (items == null) {
+      return [LoadingIndicator()];
+    }
+    List<Widget> bundleWidgets = items.map((item) => _buildItem(item)).toList();
+    return [
+      ...bundleWidgets,
+      _buildDonate(),
+    ];
+  }
+
+  Widget _buildItem(IndexItem item) {
+    switch (item.type) {
+      case IndexItemType.information_card:
+        return _buildInfoCard(item);
+        break;
+      case IndexItemType.protect_yourself:
+        return _buildProtectYourself(item);
+        break;
+      case IndexItemType.recent_numbers:
+        return _buildRecentNumbers(item);
+        break;
+      case IndexItemType.unknown:
+        return null;
+        break;
+    }
+    return null;
+  }
+
+  Widget _buildInfoCard(IndexItem item) {
+    return _HomePageSection(
+      padding: EdgeInsets.only(top: 72.0),
+      content: HomePageInformationCard(
+        title: item.title,
+        subtitle: item.subtitle,
+        buttonText: item.buttonText,
+        link: item.link,
+      ),
+    );
+  }
+
+  Widget _buildProtectYourself(IndexItem item) {
+    return _HomePageSection(
+      padding: EdgeInsets.only(top: 44.0),
+      header: _HomePageSectionHeader(
+        title: item.title,
+        linkText: item.buttonText,
+        link: item.link,
+      ),
+      content: HomePageProtectYourself(
+        dataSource: FactContent.protectYourself,
+      ),
+    );
+  }
+
+  Widget _buildRecentNumbers(IndexItem item) {
+    return _HomePageSection(
+      padding: EdgeInsets.only(top: 56.0),
+      header: _HomePageSectionHeader(
+        title: item.title,
+        linkText: item.buttonText,
+        link: item.link,
+      ),
+      content: HomePageRecentNumbers(),
+    );
+  }
+
+  Widget _buildDonate() {
+    return _HomePageSection(
+      padding: EdgeInsets.only(top: 64.0),
+      content: HomePageDonate(),
     );
   }
 }


### PR DESCRIPTION
Drives home page content from an index content bundle. Allows the server to specify which widgets are on the home page, and in what order. Currently supported index item types are: `recent_numbers`, `protect_yourself`, and `information_card`. Information cards support linking to external URLs. The home header / promo content can also be specified in the content bundle.

One thing to note is that because `IndexItem` objects now support essentially empty content with just a `itemType` specified, we lose the safety of requiring certain fields to be set (see [diff](https://github.com/WorldHealthOrganization/app/pull/1169/files#diff-c95da6beb14f1aeb66ae726d3a2b8a8aR100-R102)).

Open TODOs that I might address in this PR:
* [x] Fix LoadingIndicator error in HomePageProtectYourself before content loads
* [x] Allow hrefs to point to external URLs that would open in a browser
* [ ] ~Allow specifying SVGs in content bundle~ _(will wait on updated designs)_

Closes #1165 
Closes #1174 
Closes #1175 

#### How did you test the change?
* [x] iOS Simulator

<!-- FILL OUT THE CHECKLIST BELOW -->

---

#### Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).

- [x] REQUIRED: Do you have an Issue **assigned to you** for this PR?
- [x] Provided detailed pull request description and a succinct title
- [x] Tested your changes, especially after any code review iterations.
- [x] ~Included any relevant screenshots of UI updates.~
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).
