### PR TITLE
fix bug with not going all the way back

### DIFF
--- a/client/app_en/lib/pages/exposures_page.dart
+++ b/client/app_en/lib/pages/exposures_page.dart
@@ -7,7 +7,7 @@ class ExposuresPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PageScaffold(
-      disableBackButton: true,
+      leading: Container(),
       headingBorderColor: Color(0x0),
       title: "Exposures",
       body: <Widget>[

--- a/client/flutter/lib/components/page_scaffold/page_header.dart
+++ b/client/flutter/lib/components/page_scaffold/page_header.dart
@@ -5,16 +5,15 @@ import 'package:who_app/components/themed_text.dart';
 class PageHeader extends StatelessWidget {
   final String title;
   final String heroTag;
+  final Widget leading;
   final Color borderColor;
   final TextStyle titleStyle;
   final TypographyVariant titleTypographyVariant;
 
-  final bool disableBackButton;
-
   PageHeader({
     @required this.title,
+    this.leading,
     this.heroTag,
-    this.disableBackButton = false,
     this.titleStyle,
     this.borderColor,
     this.titleTypographyVariant = TypographyVariant.header,
@@ -33,9 +32,12 @@ class PageHeader extends StatelessWidget {
       transitionBetweenRoutes: true,
       backgroundColor: CupertinoColors.white.withOpacity(0.85),
       heroTag: this.heroTag ?? this.title,
-      leading: this.disableBackButton ? Container() : null,
-      largeTitle: buildTitle(this.title,
-          textStyle: titleStyle, variant: this.titleTypographyVariant),
+      leading: this.leading,
+      largeTitle: buildTitle(
+        this.title,
+        textStyle: titleStyle,
+        variant: this.titleTypographyVariant,
+      ),
     );
   }
 

--- a/client/flutter/lib/components/page_scaffold/page_scaffold.dart
+++ b/client/flutter/lib/components/page_scaffold/page_scaffold.dart
@@ -11,10 +11,10 @@ class PageScaffold extends StatelessWidget {
   final List<Widget> beforeHeader;
   final Color color;
   final Color headingBorderColor;
-  final bool disableBackButton;
   final TextStyle headerTitleStyle;
   final TypographyVariant headerTypographyVariant;
   final Widget header;
+  final Widget leading;
 
   final bool showHeader;
 
@@ -23,6 +23,7 @@ class PageScaffold extends StatelessWidget {
   PageScaffold({
     @required this.body,
     this.title,
+    this.leading,
     this.heroTag,
     this.header,
     this.showHeader = true,
@@ -30,7 +31,6 @@ class PageScaffold extends StatelessWidget {
     this.color = Constants.greyBackgroundColor,
     this.headingBorderColor = const Color(0xffC9CDD6),
     this.beforeHeader = const <Widget>[],
-    this.disableBackButton = false,
     this.headerTitleStyle,
     this.headerTypographyVariant = TypographyVariant.header,
   });
@@ -52,9 +52,9 @@ class PageScaffold extends StatelessWidget {
                     (this.header ??
                         PageHeader(
                           title: this.title,
+                          leading: this.leading,
                           heroTag: this.heroTag ?? this.title,
                           borderColor: headingBorderColor,
-                          disableBackButton: disableBackButton,
                           titleStyle: headerTitleStyle,
                           titleTypographyVariant: this.headerTypographyVariant,
                         )),

--- a/client/flutter/lib/pages/main_pages/learn_page.dart
+++ b/client/flutter/lib/pages/main_pages/learn_page.dart
@@ -69,7 +69,7 @@ class _LearnPageState extends State<LearnPage> {
   @override
   Widget build(BuildContext context) {
     return PageScaffold(
-      disableBackButton: true,
+      leading: Container(),
       headingBorderColor: Color(0x0),
       heroTag: HeroTags.learn,
       // TODO: localize

--- a/client/flutter/lib/pages/settings_page.dart
+++ b/client/flutter/lib/pages/settings_page.dart
@@ -107,7 +107,7 @@ class _SettingsPageState extends State<SettingsPage>
   @override
   Widget build(BuildContext context) {
     return PageScaffold(
-      disableBackButton: true,
+      leading: Container(),
       heroTag: HeroTags.settings,
       body: [
         SliverList(

--- a/client/flutter/lib/pages/symptom_checker/symptom_checker_results_page.dart
+++ b/client/flutter/lib/pages/symptom_checker/symptom_checker_results_page.dart
@@ -19,6 +19,17 @@ class SymptomCheckerResultsPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return PageScaffold(
       heroTag: HeroTags.checkUp,
+      leading: CupertinoButton(
+        padding: EdgeInsets.zero,
+        child: Icon(
+          CupertinoIcons.back,
+          size: 34,
+        ),
+        onPressed: () {
+          Navigator.pop(context);
+          Navigator.pop(context);
+        },
+      ),
       body: [
         _buildBody(context),
       ],


### PR DESCRIPTION
### When a user gets their server results and presses the back button they should be returned to the home page.

#### Screenshots
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-05-12 at 20 46 50](https://user-images.githubusercontent.com/38309438/81769178-cc7af380-9491-11ea-99f6-dce20cd2b27e.png)


<!--
#### Did you add any dependencies?
List each added dependency and justifications (see the Guidelines)
* [`package_name`](package-url): justification for including the package
-->

<!--
#### How did you test the change?
* [ ] iOS Simulator
* [ ] Android Emulator
* [ ] iOS Device
* [ ] Android Device
* [ ] `curl` to a dev App Engine server
-->

<!-- FILL OUT THE CHECKLIST BELOW -->

---

#### Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).

- [ ] REQUIRED: Do you have an Issue **assigned to you** for this PR?
- [x] Provided detailed pull request description and a succinct title
- [x] Tested your changes, especially after any code review iterations.
- [x] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).
