### PR TITLE
replace CupertinoPageScaffold with Material in CountrySelectPage

### DIFF
--- a/client/flutter/lib/pages/onboarding/country_select_page.dart
+++ b/client/flutter/lib/pages/onboarding/country_select_page.dart
@@ -19,8 +19,8 @@ class CountrySelectPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return CupertinoPageScaffold(
-      backgroundColor: CupertinoColors.white,
+    return Material(
+      color: CupertinoColors.white,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[


### PR DESCRIPTION
<!-- Uncomment sections below as relevant -->

<!-- Title should be a short phrase, e.g. "Add survey functionality". Detailed description should include any design decisions you want reviewers to take note of -->

<!--
Add the Issue number(s) assigned to you that this PR fully resolves, if any
Closes #0
-->
I don't think the `CupertinoPageScaffold ` is needed here. A small side effect of using a `MaterialApp` is that a few widgets like `Text` need to be wrapped in `Material` or the effect in the screenshot occurs. This is done automatically when using a Material `Scaffold` widget.


#### Screenshots
<details>
<summary>Screenshots</summary>
Before:

![image](https://user-images.githubusercontent.com/33752528/81751340-2639e880-94a7-11ea-9667-d768c8c88471.png)

After:
![image](https://user-images.githubusercontent.com/33752528/81751361-3225aa80-94a7-11ea-8574-06aead6ed3b9.png)

</details>


<!--
#### Did you add any dependencies?
List each added dependency and justifications (see the Guidelines)
* [`package_name`](package-url): justification for including the package
-->

<!--
#### How did you test the change?
* [ ] iOS Simulator
* [ ] Android Emulator
* [ ] iOS Device
* [x] Android Device
* [ ] `curl` to a dev App Engine server
-->

<!-- FILL OUT THE CHECKLIST BELOW -->

---

#### Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).

- [ ] REQUIRED: Do you have an Issue **assigned to you** for this PR?
- [x] Provided detailed pull request description and a succinct title
- [x] Tested your changes, especially after any code review iterations.
- [x] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).
