### PR TITLE
refactor(case-stats): Daily case stats come from WHO ARCGIS endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,4 +102,3 @@ buck-out/
 .classpath
 .project
 .settings
-.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,10 @@ buck-out/
 
 # Bundle artifact
 *.jsbundle
+
+# Visual Studio
+
+.classpath
+.project
+.settings
+.vscode

--- a/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
+++ b/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
@@ -17,7 +17,7 @@ import okhttp3.Request;
 import okhttp3.Response;
 
 public class RefreshCaseStatsServlet extends HttpServlet {
-  private static final String WHO_CASE_STATS_URL = "https://dashboards-dev.sprinklr.com/data/9043/global-covid19-who-gis.json";
+  private static final String WHO_CASE_STATS_URL = "https://services.arcgis.com/5T5nSi527N4F7luB/arcgis/rest/services/COVID19_hist_cases_adm0_v5_view/FeatureServer/0/query?where=1%3D1&objectIds=&time=&geometry=&geometryType=esriGeometryEnvelope&inSR=&spatialRel=esriSpatialRelIntersects&resultType=none&distance=0.0&units=esriSRUnit_Meter&returnGeodetic=false&outFields=ISO_2_CODE%2Cdate_epicrv%2CNewCase%2CCumCase%2CNewDeath%2CCumDeath%2C+ADM0_NAME&returnGeometry=true&featureEncoding=esriDefault&multipatchOption=xyFootprint&maxAllowableOffset=&geometryPrecision=&outSR=&datumTransformation=&applyVCSProjection=false&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnExtentOnly=false&returnQueryGeometry=false&returnDistinctValues=false&cacheHint=false&orderByFields=&groupByFieldsForStatistics=&outStatistics=&having=&resultOffset=&resultRecordCount=&returnZ=false&returnM=false&returnExceededLimitFeatures=true&quantizationParameters=&sqlFormat=none&f=pjson&token=";
 
   private static final OkHttpClient HTTP_CLIENT = new OkHttpClient();
 
@@ -41,18 +41,18 @@ public class RefreshCaseStatsServlet extends HttpServlet {
 
     String jsonString = getDashboardContents();
     JsonObject root = new JsonParser().parse(jsonString).getAsJsonObject();
-    JsonArray rows = root.getAsJsonArray("rows");
+    JsonArray rows = root.getAsJsonArray("features");
     long globalTotalCases = 0L, globalTotalDeaths = 0L;
     Map<Long, StoredCaseStats.StoredStatSnapshot> globalSnapshots = new HashMap<>();
     // Given that each row has heterogeneous elements, not sure there is much benefit
     // to using gson with reflection here.
-    for (JsonElement country : rows) {
-      JsonArray row = country.getAsJsonArray();
-      long timestamp = row.get(0).getAsLong();
-      long dailyDeaths = row.get(3).getAsLong();
-      long totalDeaths = row.get(4).getAsLong();
-      long dailyCases = row.get(5).getAsLong();
-      long totalCases = row.get(6).getAsLong();
+    for (JsonElement feature : rows) {
+      JsonObject attributes = feature.getAsJsonObject();
+      long timestamp = attributes.get("date_epicrv").getAsLong();
+      long dailyDeaths = attributes.get("NewDeath").getAsLong();
+      long totalDeaths = attributes.get("CumDeath").getAsLong();
+      long dailyCases = attributes.get("NewCase").getAsLong();
+      long totalCases = attributes.get("CumCase").getAsLong();
       globalTotalCases += dailyCases;
       globalTotalDeaths += dailyDeaths;
 

--- a/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
+++ b/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
@@ -32,6 +32,7 @@ public class RefreshCaseStatsServlet extends HttpServlet {
 
   @Override protected void doGet(HttpServletRequest request, HttpServletResponse response)
           throws IOException {
+
     // App Engine strips all external X-* request headers, so we can trust this is set by App Engine.
     // https://cloud.google.com/appengine/docs/flexible/java/scheduling-jobs-with-cron-yaml#validating_cron_requests
     if (Environment.isProduction() && !"true".equals(request.getHeader("X-Appengine-Cron"))) {
@@ -40,23 +41,43 @@ public class RefreshCaseStatsServlet extends HttpServlet {
     }
 
     String jsonString = getDashboardContents();
+
     JsonObject root = new JsonParser().parse(jsonString).getAsJsonObject();
+
     JsonArray rows = root.getAsJsonArray("features");
+
     long globalTotalCases = 0L, globalTotalDeaths = 0L;
+    long lastUpdated = 0L;
+
     Map<Long, StoredCaseStats.StoredStatSnapshot> globalSnapshots = new HashMap<>();
     // Given that each row has heterogeneous elements, not sure there is much benefit
     // to using gson with reflection here.
     for (JsonElement feature : rows) {
-      JsonObject attributes = feature.getAsJsonObject();
+
+      JsonObject featureAsJsonObject = feature.getAsJsonObject();
+      JsonElement attributesElement = featureAsJsonObject.get("attributes");
+
+      JsonObject attributes = attributesElement.getAsJsonObject();
+
       long timestamp = attributes.get("date_epicrv").getAsLong();
+
+      if (timestamp>lastUpdated){
+        lastUpdated = timestamp;
+      }
+
       long dailyDeaths = attributes.get("NewDeath").getAsLong();
+
       long totalDeaths = attributes.get("CumDeath").getAsLong();
+
       long dailyCases = attributes.get("NewCase").getAsLong();
+
       long totalCases = attributes.get("CumCase").getAsLong();
+
       globalTotalCases += dailyCases;
       globalTotalDeaths += dailyDeaths;
 
       StoredCaseStats.StoredStatSnapshot snapshot = globalSnapshots.get(timestamp);
+
       if (snapshot == null) {
         snapshot = new StoredCaseStats.StoredStatSnapshot();
         snapshot.epochMsec = timestamp;
@@ -77,7 +98,7 @@ public class RefreshCaseStatsServlet extends HttpServlet {
         .jurisdiction("")
         .cases(globalTotalCases)
         .deaths(globalTotalDeaths)
-        .lastUpdated(root.getAsJsonPrimitive("createdTime").getAsLong())
+        .lastUpdated(lastUpdated)
         .recoveries(-1L)
         .timeseries(
             globalSnapshots.entrySet().stream()


### PR DESCRIPTION
Switch daily case stats from WHO's Sprinklr dashboard pipeline to WHO's ARCGIS pipeline.

Closes #1093 

#### Screenshots
N/A

#### Did you add any dependencies?
NO

#### How did you test the change?
* [ ] iOS Simulator
* [ ] Android Emulator
* [ ] iOS Device
* [ ] Android Device
* [x] `curl` to a dev App Engine server

From 'app/server' directory (2 terminals)

Terminal 1

git checkout master;
gradle clean && gradle build;
./bin/run-dev-server.sh;

Terminal 2

TMP_OUTPUT_DIR=~/Desktop/tmp/who-output/master;
mkdir -p $TMP_OUTPUT_DIR;

curl -XPOST http://localhost:8080/WhoService/getCaseStats -d '' -H "Content-Type: application/json" -H "Who-Client-ID:a67eda24-90c3-11ea-bb37-0242ac130002" -H "Who-Platform: WEB" | jq '.' > $TMP_OUTPUT_DIR/output-after-clean-build-getstats-before-cron.json

curl -i -H 'X-Appengine-Cron: true' -X GET http://localhost:8080/internal/cron/refreshCaseStats > $TMP_OUTPUT_DIR/output-internal-cron.txt;

curl -XPOST http://localhost:8080/WhoService/getCaseStats -d '' -H "Content-Type: application/json" -H "Who-Client-ID:a67eda24-90c3-11ea-bb37-0242ac130002" -H "Who-Platform: WEB" | jq '.' > $TMP_OUTPUT_DIR/output-after-clean-build-getstats-after-cron.json;

Terminal 1

(stop other process)

git checkout WHO_1093_arcgis_endpoint;
gradle clean && gradle build;
./bin/run-dev-server.sh;

Terminal 2

TMP_OUTPUT_DIR=~/Desktop/tmp/who-output/branch;
mkdir -p $TMP_OUTPUT_DIR;

curl -XPOST http://localhost:8080/WhoService/getCaseStats -d '' -H "Content-Type: application/json" -H "Who-Client-ID:a67eda24-90c3-11ea-bb37-0242ac130002" -H "Who-Platform: WEB" | jq '.' > $TMP_OUTPUT_DIR/output-after-clean-build-getstats-before-cron.json

curl -i -H 'X-Appengine-Cron: true' -X GET http://localhost:8080/internal/cron/refreshCaseStats > $TMP_OUTPUT_DIR/output-internal-cron.txt;

curl -XPOST http://localhost:8080/WhoService/getCaseStats -d '' -H "Content-Type: application/json" -H "Who-Client-ID:a67eda24-90c3-11ea-bb37-0242ac130002" -H "Who-Platform: WEB" | jq '.' > $TMP_OUTPUT_DIR/output-after-clean-build-getstats-after-cron.json;


diff -r ~/Desktop/tmp/who-output/master ~/Desktop/tmp/who-output/branch

Only meaningful change was this: not sure how it was getting calculated last time. its not returned in the updated response. it was in the original response.  Perhaps its configurable?

```
<     "lastUpdated": 1588965569998,
---
>     "lastUpdated": 1588896000000,
```

---

#### Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).

- [x] REQUIRED: Do you have an Issue **assigned to you** for this PR?
- [x] Provided detailed pull request description and a succinct title
- [x] Tested your changes, especially after any code review iterations.
- [x] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).