### PR TITLE
fix: hide next/prev carousel buttons

### DIFF
--- a/client/flutter/lib/components/carousel/carousel.dart
+++ b/client/flutter/lib/components/carousel/carousel.dart
@@ -15,6 +15,17 @@ class CarouselView extends StatelessWidget {
 
   final PageController pageController = PageController();
 
+  Widget _animatedVisibility({@required Widget child, @required bool visible}) {
+    return ExcludeSemantics(
+      excluding: !visible,
+      child: AnimatedOpacity(
+        opacity: visible ? 1 : 0,
+        duration: Duration(milliseconds: 200),
+        child: IgnorePointer(ignoring: !visible, child: child),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Stack(
@@ -44,24 +55,35 @@ class CarouselView extends StatelessWidget {
         Align(
           alignment: FractionalOffset.bottomCenter,
           child: SafeArea(
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: <Widget>[
-                CupertinoButton(
-                  child: Icon(CupertinoIcons.back),
-                  onPressed: () => pageController.page > 0
-                      ? goToPreviousPage()
-                      : goToLastPage(),
-                ),
-                Container(child: _buildPageViewIndicator(context)),
-                CupertinoButton(
-                  child: Icon(CupertinoIcons.forward),
-                  onPressed: () => pageController.page < this.items.length - 1
-                      ? goToNextPage()
-                      : goToFirstPage(),
-                ),
-              ],
+            child: ValueListenableBuilder(
+              valueListenable: pageIndexNotifier,
+              // Anything not effected by the value of the notifier
+              child: _buildPageViewIndicator(context),
+              builder: (context, index, child) {
+                final bool isFirstPage = index == 0;
+                final bool isLastPage = index + 1 == items.length;
+                return Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: <Widget>[
+                    _animatedVisibility(
+                      visible: !isFirstPage,
+                      child: CupertinoButton(
+                        child: Icon(CupertinoIcons.back),
+                        onPressed: goToPreviousPage,
+                      ),
+                    ),
+                    child,
+                    _animatedVisibility(
+                      visible: !isLastPage,
+                      child: CupertinoButton(
+                        child: Icon(CupertinoIcons.forward),
+                        onPressed: goToNextPage,
+                      ),
+                    ),
+                  ],
+                );
+              },
             ),
           ),
         ),


### PR DESCRIPTION
<!-- Uncomment sections below as relevant -->

<!-- Title should be a short phrase, e.g. "Add survey functionality". Detailed description should include any design decisions you want reviewers to take note of -->

<!--
Add the Issue number(s) assigned to you that this PR fully resolves, if any
Closes #0
-->

Closes https://github.com/WorldHealthOrganization/app/issues/1247

uses `_animatedVisibility` to hide the next/previous arrow buttons when on the first/last page respectively while still occupying the size of the buttons automatically. It's similar to the `Visibility` widget but with a 200ms fade animation.


#### Screenshots
<details>
<summary>Screenshots</summary>
First page:

![image](https://user-images.githubusercontent.com/33752528/81701093-72fad080-9461-11ea-8000-a59db6c87797.png)
Second page:
![image](https://user-images.githubusercontent.com/33752528/81701167-8c9c1800-9461-11ea-80b2-b3cd3cb8289f.png)

Last page:
![image](https://user-images.githubusercontent.com/33752528/81701125-7ee69280-9461-11ea-984a-bd5d8983ce72.png)

</details>


<!--
#### Did you add any dependencies?
List each added dependency and justifications (see the Guidelines)
* [`package_name`](package-url): justification for including the package
-->

<!--
#### How did you test the change?
* [ ] iOS Simulator
* [ ] Android Emulator
* [ ] iOS Device
* [x] Android Device
* [ ] `curl` to a dev App Engine server
-->

<!-- FILL OUT THE CHECKLIST BELOW -->

---

#### Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).

- [x] REQUIRED: Do you have an Issue **assigned to you** for this PR?
- [x] Provided detailed pull request description and a succinct title
- [x] Tested your changes, especially after any code review iterations.
- [x] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).
