### PR TITLE
Feature: MD nav bar on Android & RouteLink tab switching where applicable.

### DIFF
--- a/client/flutter/lib/api/linking.dart
+++ b/client/flutter/lib/api/linking.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:who_app/pages/main_pages/app_tab_router.dart';
 
 class RouteLink {
   Uri _url;
@@ -21,11 +22,22 @@ class RouteLink {
     @required this.args,
   });
 
-  Future open(BuildContext context) {
-    return this.isExternal
+  Future open(BuildContext context) async {
+    if (isExternal) {
+      await launch(url);
+    } else {
+      /// Intercepted by the [AppTabRouter] which decides whether to switch
+      /// home page tabs or to push the route with the provided arguments 
+      SwitchTabNotification(
+        args: args,
+        route: route,
+      ).dispatch(context);
+    }
+
+    /* return this.isExternal
         ? launch(this.url)
         : Navigator.of(context, rootNavigator: true)
-            .pushNamed(this.route, arguments: this.args);
+            .pushNamed(this.route, arguments: this.args); */
   }
 
   RouteLink.fromUri(String uri) {

--- a/client/flutter/lib/api/linking.dart
+++ b/client/flutter/lib/api/linking.dart
@@ -27,7 +27,7 @@ class RouteLink {
       await launch(url);
     } else {
       /// Intercepted by the [AppTabRouter] which decides whether to switch
-      /// home page tabs or to push the route with the provided arguments 
+      /// home page tabs or to push the route with the provided arguments
       SwitchTabNotification(
         args: args,
         route: route,

--- a/client/flutter/lib/api/linking.dart
+++ b/client/flutter/lib/api/linking.dart
@@ -33,11 +33,6 @@ class RouteLink {
         route: route,
       ).dispatch(context);
     }
-
-    /* return this.isExternal
-        ? launch(this.url)
-        : Navigator.of(context, rootNavigator: true)
-            .pushNamed(this.route, arguments: this.args); */
   }
 
   RouteLink.fromUri(String uri) {

--- a/client/flutter/lib/pages/main_pages/app_tab_router.dart
+++ b/client/flutter/lib/pages/main_pages/app_tab_router.dart
@@ -6,6 +6,7 @@ import 'package:who_app/pages/main_pages/check_up_intro_page.dart';
 import 'package:who_app/pages/main_pages/recent_numbers.dart';
 import 'package:who_app/pages/main_pages/home_page.dart';
 import 'package:who_app/pages/main_pages/learn_page.dart';
+import 'package:who_app/pages/main_pages/routes.dart';
 import 'package:who_app/pages/settings_page.dart';
 import 'package:flutter/material.dart';
 
@@ -67,29 +68,57 @@ class _AppTabRouterState extends State<AppTabRouter> {
     }
   }
 
+  bool _onSwitchTabNotification(SwitchTabNotification notification) {
+    final String routeName = notification.route;
+    final int newIndex = widget.tabs.indexWhere(
+      (Widget Function(BuildContext) builder) =>
+          builder(context).runtimeType ==
+          Routes.map[routeName](context).runtimeType,
+    );
+
+    if (newIndex != -1) {
+      _switchPage(newIndex);
+    } else {
+      Navigator.pushNamed(context, routeName, arguments: notification.args);
+    }
+
+    // Terminates the notification
+    return true;
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: widget.tabs[currentIndex](context),
-      extendBody: Theme.of(context).platform == TargetPlatform.iOS,
-      bottomNavigationBar: PlatformWidget(
-        material: BottomNavigationBar(
-          currentIndex: currentIndex,
-          onTap: _switchPage,
-          items: widget.navItems,
-          selectedItemColor: selectedColor,
-          unselectedItemColor: unselectedColor,
-          type: BottomNavigationBarType.fixed,
-          selectedFontSize: 12,
-        ),
-        cupertino: CupertinoTabBar(
-          currentIndex: currentIndex,
-          onTap: _switchPage,
-          items: widget.navItems,
-          activeColor: selectedColor,
-          inactiveColor: unselectedColor,
+    return NotificationListener<SwitchTabNotification>(
+      onNotification: _onSwitchTabNotification,
+      child: Scaffold(
+        body: widget.tabs[currentIndex](context),
+        extendBody: Theme.of(context).platform == TargetPlatform.iOS,
+        bottomNavigationBar: PlatformWidget(
+          material: BottomNavigationBar(
+            currentIndex: currentIndex,
+            onTap: _switchPage,
+            items: widget.navItems,
+            selectedItemColor: selectedColor,
+            unselectedItemColor: unselectedColor,
+            type: BottomNavigationBarType.fixed,
+            selectedFontSize: 12,
+          ),
+          cupertino: CupertinoTabBar(
+            currentIndex: currentIndex,
+            onTap: _switchPage,
+            items: widget.navItems,
+            activeColor: selectedColor,
+            inactiveColor: unselectedColor,
+          ),
         ),
       ),
     );
   }
+}
+
+class SwitchTabNotification extends Notification {
+  SwitchTabNotification({@required this.route, @required this.args});
+
+  final String route;
+  final Object args;
 }

--- a/client/flutter/lib/pages/main_pages/app_tab_router.dart
+++ b/client/flutter/lib/pages/main_pages/app_tab_router.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:who_app/api/content/schema/index_content.dart';
+import 'package:who_app/components/platform_widget.dart';
 import 'package:who_app/constants.dart';
 import 'package:who_app/pages/main_pages/check_up_intro_page.dart';
 import 'package:who_app/pages/main_pages/recent_numbers.dart';
@@ -8,7 +9,7 @@ import 'package:who_app/pages/main_pages/learn_page.dart';
 import 'package:who_app/pages/settings_page.dart';
 import 'package:flutter/material.dart';
 
-class AppTabRouter extends StatelessWidget {
+class AppTabRouter extends StatefulWidget {
   static final List<Widget Function(BuildContext)> defaultTabs = [
     (context) => HomePage(
           dataSource: IndexContent.homeIndex,
@@ -41,6 +42,15 @@ class AppTabRouter extends StatelessWidget {
 
   AppTabRouter(this.tabs, this.navItems);
 
+  @override
+  _AppTabRouterState createState() => _AppTabRouterState();
+}
+
+class _AppTabRouterState extends State<AppTabRouter> {
+  int currentIndex = 0;
+  final Color selectedColor = Constants.accentColor;
+  final Color unselectedColor = Colors.black;
+
   Widget wrapTabView(Widget Function(BuildContext) builder) {
     return Material(
       child: CupertinoTabView(
@@ -49,19 +59,36 @@ class AppTabRouter extends StatelessWidget {
     );
   }
 
+  void _switchPage(int index) {
+    if (currentIndex != index) {
+      setState(() {
+        currentIndex = index;
+      });
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    return CupertinoTabScaffold(
-      tabBuilder: (BuildContext context, int index) {
-        if (index < tabs.length) {
-          return wrapTabView(tabs[index]);
-        }
-        return null;
-      },
-      tabBar: CupertinoTabBar(
-        inactiveColor: CupertinoColors.black,
-        activeColor: Constants.accentColor,
-        items: navItems,
+    return Scaffold(
+      body: widget.tabs[currentIndex](context),
+      extendBody: Theme.of(context).platform == TargetPlatform.iOS,
+      bottomNavigationBar: PlatformWidget(
+        material: BottomNavigationBar(
+          currentIndex: currentIndex,
+          onTap: _switchPage,
+          items: widget.navItems,
+          selectedItemColor: selectedColor,
+          unselectedItemColor: unselectedColor,
+          type: BottomNavigationBarType.fixed,
+          selectedFontSize: 12,
+        ),
+        cupertino: CupertinoTabBar(
+          currentIndex: currentIndex,
+          onTap: _switchPage,
+          items: widget.navItems,
+          activeColor: selectedColor,
+          inactiveColor: unselectedColor,
+        ),
       ),
     );
   }


### PR DESCRIPTION
<!-- Uncomment sections below as relevant -->

<!-- Title should be a short phrase, e.g. "Add survey functionality". Detailed description should include any design decisions you want reviewers to take note of -->

<!--
Add the Issue number(s) assigned to you that this PR fully resolves, if any
Closes #0
-->

- Tapping the "Check now" or "See All"(for recent numbers) button on the home page will now detect that a home page tab is available and switch to it instead of opening a separate page. It works by dispatching a `SwitchTabNotification` that's intercepted by the `AppTabRouter`. 
- A `PlatformWidget` is now being used to show a `CupertinoTabBar` on IOS and a `BottomNavigationBar` on Android.

#### Screenshots
<details>
<summary>Screenshots</summary>
Demonstration of the Material Design bottom nav bar only shown on Android:

![image](https://user-images.githubusercontent.com/33752528/81881372-ea2a8480-9587-11ea-96cf-e958ee077c17.png)

</details>

<!--
#### Did you add any dependencies?
List each added dependency and justifications (see the Guidelines)
* [`package_name`](package-url): justification for including the package
-->

#### How did you test the change?
* [ ] iOS Simulator
* [ ] Android Emulator
* [ ] iOS Device
* [x] Android Device
* [ ] `curl` to a dev App Engine server

<!-- FILL OUT THE CHECKLIST BELOW -->

---

#### Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).

- [ ] REQUIRED: Do you have an Issue **assigned to you** for this PR?
- [x] Provided detailed pull request description and a succinct title
- [x] Tested your changes, especially after any code review iterations.
- [x] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).
