### PR TITLE
Bug Fix: Clippers should not re-clip

### DIFF
--- a/client/flutter/lib/components/home_page_sections/home_page_donate.dart
+++ b/client/flutter/lib/components/home_page_sections/home_page_donate.dart
@@ -86,6 +86,6 @@ class _BackgroundClipper extends CustomClipper<Path> {
 
   @override
   bool shouldReclip(CustomClipper<Path> path) {
-    return true;
+    return false;
   }
 }

--- a/client/flutter/lib/components/home_page_sections/home_page_header.dart
+++ b/client/flutter/lib/components/home_page_sections/home_page_header.dart
@@ -180,7 +180,7 @@ class HeaderClipper extends CustomClipper<Path> {
 
   @override
   bool shouldReclip(CustomClipper<Path> path) {
-    return true;
+    return false;
   }
 }
 


### PR DESCRIPTION
### Homepage Clipper quick fix

The headers should never rebuild as their clippers never change

#### How did you test the change?
* [x] iOS Simulator
* [x] Android Emulator
* [ ] iOS Device
* [ ] Android Device
* [ ] `curl` to a dev App Engine server


#### Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).

- [x] REQUIRED: Do you have an Issue **assigned to you** for this PR?
- [x] Provided detailed pull request description and a succinct title
- [x] Tested your changes, especially after any code review iterations.
- [x] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).
