### PR TITLE
[feat] Add optional image to HomePageInformationCard

### DIFF
--- a/client/flutter/lib/components/home_page_sections/home_page_information_card.dart
+++ b/client/flutter/lib/components/home_page_sections/home_page_information_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/cupertino.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:who_app/api/linking.dart';
 import 'package:who_app/components/themed_text.dart';
 import 'package:who_app/constants.dart';
@@ -8,8 +9,52 @@ class HomePageInformationCard extends StatelessWidget {
   final RouteLink link;
   final String subtitle;
   final String title;
+  final String imageName;
+
+  String get assetName =>
+      this.imageName != null ? 'assets/svg/${this.imageName}.svg' : null;
 
   const HomePageInformationCard({
+    @required this.buttonText,
+    @required this.link,
+    @required this.subtitle,
+    @required this.title,
+    this.imageName,
+    Key key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final inner = _HomePageInformationCardInner(
+      buttonText: this.buttonText,
+      link: this.link,
+      subtitle: this.subtitle,
+      title: this.title,
+    );
+    return this.assetName != null
+        ? Stack(
+            children: <Widget>[
+              Container(
+                margin: EdgeInsets.only(top: 36.0),
+                child: inner,
+              ),
+              Positioned(
+                right: 44.0,
+                child: SvgPicture.asset(this.assetName),
+              )
+            ],
+          )
+        : inner;
+  }
+}
+
+class _HomePageInformationCardInner extends StatelessWidget {
+  final String buttonText;
+  final RouteLink link;
+  final String subtitle;
+  final String title;
+
+  const _HomePageInformationCardInner({
     @required this.buttonText,
     @required this.link,
     @required this.subtitle,

--- a/client/flutter/lib/pages/main_pages/home_page.dart
+++ b/client/flutter/lib/pages/main_pages/home_page.dart
@@ -118,6 +118,7 @@ class _HomePageState extends State<HomePage> {
         subtitle: item.subtitle,
         buttonText: item.buttonText,
         link: item.link,
+        imageName: item.imageName,
       ),
     );
   }


### PR DESCRIPTION
Awaiting finalized asset to be included, but should be able to add `image_name: <svg-name>` to the `home_index.en.yaml` when ready to include.

Closes #1245 

#### Screenshots
<details>
<summary>With Placeholder SVG</summary>

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-05-13 at 16 31 07](https://user-images.githubusercontent.com/1484366/81876554-d5260500-9537-11ea-946b-310dca37aad9.png)
</details>

#### How did you test the change?
* [x] iOS Simulator

---

#### Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).

- [x] REQUIRED: Do you have an Issue **assigned to you** for this PR?
- [x] Provided detailed pull request description and a succinct title
- [x] Tested your changes, especially after any code review iterations.
- [x] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).
