### PR TITLE
[refactor] Use new Button component for all rounded rect buttons

### DIFF
--- a/client/flutter/lib/components/button.dart
+++ b/client/flutter/lib/components/button.dart
@@ -11,7 +11,7 @@ class Button extends StatelessWidget {
   const Button({
     Key key,
     this.color,
-    this.borderRadius,
+    this.borderRadius = const BorderRadius.all(Radius.zero),
     this.padding,
     this.child,
     this.onPressed,

--- a/client/flutter/lib/components/home_page_sections/home_page_donate.dart
+++ b/client/flutter/lib/components/home_page_sections/home_page_donate.dart
@@ -2,6 +2,7 @@ import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:who_app/components/button.dart';
 import 'package:who_app/components/themed_text.dart';
 import 'package:who_app/constants.dart';
 import 'package:who_app/generated/l10n.dart';
@@ -30,10 +31,10 @@ class HomePageDonate extends StatelessWidget {
           padding: const EdgeInsets.symmetric(
             vertical: 24.0,
           ),
-          child: CupertinoButton(
+          child: Button(
             borderRadius: BorderRadius.circular(50.0),
             color: Constants.accentTealColor,
-            padding: EdgeInsets.symmetric(horizontal: 88.0, vertical: 8.0),
+            padding: EdgeInsets.symmetric(horizontal: 88.0, vertical: 12.0),
             child: ThemedText(
               // TODO: localize
               'Donate Now',

--- a/client/flutter/lib/components/home_page_sections/home_page_header.dart
+++ b/client/flutter/lib/components/home_page_sections/home_page_header.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:who_app/api/content/schema/index_content.dart';
 import 'package:who_app/api/linking.dart';
+import 'package:who_app/components/button.dart';
 import 'package:who_app/components/promo_curved_background.dart';
 import 'package:who_app/components/themed_text.dart';
 import 'package:who_app/constants.dart';
@@ -98,11 +99,11 @@ class HomePageHeader extends StatelessWidget {
                           Padding(
                             padding:
                                 const EdgeInsets.only(top: 32.0, bottom: 88.0),
-                            child: CupertinoButton(
+                            child: Button(
                               borderRadius: BorderRadius.circular(50),
                               padding: EdgeInsets.symmetric(
                                 horizontal: 32,
-                                vertical: 8,
+                                vertical: 12,
                               ),
                               color: CupertinoColors.white,
                               child: Container(

--- a/client/flutter/lib/components/home_page_sections/home_page_information_card.dart
+++ b/client/flutter/lib/components/home_page_sections/home_page_information_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:who_app/api/linking.dart';
+import 'package:who_app/components/button.dart';
 import 'package:who_app/components/themed_text.dart';
 import 'package:who_app/constants.dart';
 
@@ -96,11 +97,11 @@ class _HomePageInformationCardInner extends StatelessWidget {
               Row(
                 mainAxisAlignment: MainAxisAlignment.end,
                 children: <Widget>[
-                  CupertinoButton(
+                  Button(
                     color: CupertinoColors.white,
                     borderRadius: BorderRadius.circular(50.0),
                     padding:
-                        EdgeInsets.symmetric(horizontal: 32.0, vertical: 8.0),
+                        EdgeInsets.symmetric(horizontal: 32.0, vertical: 12.0),
                     child: ThemedText(
                       this.buttonText,
                       variant: TypographyVariant.button,

--- a/client/flutter/lib/components/learn_page_promo.dart
+++ b/client/flutter/lib/components/learn_page_promo.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:who_app/api/linking.dart';
+import 'package:who_app/components/button.dart';
 import 'package:who_app/components/promo_curved_background.dart';
 import 'package:who_app/components/themed_text.dart';
 import 'package:who_app/constants.dart';
@@ -64,7 +65,7 @@ class LearnPagePromo extends StatelessWidget {
                 SizedBox(
                   height: 16.0,
                 ),
-                CupertinoButton(
+                Button(
                   color: CupertinoColors.white,
                   borderRadius: BorderRadius.circular(50),
                   padding: EdgeInsets.symmetric(

--- a/client/flutter/lib/pages/onboarding/permission_request_page.dart
+++ b/client/flutter/lib/pages/onboarding/permission_request_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/cupertino.dart';
+import 'package:who_app/components/button.dart';
 import 'package:who_app/components/page_button.dart';
 import 'package:who_app/components/themed_text.dart';
 import 'package:who_app/constants.dart';
@@ -99,7 +100,7 @@ class PermissionRequestPage extends StatelessWidget {
                           titleStyle: ThemedText.styleForVariant(
                                   TypographyVariant.button)
                               .merge(TextStyle(color: CupertinoColors.white))),
-                      CupertinoButton(
+                      Button(
                         padding: EdgeInsets.all(16),
                         child: Text(
                           S.of(context).commonPermissionRequestPageButtonSkip,


### PR DESCRIPTION
Leaves the buttons that do not have rounded rect backgrounds, specifically the home page section "Learn more >" buttons, the carousel next/prev buttons, and the check up page intro terms link

Closes #1219 (at least enough to open specific issues for specific elements that need debouncing)
Closes #1156 (at least enough to open specific issues for specific elements that need splash)

#### How did you test the change?
* [x] iOS Simulator

---

#### Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).

- [x] REQUIRED: Do you have an Issue **assigned to you** for this PR?
- [x] Provided detailed pull request description and a succinct title
- [x] Tested your changes, especially after any code review iterations.
- [x] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).
