### PR TITLE
Fix onboarding screen button color regressions

### DIFF
--- a/client/flutter/lib/pages/onboarding/legal_landing_page.dart
+++ b/client/flutter/lib/pages/onboarding/legal_landing_page.dart
@@ -52,8 +52,9 @@ class LegalLandingPage extends StatelessWidget {
                   mainAxisAlignment: MainAxisAlignment.center,
                   crossAxisAlignment: CrossAxisAlignment.center,
                   borderRadius: 60,
-                  titleStyle: ThemedText.styleForVariant(TypographyVariant.button)
-                      .merge(TextStyle(color: CupertinoColors.white)),
+                  titleStyle:
+                      ThemedText.styleForVariant(TypographyVariant.button)
+                          .merge(TextStyle(color: CupertinoColors.white)),
                 ),
                 SizedBox(height: 17),
                 Text.rich(

--- a/client/flutter/lib/pages/onboarding/legal_landing_page.dart
+++ b/client/flutter/lib/pages/onboarding/legal_landing_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:who_app/components/page_button.dart';
+import 'package:who_app/components/themed_text.dart';
 import 'package:who_app/constants.dart';
 import 'package:who_app/generated/l10n.dart';
 import 'package:flutter_html/rich_text_parser.dart';
@@ -44,13 +45,15 @@ class LegalLandingPage extends StatelessWidget {
               flex: 1,
               child: Column(children: <Widget>[
                 PageButton(
-                  Constants.primaryColor,
+                  Constants.whoBackgroundBlueColor,
                   S.of(context).legalLandingPageButtonGetStarted,
                   onNext,
                   verticalPadding: 12,
                   mainAxisAlignment: MainAxisAlignment.center,
                   crossAxisAlignment: CrossAxisAlignment.center,
                   borderRadius: 60,
+                  titleStyle: ThemedText.styleForVariant(TypographyVariant.button)
+                      .merge(TextStyle(color: CupertinoColors.white)),
                 ),
                 SizedBox(height: 17),
                 Text.rich(

--- a/client/flutter/lib/pages/onboarding/permission_request_page.dart
+++ b/client/flutter/lib/pages/onboarding/permission_request_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:who_app/components/page_button.dart';
+import 'package:who_app/components/themed_text.dart';
 import 'package:who_app/constants.dart';
 import 'package:who_app/generated/l10n.dart';
 import 'package:flutter/material.dart';
@@ -90,13 +91,15 @@ class PermissionRequestPage extends StatelessWidget {
                   child: Column(
                     children: <Widget>[
                       PageButton(
-                        Constants.primaryColor,
+                        Constants.whoBackgroundBlueColor,
                         buttonTitle,
                         onGrantPermission,
                         crossAxisAlignment: CrossAxisAlignment.center,
                         mainAxisAlignment: MainAxisAlignment.center,
                         verticalPadding: 12,
                         borderRadius: 35,
+                        titleStyle: ThemedText.styleForVariant(TypographyVariant.button)
+                      .merge(TextStyle(color: CupertinoColors.white))
                       ),
                       CupertinoButton(
                         padding: EdgeInsets.all(16),

--- a/client/flutter/lib/pages/onboarding/permission_request_page.dart
+++ b/client/flutter/lib/pages/onboarding/permission_request_page.dart
@@ -90,17 +90,15 @@ class PermissionRequestPage extends StatelessWidget {
                   flex: 1,
                   child: Column(
                     children: <Widget>[
-                      PageButton(
-                        Constants.whoBackgroundBlueColor,
-                        buttonTitle,
-                        onGrantPermission,
-                        crossAxisAlignment: CrossAxisAlignment.center,
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        verticalPadding: 12,
-                        borderRadius: 35,
-                        titleStyle: ThemedText.styleForVariant(TypographyVariant.button)
-                      .merge(TextStyle(color: CupertinoColors.white))
-                      ),
+                      PageButton(Constants.whoBackgroundBlueColor, buttonTitle,
+                          onGrantPermission,
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          verticalPadding: 12,
+                          borderRadius: 35,
+                          titleStyle: ThemedText.styleForVariant(
+                                  TypographyVariant.button)
+                              .merge(TextStyle(color: CupertinoColors.white))),
                       CupertinoButton(
                         padding: EdgeInsets.all(16),
                         child: Text(


### PR DESCRIPTION
Fixes #1307 -- change text color and background color of "Get Started" and "Allow Notifications" buttons to match the mockup.

#### Screenshots
<details>
<summary>Screenshots</summary>

![image](https://user-images.githubusercontent.com/1689183/81871631-38b72f00-9546-11ea-89bd-72b73b2b663b.png)

![image](https://user-images.githubusercontent.com/1689183/81871650-3f45a680-9546-11ea-8020-0fdee48fae47.png)


</details>

#### How did you test the change?
* [x] iOS Simulator