### PR TITLE
refactor: use MenuListTile in AboutPage

### DIFF
--- a/client/flutter/lib/components/menu_list_tile.dart
+++ b/client/flutter/lib/components/menu_list_tile.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:who_app/components/themed_text.dart';
+
+class MenuListTile extends StatelessWidget {
+  const MenuListTile({
+    Key key,
+    @required this.title,
+    @required this.onTap,
+  }) : super(key: key);
+
+  final String title;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.white,
+      child: ListTile(
+        contentPadding: EdgeInsets.symmetric(horizontal: 24, vertical: 8),
+        title: ThemedText(title, variant: TypographyVariant.button),
+        trailing: Icon(Icons.arrow_forward_ios, color: Color(0xFFC9CDD6)),
+        onTap: onTap,
+      ),
+    );
+  }
+}

--- a/client/flutter/lib/pages/about_page.dart
+++ b/client/flutter/lib/pages/about_page.dart
@@ -1,10 +1,10 @@
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
+import 'package:who_app/components/menu_list_tile.dart';
 import 'package:who_app/components/page_scaffold/page_scaffold.dart';
 import 'package:who_app/components/themed_text.dart';
 import 'package:who_app/generated/l10n.dart';
 import 'package:flutter/cupertino.dart';
-import 'package:flutter_html/rich_text_parser.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:who_app/main.dart';
 import 'package:who_app/pages/license_page.dart' as who;
@@ -23,61 +23,50 @@ class AboutPage extends StatelessWidget {
         .of(context)
         .commonWorldHealthOrganizationCoronavirusCopyright(DateTime.now().year);
 
+    void _openTermsOfService(BuildContext context) {
+      final String url = S.of(context).aboutPageTermsOfServiceLinkUrl;
+      launch(url);
+      FirebaseAnalytics().logEvent(name: 'TermsOfService');
+    }
+
+    void _openPrivacyPolicy(BuildContext context) {
+      final String url = S.of(context).legalLandingPagePrivacyPolicyLinkUrl;
+      launch(url);
+      FirebaseAnalytics().logEvent(name: 'PrivacyPolicy');
+    }
+
+    void _openLicenses(BuildContext context) {
+      Navigator.push(
+        context,
+        MaterialPageRoute(builder: (BuildContext context) => who.LicensePage()),
+      );
+      FirebaseAnalytics().logEvent(name: 'ViewLicenses');
+    }
+
+    // TODO add divider theme to ThemeData once we've switched to a MaterialApp
+    Widget _divider() =>
+        Divider(height: 1, thickness: 1, color: Color(0xFFC9CDD6));
+
     return PageScaffold(
       body: [
         SliverList(
           delegate: SliverChildListDelegate.fixed(
             [
-              Container(
-                color: CupertinoColors.white,
-                padding: EdgeInsets.symmetric(horizontal: 25, vertical: 10),
-                child: Text.rich(
-                  TextSpan(
-                    style: TextStyle(color: CupertinoColors.black),
-                    children: [
-                      LinkTextSpan(
-                          text: S.of(context).aboutPageTermsOfServiceLinkText,
-                          style: TextStyle(
-                              decoration: TextDecoration.underline,
-                              color: CupertinoColors.activeBlue),
-                          url: S.of(context).aboutPageTermsOfServiceLinkUrl,
-                          onLinkTap: (v) {
-                            FirebaseAnalytics()
-                                .logEvent(name: 'TermsOfService');
-                            return launch(v);
-                          }),
-                      TextSpan(text: "  —  "),
-                      LinkTextSpan(
-                          text: S.of(context).aboutPagePrivacyPolicyLinkText,
-                          style: TextStyle(
-                              decoration: TextDecoration.underline,
-                              color: CupertinoColors.activeBlue),
-                          url: S
-                              .of(context)
-                              .legalLandingPagePrivacyPolicyLinkUrl,
-                          onLinkTap: (v) {
-                            FirebaseAnalytics().logEvent(name: 'PrivacyPolicy');
-                            return launch(v);
-                          }),
-                      TextSpan(text: "  —  "),
-                      LinkTextSpan(
-                          text: S.of(context).aboutPageViewLicensesLinkText,
-                          style: TextStyle(
-                            decoration: TextDecoration.underline,
-                            color: CupertinoColors.activeBlue,
-                          ),
-                          onLinkTap: (v) {
-                            FirebaseAnalytics().logEvent(name: 'ViewLicenses');
-                            return Navigator.of(context)
-                                .push(CupertinoPageRoute(
-                              builder: (c) => who.LicensePage(),
-                            ));
-                          }),
-                    ],
-                  ),
-                  textAlign: TextAlign.center,
-                ),
+              MenuListTile(
+                title: S.of(context).aboutPageTermsOfServiceLinkText,
+                onTap: () => _openTermsOfService(context),
               ),
+              _divider(),
+              MenuListTile(
+                title: S.of(context).aboutPagePrivacyPolicyLinkText,
+                onTap: () => _openPrivacyPolicy(context),
+              ),
+              _divider(),
+              MenuListTile(
+                title: S.of(context).aboutPageViewLicensesLinkText,
+                onTap: () => _openLicenses(context),
+              ),
+              _divider(),
               Container(
                 color: CupertinoColors.white,
                 padding: EdgeInsets.symmetric(horizontal: 25, vertical: 10),

--- a/client/flutter/lib/pages/about_page.dart
+++ b/client/flutter/lib/pages/about_page.dart
@@ -72,7 +72,7 @@ class AboutPage extends StatelessWidget {
               _divider(),
               Container(
                 color: CupertinoColors.white,
-                padding: EdgeInsets.symmetric(horizontal: 25, vertical: 10),
+                padding: EdgeInsets.fromLTRB(25, 25, 25, 10),
                 child: ThemedText(
                   S.of(context).aboutPageBuiltByCreditText(
                       copyrightString, versionString),

--- a/client/flutter/lib/pages/about_page.dart
+++ b/client/flutter/lib/pages/about_page.dart
@@ -23,24 +23,27 @@ class AboutPage extends StatelessWidget {
         .of(context)
         .commonWorldHealthOrganizationCoronavirusCopyright(DateTime.now().year);
 
-    void _openTermsOfService(BuildContext context) {
+    Future<void> _openTermsOfService(BuildContext context) async {
       final String url = S.of(context).aboutPageTermsOfServiceLinkUrl;
-      launch(url);
-      FirebaseAnalytics().logEvent(name: 'TermsOfService');
+      await launch(url);
+      await FirebaseAnalytics().logEvent(name: 'TermsOfService');
     }
 
-    void _openPrivacyPolicy(BuildContext context) {
+    Future<void> _openPrivacyPolicy(BuildContext context) async {
       final String url = S.of(context).legalLandingPagePrivacyPolicyLinkUrl;
-      launch(url);
-      FirebaseAnalytics().logEvent(name: 'PrivacyPolicy');
+      await launch(url);
+      await FirebaseAnalytics().logEvent(name: 'PrivacyPolicy');
     }
 
-    void _openLicenses(BuildContext context) {
-      Navigator.push(
+    Future<void> _openLicenses(BuildContext context) async {
+      // Logs the page switch as it happens while avoiding any delay caused
+      // by logging.
+      // ignore: unawaited_futures
+      FirebaseAnalytics().logEvent(name: 'ViewLicenses');
+      await Navigator.push(
         context,
         MaterialPageRoute(builder: (BuildContext context) => who.LicensePage()),
       );
-      FirebaseAnalytics().logEvent(name: 'ViewLicenses');
     }
 
     // TODO add divider theme to ThemeData once we've switched to a MaterialApp

--- a/client/flutter/lib/pages/settings_page.dart
+++ b/client/flutter/lib/pages/settings_page.dart
@@ -5,6 +5,7 @@ import 'package:share/share.dart';
 import 'package:who_app/api/notifications.dart';
 import 'package:who_app/api/user_preferences.dart';
 import 'package:who_app/components/dialogs.dart';
+import 'package:who_app/components/menu_list_tile.dart';
 import 'package:who_app/components/page_scaffold/page_scaffold.dart';
 import 'package:who_app/components/themed_text.dart';
 import 'package:who_app/constants.dart';
@@ -157,7 +158,7 @@ class _SettingsPageState extends State<SettingsPage>
     final Size size = MediaQuery.of(context).size;
     return Column(children: <Widget>[
       divider,
-      menuItem(
+      MenuListTile(
         title: S.of(context).homePagePageSliverListShareTheApp,
         onTap: () {
           FirebaseAnalytics().logShare(
@@ -171,14 +172,14 @@ class _SettingsPageState extends State<SettingsPage>
       ),
       divider,
       // TODO: Localize
-      menuItem(
+      MenuListTile(
           title: 'Provide app feedback',
           onTap: () {
             FirebaseAnalytics().logEvent(name: 'Feedback');
             // TODO: Implement feedback #989 #1015
           }),
       divider,
-      menuItem(
+      MenuListTile(
         title: S.of(context).homePagePageSliverListAboutTheApp,
         onTap: () {
           return Navigator.of(context, rootNavigator: true).pushNamed('/about');
@@ -186,27 +187,6 @@ class _SettingsPageState extends State<SettingsPage>
       ),
       divider,
     ]);
-  }
-
-  Widget menuItem({BuildContext context, String title, Function() onTap}) {
-    return Material(
-      color: Colors.white,
-      child: ListTile(
-        contentPadding: EdgeInsets.symmetric(
-          horizontal: 24,
-          vertical: 8,
-        ),
-        title: ThemedText(
-          title,
-          variant: TypographyVariant.button,
-        ),
-        trailing: Icon(
-          Icons.arrow_forward_ios,
-          color: Color(0xFFC9CDD6),
-        ),
-        onTap: onTap,
-      ),
-    );
   }
 
   Widget switchItem(


### PR DESCRIPTION
<!-- Uncomment sections below as relevant -->

<!-- Title should be a short phrase, e.g. "Add survey functionality". Detailed description should include any design decisions you want reviewers to take note of -->

<!--
Add the Issue number(s) assigned to you that this PR fully resolves, if any
Closes #0
-->
- Closes https://github.com/WorldHealthOrganization/app/issues/1250
- Moves the `menuItem` component out of the settings page and into the components folder(renamed to `MenuListTile`).
- Replaces the `LinkTextSpan`s with vertically stacked `MenuListTile`s


#### Screenshots
<details>
<summary>Screenshots</summary>
Before:

![image](https://user-images.githubusercontent.com/33752528/81691227-63c15600-9454-11ea-828f-6afb4cb2535e.png)

After:
![image](https://user-images.githubusercontent.com/33752528/81691198-586e2a80-9454-11ea-8770-71ffb61fa8fb.png)

</details>


<!--
#### Did you add any dependencies?
List each added dependency and justifications (see the Guidelines)
* [`package_name`](package-url): justification for including the package
-->

#### How did you test the change?
* [ ] iOS Simulator
* [ ] Android Emulator
* [ ] iOS Device
* [x] Android Device
* [ ] `curl` to a dev App Engine server


<!-- FILL OUT THE CHECKLIST BELOW -->

---

#### Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).

- [x] REQUIRED: Do you have an Issue **assigned to you** for this PR?
- [x] Provided detailed pull request description and a succinct title
- [x] Tested your changes, especially after any code review iterations.
- [x] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).
