### PR TITLE
fix: prevent premature home page initialisation  

### DIFF
--- a/client/flutter/lib/main.dart
+++ b/client/flutter/lib/main.dart
@@ -120,6 +120,9 @@ class _MyAppState extends State<MyApp> {
         // FIXME Issue #1012 - disabled supported languages for P0
         //supportedLocales: S.delegate.supportedLocales,
         initialRoute: widget.showOnboarding ? '/onboarding' : '/home',
+
+        /// allows routing to work without a [Navigator.defaultRouteName] route
+        builder: (context, child) => child,
         navigatorObservers: <NavigatorObserver>[observer],
         theme: CupertinoThemeData(
             brightness: Brightness.light,

--- a/client/flutter/lib/main.dart
+++ b/client/flutter/lib/main.dart
@@ -119,7 +119,7 @@ class _MyAppState extends State<MyApp> {
         routes: widget.routes,
         // FIXME Issue #1012 - disabled supported languages for P0
         //supportedLocales: S.delegate.supportedLocales,
-        initialRoute: widget.showOnboarding ? '/onboarding' : '/',
+        initialRoute: widget.showOnboarding ? 'onboarding' : '/',
         navigatorObservers: <NavigatorObserver>[observer],
         theme: CupertinoThemeData(
             brightness: Brightness.light,

--- a/client/flutter/lib/main.dart
+++ b/client/flutter/lib/main.dart
@@ -119,7 +119,7 @@ class _MyAppState extends State<MyApp> {
         routes: widget.routes,
         // FIXME Issue #1012 - disabled supported languages for P0
         //supportedLocales: S.delegate.supportedLocales,
-        initialRoute: widget.showOnboarding ? 'onboarding' : '/',
+        initialRoute: widget.showOnboarding ? '/onboarding' : '/home',
         navigatorObservers: <NavigatorObserver>[observer],
         theme: CupertinoThemeData(
             brightness: Brightness.light,

--- a/client/flutter/lib/pages/main_pages/routes.dart
+++ b/client/flutter/lib/pages/main_pages/routes.dart
@@ -19,7 +19,7 @@ class Routes {
     '/home': (context) =>
         AppTabRouter(AppTabRouter.defaultTabs, AppTabRouter.defaultNavItems),
     '/about': (context) => AboutPage(),
-    'onboarding': (context) => OnboardingPage(),
+    '/onboarding': (context) => OnboardingPage(),
     '/travel-advice': (context) => TravelAdvice(
           dataSource: AdviceContent.travelAdvice,
         ),

--- a/client/flutter/lib/pages/main_pages/routes.dart
+++ b/client/flutter/lib/pages/main_pages/routes.dart
@@ -16,7 +16,7 @@ import 'package:who_app/pages/travel_advice.dart';
 
 class Routes {
   static final Map<String, WidgetBuilder> map = {
-    '/': (context) =>
+    '/home': (context) =>
         AppTabRouter(AppTabRouter.defaultTabs, AppTabRouter.defaultNavItems),
     '/about': (context) => AboutPage(),
     'onboarding': (context) => OnboardingPage(),

--- a/client/flutter/lib/pages/main_pages/routes.dart
+++ b/client/flutter/lib/pages/main_pages/routes.dart
@@ -19,7 +19,7 @@ class Routes {
     '/': (context) =>
         AppTabRouter(AppTabRouter.defaultTabs, AppTabRouter.defaultNavItems),
     '/about': (context) => AboutPage(),
-    '/onboarding': (context) => OnboardingPage(),
+    'onboarding': (context) => OnboardingPage(),
     '/travel-advice': (context) => TravelAdvice(
           dataSource: AdviceContent.travelAdvice,
         ),

--- a/client/flutter/lib/pages/onboarding/onboarding_page.dart
+++ b/client/flutter/lib/pages/onboarding/onboarding_page.dart
@@ -70,7 +70,7 @@ class _OnboardingPageState extends State<OnboardingPage> {
     await UserPreferences().setOnboardingCompleted(true);
     await UserPreferences().setAnalyticsEnabled(true);
     await Navigator.of(context, rootNavigator: true).pushReplacementNamed(
-      '/',
+      '/home',
     );
   }
 }


### PR DESCRIPTION
<!-- Uncomment sections below as relevant -->

<!-- Title should be a short phrase, e.g. "Add survey functionality". Detailed description should include any design decisions you want reviewers to take note of -->


Add the Issue number(s) assigned to you that this PR fully resolves, if any
Closes https://github.com/WorldHealthOrganization/app/issues/1205

The router was pushing two routes, `/` and `onboarding`. You can actually start on the onboarding page, hit the back button, and find yourself on the home page as `/` is the name of the home page route.

I renamed the `/` route to `/home` which fixes the issue, by not having a `/` route it's unlikely that this issue will pop up again but Flutter requires either `builder`, `home`, `onGenerateRoute` or `onUnknownRoute` to be specified as a result otherwise it apparently has no fallback when routing fails.

On a side note, it'd be nice if we define route names as static strings inside each page e.g.
```
class OnboardingPage extends StatefulWidget {
    static const String routeName = 'onboarding';
...
```

### Widget tree before:
![image](https://user-images.githubusercontent.com/33752528/81458540-cf749c00-9192-11ea-820d-9196f5b35f80.png)
### Widget tree after:
![image](https://user-images.githubusercontent.com/33752528/81458548-dd2a2180-9192-11ea-8648-7aead708e6f8.png)

### HTTP requests before:
![image](https://user-images.githubusercontent.com/33752528/81458562-e915e380-9192-11ea-9204-2a335ea3d1d4.png)

### HTTP requests after:
![image](https://user-images.githubusercontent.com/33752528/81458572-f206b500-9192-11ea-9f43-a1c93e6159bd.png)





<!--
#### Screenshots
<details>
<summary>Screenshots</summary>
Add any relevant before/after screenshots here
</details>
-->

<!--
#### Did you add any dependencies?
List each added dependency and justifications (see the Guidelines)
* [`package_name`](package-url): justification for including the package
-->

<!--
#### How did you test the change?
* [ ] iOS Simulator
* [ ] Android Emulator
* [ ] iOS Device
* [x] Android Device
* [ ] `curl` to a dev App Engine server
-->

<!-- FILL OUT THE CHECKLIST BELOW -->

---

#### Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).

- [x] REQUIRED: Do you have an Issue **assigned to you** for this PR?
- [x] Provided detailed pull request description and a succinct title
- [x] Tested your changes, especially after any code review iterations.
- [x] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).
