### PR TITLE
🎶🦜 Server country and push notification topic registration

### DIFF
--- a/api/who/who.proto
+++ b/api/who/who.proto
@@ -21,12 +21,8 @@ message PutDeviceTokenRequest {
 }
 
 message PutLocationRequest {
-  // A token is a hex representation of the 64-bit S2CellId
-  // in string format that will also survive JSON (which
-  // lacks 64-bit number precision).
-  // The level (specificity) of the S2CellId must not exceed
-  // who.Client.MAX_S2_CELL_LEVEL.
-  string s2CellIdToken = 11;
+  // ISO 3166-1 alpha-2 (uppercase) code
+  string isoCountryCode = 12;
 }
 
 message GetCaseStatsResponse {

--- a/server/README.md
+++ b/server/README.md
@@ -14,7 +14,7 @@ Services:
 - Staging Cloud Datastore
 - Staging Firebase Project
 
-### [`who-myhealth-production`](https://console.cloud.google.com/home/dashboard?project=who-myhealth-production)
+### [`who-myhealth-production`](https://console.cloud.google.com/home/dashboard?project=who-myhealth-europe)
 
 Services:
 
@@ -101,6 +101,10 @@ Follow the directions [here](https://cloud.google.com/sdk/?hl=en_US).
 ### Log In
 
     $ gcloud auth login
+
+And, if you want to be able to manipulate Firebase:
+
+    	$ gcloud auth application-default login
 
 ### Install the most up-to-date App Engine Component
 

--- a/server/README.md
+++ b/server/README.md
@@ -14,7 +14,7 @@ Services:
 - Staging Cloud Datastore
 - Staging Firebase Project
 
-### [`who-myhealth-production`](https://console.cloud.google.com/home/dashboard?project=who-myhealth-europe)
+### [`who-myhealth-production`](https://console.cloud.google.com/home/dashboard?project=who-myhealth-production)
 
 Services:
 

--- a/server/appengine/build.gradle
+++ b/server/appengine/build.gradle
@@ -65,7 +65,8 @@ dependencies {
 
     // Not sure why this didn't come in with present-engine...
     implementation 'com.google.appengine:appengine-remote-api:+'
-    implementation 'com.google.appengine:appengine-remote-api:+'
+
+    implementation 'com.google.firebase:firebase-admin:6.12.2'
 
     testCompile 'junit:junit:4.12'
     testCompile "org.mockito:mockito-core:1.+"

--- a/server/appengine/build.gradle
+++ b/server/appengine/build.gradle
@@ -67,6 +67,8 @@ dependencies {
     implementation 'com.google.appengine:appengine-remote-api:+'
 
     implementation 'com.google.firebase:firebase-admin:6.12.2'
+    // 4.1.34.Final included in Firebase, which has vulnerabilities.
+    implementation 'io.netty:netty-codec-http:4.1.46.Final'
 
     testCompile 'junit:junit:4.12'
     testCompile "org.mockito:mockito-core:1.+"

--- a/server/appengine/src/main/java/who/Client.java
+++ b/server/appengine/src/main/java/who/Client.java
@@ -6,6 +6,9 @@ import com.googlecode.objectify.annotation.Id;
 import com.googlecode.objectify.annotation.Index;
 import com.googlecode.objectify.condition.IfNotNull;
 
+import java.util.SortedSet;
+import java.util.TreeSet;
+
 import static com.googlecode.objectify.ObjectifyService.ofy;
 
 /**
@@ -34,14 +37,19 @@ import static com.googlecode.objectify.ObjectifyService.ofy;
   public Double latitude;
   public Double longitude;
 
-  // TODO: Store denormalized location info if/when needed.
-  public String countryCode;
-  public String adminArea1;
-  public String adminArea2;
-  public String adminArea3;
-  public String adminArea4;
-  public String adminArea5;
-  public String locality;
+  // Store denormalized location info.
+  @Index(IfNotNull.class) public String countryCode;
+  @Index(IfNotNull.class) public String adminArea1;
+  @Index(IfNotNull.class) public String adminArea2;
+  @Index(IfNotNull.class) public String adminArea3;
+  @Index(IfNotNull.class) public String adminArea4;
+  @Index(IfNotNull.class) public String adminArea5;
+  @Index(IfNotNull.class) public String locality;
+
+  // No FCM API exists to list a token's topics, so we
+  // must track them explicitly and sub and unsub from
+  // the appropriate topics as the client changes.
+  public SortedSet<String> subscribedTopics = new TreeSet<>();
 
   public static Client getOrCreate(String uuid, Platform platform) {
     Client client = ofy().load().type(Client.class).id(uuid).now();

--- a/server/appengine/src/main/java/who/Client.java
+++ b/server/appengine/src/main/java/who/Client.java
@@ -23,28 +23,7 @@ import static com.googlecode.objectify.ObjectifyService.ofy;
 
   public Platform platform;
 
-
-  /** S2 cell ID for last known location. See S2CellId. */
-  @Index(IfNotNull.class) public Long location;
-  // No locations of greater level (specificity) than this will be
-  // stored and indexed.  This prevents us from storing precise
-  // locations and protects the database index size.
-  // See: https://s2geometry.io/resources/s2cell_statistics.html
-  public static final int MAX_S2_CELL_LEVEL = 9;
-
-  // Lat/lng representative of the cell, not neccessarily
-  // of the device.
-  public Double latitude;
-  public Double longitude;
-
-  // Store denormalized location info.
-  @Index(IfNotNull.class) public String countryCode;
-  @Index(IfNotNull.class) public String adminArea1;
-  @Index(IfNotNull.class) public String adminArea2;
-  @Index(IfNotNull.class) public String adminArea3;
-  @Index(IfNotNull.class) public String adminArea4;
-  @Index(IfNotNull.class) public String adminArea5;
-  @Index(IfNotNull.class) public String locality;
+  @Index(IfNotNull.class) public String isoCountryCode;
 
   // No FCM API exists to list a token's topics, so we
   // must track them explicitly and sub and unsub from

--- a/server/appengine/src/main/java/who/Environment.java
+++ b/server/appengine/src/main/java/who/Environment.java
@@ -43,6 +43,18 @@ public enum Environment {
     }
   }
 
+  public String firebaseApplicationId() {
+    switch (this) {
+      case TEST:
+      case DEVELOPMENT:
+      case STAGING:
+        return "who-myhealth-staging";
+      case HACKER_ONE: return "who-myhealth-hackerone";
+      case PRODUCTION: return "who-myhealth-europe";
+      default: throw new RuntimeException("Unrecognized environment: " + this);
+    }
+  }
+
   /** True if this is the development server. */
   public static boolean isDevelopment() {
     return current() == DEVELOPMENT;

--- a/server/appengine/src/main/java/who/FirebaseModule.java
+++ b/server/appengine/src/main/java/who/FirebaseModule.java
@@ -14,12 +14,11 @@ import javax.inject.Singleton;
 public class FirebaseModule extends AbstractModule {
 
   @Provides @Singleton
-  FirebaseApp provideFirebaseApp() throws IOException {
-
+  FirebaseApp provideFirebaseApp(Environment env) throws IOException {
     FirebaseOptions options = new FirebaseOptions.Builder()
       .setCredentials(GoogleCredentials.getApplicationDefault())
       // FIXME
-      .setDatabaseUrl("https://who-myhealth-staging.firebaseio.com")
+      .setDatabaseUrl("https://" + env.firebaseApplicationId() + ".firebaseio.com")
       .build();
 
     FirebaseApp.initializeApp(options);

--- a/server/appengine/src/main/java/who/FirebaseModule.java
+++ b/server/appengine/src/main/java/who/FirebaseModule.java
@@ -1,0 +1,34 @@
+package who;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+
+import java.io.IOException;
+
+import javax.inject.Singleton;
+
+public class FirebaseModule extends AbstractModule {
+
+  @Provides @Singleton
+  FirebaseApp provideFirebaseApp() throws IOException {
+
+    FirebaseOptions options = new FirebaseOptions.Builder()
+      .setCredentials(GoogleCredentials.getApplicationDefault())
+      // FIXME
+      .setDatabaseUrl("https://who-myhealth-staging.firebaseio.com")
+      .build();
+
+    FirebaseApp.initializeApp(options);
+
+    return FirebaseApp.getInstance();
+  }
+
+  @Provides @Singleton
+  FirebaseMessaging provideFirebaseMessaging(FirebaseApp app) {
+    return FirebaseMessaging.getInstance(app);
+  }
+}

--- a/server/appengine/src/main/java/who/FirebaseModule.java
+++ b/server/appengine/src/main/java/who/FirebaseModule.java
@@ -17,7 +17,6 @@ public class FirebaseModule extends AbstractModule {
   FirebaseApp provideFirebaseApp(Environment env) throws IOException {
     FirebaseOptions options = new FirebaseOptions.Builder()
       .setCredentials(GoogleCredentials.getApplicationDefault())
-      // FIXME
       .setDatabaseUrl("https://" + env.firebaseApplicationId() + ".firebaseio.com")
       .build();
 

--- a/server/appengine/src/main/java/who/NotificationsManager.java
+++ b/server/appengine/src/main/java/who/NotificationsManager.java
@@ -1,0 +1,66 @@
+package who;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.collect.Sets;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.inject.Inject;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.TopicManagementResponse;
+import java.io.IOException;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.stream.Collectors;
+
+import static com.googlecode.objectify.ObjectifyService.ofy;
+
+public class NotificationsManager {
+  FirebaseMessaging fcm;
+
+  @Inject
+  public NotificationsManager(FirebaseMessaging fcm) {
+    this.fcm = fcm;
+  }
+
+  public void updateSubscriptions(Client client) throws IOException {
+    Preconditions.checkNotNull(client);
+    if (client.token == null) {
+      return;
+    }
+    SortedSet<String> finalTopics = Topics.getTopicNames(client);
+    Set<String> topicsToRemove = Sets.difference(client.subscribedTopics, finalTopics).immutableCopy();
+    Set<String> topicsToAdd = Sets.difference(finalTopics, client.subscribedTopics).immutableCopy();
+    List<String> theToken = ImmutableList.of(client.token);
+
+    try {
+      // We cannot atomically change subscription sets.  Better to have more subscriptions
+      // as the user moves locations rather than fewer, so subscribe first.
+      for (String topic : topicsToAdd) {
+        TopicManagementResponse resp = fcm.subscribeToTopic(theToken, topic);
+        if (resp.getSuccessCount() == 1) {
+          client.subscribedTopics.add(topic);
+          // If something goes wrong we'll still save the partial update.
+          ofy().defer().save().entity(client);
+        }
+      }
+
+      for (String topic : topicsToRemove) {
+        TopicManagementResponse resp = fcm.unsubscribeFromTopic(theToken, topic);
+        if (resp.getSuccessCount() == 1) {
+          client.subscribedTopics.remove(topic);
+          // If something goes wrong we'll still save the partial update.
+          ofy().defer().save().entity(client);
+        }
+      }
+    } catch (FirebaseMessagingException fme) {
+      throw new IOException(fme);
+    }
+
+    ofy().save().entity(client).now();
+  }
+}

--- a/server/appengine/src/main/java/who/Topics.java
+++ b/server/appengine/src/main/java/who/Topics.java
@@ -1,0 +1,94 @@
+package who;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Ordering;
+
+import java.text.Normalizer;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class Topics {
+  public enum Namespace {
+    LOCATION,
+  }
+
+  // In the future, users may only want to see specific kinds
+  // of notifications like alert vs general news, etc.
+  public enum NotificationType {
+    ALL,
+  }
+
+  public static final String SCOPE_SEPARATOR = "~";
+
+  static String encodeScope(String scope) {
+    // An empty string is a valid scope.
+    // We want accents to be "reduced" to their ascii counterparts.
+    String norm = Normalizer.normalize(Strings.nullToEmpty(scope), Normalizer.Form.NFD);
+    // See the following for valid characters
+    // https://github.com/firebase/firebase-admin-java/blob/2cfbc3d96d0090593828f78b497ea29c09fcaae1/src/main/java/com/google/firebase/messaging/FirebaseMessaging.java#L400
+    return norm.replaceAll(SCOPE_SEPARATOR + "|" + "[^a-zA-Z0-9-_.~%]", "_");
+  }
+
+  public static String createTopicName(NotificationType t, Namespace n, String ... scopes) {
+    Preconditions.checkArgument(scopes.length >= 1);
+    return t.toString() + SCOPE_SEPARATOR +
+      n.toString() + SCOPE_SEPARATOR +
+      String.join(SCOPE_SEPARATOR,
+        Arrays.stream(scopes)
+        .map(s -> encodeScope(s))
+        .collect(Collectors.toList()));
+  }
+
+  private static ImmutableSortedSet<String> getLocationTopicNames(NotificationType t, Client client) {
+    ImmutableSortedSet.Builder<String> topics = new ImmutableSortedSet.Builder<>(Ordering.natural());
+    if (Strings.isNullOrEmpty(client.countryCode)) {
+      return topics.build();
+    }
+
+    topics.add(createTopicName(t, Namespace.LOCATION, client.countryCode));
+    if (!Strings.isNullOrEmpty(client.adminArea1)) {
+      topics.add(createTopicName(t, Namespace.LOCATION,
+        client.countryCode, client.adminArea1));
+    }
+    // Intermediate categorizations can legitimately be empty, however we would never target
+    // an empty terminal categorization.
+    if (!Strings.isNullOrEmpty(client.adminArea2)) {
+      topics.add(createTopicName(t, Namespace.LOCATION,
+        client.countryCode, client.adminArea1, client.adminArea2));
+    }
+    if (!Strings.isNullOrEmpty(client.adminArea3)) {
+      topics.add(createTopicName(t, Namespace.LOCATION,
+        client.countryCode, client.adminArea1, client.adminArea2, client.adminArea3));
+    }
+    if (!Strings.isNullOrEmpty(client.adminArea4)) {
+      topics.add(createTopicName(t, Namespace.LOCATION,
+        client.countryCode, client.adminArea1, client.adminArea2, client.adminArea3, client.adminArea4));
+    }
+    if (!Strings.isNullOrEmpty(client.adminArea5)) {
+      topics.add(createTopicName(t, Namespace.LOCATION,
+        client.countryCode, client.adminArea1, client.adminArea2, client.adminArea3, client.adminArea4, client.adminArea5));
+    }
+    if (!Strings.isNullOrEmpty(client.locality)) {
+      topics.add(createTopicName(t, Namespace.LOCATION,
+        client.countryCode, client.adminArea1, client.adminArea2, client.adminArea3, client.adminArea4, client.adminArea5, client.locality));
+    }
+    return topics.build();
+  }
+
+  public static ImmutableSortedSet<String> getTopicNames(Client client) {
+    Preconditions.checkNotNull(client);
+    // TODO: Store these user-selected types in the Client and add
+    // an RPC to modify them.
+    NotificationType[] types = {NotificationType.ALL};
+
+    ImmutableSortedSet.Builder<String> topics = new ImmutableSortedSet.Builder<>(Ordering.natural());
+    for (NotificationType t : types) {
+      topics.addAll(getLocationTopicNames(t, client));
+    }
+  
+    return topics.build();
+  }
+}

--- a/server/appengine/src/main/java/who/WhoServiceImpl.java
+++ b/server/appengine/src/main/java/who/WhoServiceImpl.java
@@ -3,22 +3,40 @@ package who;
 import com.google.common.base.Strings;
 import com.google.common.geometry.S2CellId;
 import com.google.common.geometry.S2LatLng;
+import com.google.inject.Inject;
+
 import present.rpc.ClientException;
+
 import java.io.IOException;
+import java.util.TreeSet;
 
 import static com.googlecode.objectify.ObjectifyService.ofy;
 
 public class WhoServiceImpl implements WhoService {
+  NotificationsManager nm;
+
+  @Inject WhoServiceImpl(NotificationsManager nm) {
+    this.nm = nm;
+  }
 
   @Override public Void putDeviceToken(PutDeviceTokenRequest request) throws IOException {
     Client client = Client.current();
-    client.token = request.token;
+    if (client.token != null && client.token.equals(request.token)) {
+      // Nothing to change.
+      return new Void();
+    }
+    client.token = Strings.emptyToNull(request.token);
+    // The token changed; we will need to resubscribe to topics b/c this
+    // new token has never been subscribed to anything.
+    client.subscribedTopics = new TreeSet<String>();
     ofy().save().entities(client);
+    nm.updateSubscriptions(client);
     return new Void();
   }
 
   @Override public Void putLocation(PutLocationRequest request) throws IOException {
     Client client = Client.current();
+<<<<<<< HEAD
     S2CellId location = S2CellId.fromToken(request.s2CellIdToken);
     if (!location.isValid()) {
       throw new ClientException("Invalid s2CellId");
@@ -31,7 +49,25 @@ public class WhoServiceImpl implements WhoService {
     S2LatLng point = location.toLatLng();
     client.latitude = point.latDegrees();
     client.longitude = point.lngDegrees();
+=======
+    client.latitude = request.latitude;
+    client.longitude = request.longitude;
+    client.countryCode = Strings.emptyToNull(request.countryCode);
+    client.adminArea1 = Strings.emptyToNull(request.adminArea1);
+    client.adminArea2 = Strings.emptyToNull(request.adminArea2);
+    client.adminArea3 = Strings.emptyToNull(request.adminArea3);
+    client.adminArea4 = Strings.emptyToNull(request.adminArea4);
+    client.adminArea5 = Strings.emptyToNull(request.adminArea5);
+    client.locality = Strings.emptyToNull(request.locality);
+    if (request.latitude != null & request.longitude != null) {
+      S2LatLng coordinates = S2LatLng.fromDegrees(request.latitude, request.longitude);
+      client.location = S2CellId.fromLatLng(coordinates).id();
+    } else {
+      client.location = null;
+    }
+>>>>>>> 62c08a4... [feat] DRAFT - Subscribe clients to topics based on locations
     ofy().save().entities(client);
+    nm.updateSubscriptions(client);
     return new Void();
   }
 

--- a/server/appengine/src/main/java/who/WhoServiceImpl.java
+++ b/server/appengine/src/main/java/who/WhoServiceImpl.java
@@ -1,13 +1,11 @@
 package who;
 
 import com.google.common.base.Strings;
-import com.google.common.geometry.S2CellId;
-import com.google.common.geometry.S2LatLng;
 import com.google.inject.Inject;
-
 import present.rpc.ClientException;
 
 import java.io.IOException;
+import java.util.regex.Pattern;
 import java.util.TreeSet;
 
 import static com.googlecode.objectify.ObjectifyService.ofy;
@@ -34,38 +32,16 @@ public class WhoServiceImpl implements WhoService {
     return new Void();
   }
 
+  private static final Pattern COUNTRY_CODE = Pattern.compile("^[A-Z][A-Z]$");
+
   @Override public Void putLocation(PutLocationRequest request) throws IOException {
     Client client = Client.current();
-<<<<<<< HEAD
-    S2CellId location = S2CellId.fromToken(request.s2CellIdToken);
-    if (!location.isValid()) {
-      throw new ClientException("Invalid s2CellId");
+    // Don't even run a regex on a very long string.
+    if (request.isoCountryCode == null || request.isoCountryCode.length() != 2
+        || !COUNTRY_CODE.matcher(request.isoCountryCode).matches()) {
+      throw new ClientException("Invalid isoCountryCode");
     }
-    if (location.level() > Client.MAX_S2_CELL_LEVEL) {
-      throw new ClientException("s2CellId level too high");
-    }
-    client.location = location.id();
-    // Center of the cell.
-    S2LatLng point = location.toLatLng();
-    client.latitude = point.latDegrees();
-    client.longitude = point.lngDegrees();
-=======
-    client.latitude = request.latitude;
-    client.longitude = request.longitude;
-    client.countryCode = Strings.emptyToNull(request.countryCode);
-    client.adminArea1 = Strings.emptyToNull(request.adminArea1);
-    client.adminArea2 = Strings.emptyToNull(request.adminArea2);
-    client.adminArea3 = Strings.emptyToNull(request.adminArea3);
-    client.adminArea4 = Strings.emptyToNull(request.adminArea4);
-    client.adminArea5 = Strings.emptyToNull(request.adminArea5);
-    client.locality = Strings.emptyToNull(request.locality);
-    if (request.latitude != null & request.longitude != null) {
-      S2LatLng coordinates = S2LatLng.fromDegrees(request.latitude, request.longitude);
-      client.location = S2CellId.fromLatLng(coordinates).id();
-    } else {
-      client.location = null;
-    }
->>>>>>> 62c08a4... [feat] DRAFT - Subscribe clients to topics based on locations
+    client.isoCountryCode = request.isoCountryCode;
     ofy().save().entities(client);
     nm.updateSubscriptions(client);
     return new Void();

--- a/server/appengine/src/main/java/who/WhoServletModule.java
+++ b/server/appengine/src/main/java/who/WhoServletModule.java
@@ -2,6 +2,7 @@ package who;
 
 import com.google.apphosting.utils.remoteapi.RemoteApiServlet;
 import com.google.inject.servlet.ServletModule;
+import com.google.inject.Provides;
 import com.googlecode.objectify.ObjectifyFilter;
 import com.googlecode.objectify.ObjectifyService;
 import javax.inject.Singleton;
@@ -16,6 +17,11 @@ import static who.ForwardingServlet.forwardTo;
 public class WhoServletModule extends ServletModule {
 
   private static final Logger logger = LoggerFactory.getLogger(WhoServletModule.class);
+
+  @Provides
+  Environment provideEnvironment() {
+    return Environment.current();
+  }
 
   @Override protected void configureServlets() {
     install(new FirebaseModule());

--- a/server/appengine/src/main/java/who/WhoServletModule.java
+++ b/server/appengine/src/main/java/who/WhoServletModule.java
@@ -18,6 +18,8 @@ public class WhoServletModule extends ServletModule {
   private static final Logger logger = LoggerFactory.getLogger(WhoServletModule.class);
 
   @Override protected void configureServlets() {
+    install(new FirebaseModule());
+  
     // App Engine Remote API
     serve("/remote_api").with(new RemoteApiServlet());
 
@@ -33,10 +35,13 @@ public class WhoServletModule extends ServletModule {
     ObjectifyService.register(Client.class);
     ObjectifyService.register(StoredCaseStats.class);
 
+    bind(NotificationsManager.class).asEagerSingleton();
+
     // Internal cron jobs using Objectify but not requiring Clients.
     serve("/internal/cron/refreshCaseStats").with(new RefreshCaseStatsServlet());
 
     // Set up Present RPC
     filter("/*").through(WhoRpcFilter.class);
   }
+
 }

--- a/server/appengine/src/test/java/who/TopicsTest.java
+++ b/server/appengine/src/test/java/who/TopicsTest.java
@@ -8,21 +8,15 @@ public class TopicsTest {
 
   @Test
   public void testCreateTopicName() throws Exception {
-    assertEquals(Topics.createTopicName(Topics.NotificationType.ALL, Topics.Namespace.LOCATION, "US"), "ALL~LOCATION~US");
-    assertEquals(Topics.createTopicName(Topics.NotificationType.ALL, Topics.Namespace.LOCATION, "US", ""), "ALL~LOCATION~US~");
-    assertEquals(Topics.createTopicName(Topics.NotificationType.ALL, Topics.Namespace.LOCATION, "", "CA"), "ALL~LOCATION~~CA");
-    assertEquals(Topics.createTopicName(Topics.NotificationType.ALL, Topics.Namespace.LOCATION, "US", "CA"), "ALL~LOCATION~US~CA");
-    assertEquals(Topics.createTopicName(Topics.NotificationType.ALL, Topics.Namespace.LOCATION, "US", "CA", null, null, null, null, "San José"), "ALL~LOCATION~US~CA~~~~~San_Jose_");
-    assertEquals(Topics.createTopicName(Topics.NotificationType.ALL, Topics.Namespace.LOCATION, "U/S", "CA"), "ALL~LOCATION~U_S~CA");
+    System.err.println(Topics.createTopicName(Topics.NotificationType.ALL, Topics.Namespace.LOCATION));
+    assertEquals("ALL~LOCATION", Topics.createTopicName(Topics.NotificationType.ALL, Topics.Namespace.LOCATION));
+    assertEquals("ALL~LOCATION~US", Topics.createTopicName(Topics.NotificationType.ALL, Topics.Namespace.LOCATION, "US"));
   }
 
   @Test
   public void testTopicNames() throws Exception {
     Client c = new Client();
-    c.countryCode = "US";
-    c.adminArea1 = "CA";
-    c.adminArea2 = "San Francisco County";
-    c.locality = "San Francisco";
+    c.isoCountryCode = "US";
     System.err.println(Topics.getTopicNames(c));
   }
 }

--- a/server/appengine/src/test/java/who/TopicsTest.java
+++ b/server/appengine/src/test/java/who/TopicsTest.java
@@ -1,0 +1,28 @@
+package who;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TopicsTest {
+
+  @Test
+  public void testCreateTopicName() throws Exception {
+    assertEquals(Topics.createTopicName(Topics.NotificationType.ALL, Topics.Namespace.LOCATION, "US"), "ALL~LOCATION~US");
+    assertEquals(Topics.createTopicName(Topics.NotificationType.ALL, Topics.Namespace.LOCATION, "US", ""), "ALL~LOCATION~US~");
+    assertEquals(Topics.createTopicName(Topics.NotificationType.ALL, Topics.Namespace.LOCATION, "", "CA"), "ALL~LOCATION~~CA");
+    assertEquals(Topics.createTopicName(Topics.NotificationType.ALL, Topics.Namespace.LOCATION, "US", "CA"), "ALL~LOCATION~US~CA");
+    assertEquals(Topics.createTopicName(Topics.NotificationType.ALL, Topics.Namespace.LOCATION, "US", "CA", null, null, null, null, "San José"), "ALL~LOCATION~US~CA~~~~~San_Jose_");
+    assertEquals(Topics.createTopicName(Topics.NotificationType.ALL, Topics.Namespace.LOCATION, "U/S", "CA"), "ALL~LOCATION~U_S~CA");
+  }
+
+  @Test
+  public void testTopicNames() throws Exception {
+    Client c = new Client();
+    c.countryCode = "US";
+    c.adminArea1 = "CA";
+    c.adminArea2 = "San Francisco County";
+    c.locality = "San Francisco";
+    System.err.println(Topics.getTopicNames(c));
+  }
+}

--- a/server/appengine/src/test/java/who/TopicsTest.java
+++ b/server/appengine/src/test/java/who/TopicsTest.java
@@ -12,11 +12,4 @@ public class TopicsTest {
     assertEquals("ALL~LOCATION", Topics.createTopicName(Topics.NotificationType.ALL, Topics.Namespace.LOCATION));
     assertEquals("ALL~LOCATION~US", Topics.createTopicName(Topics.NotificationType.ALL, Topics.Namespace.LOCATION, "US"));
   }
-
-  @Test
-  public void testTopicNames() throws Exception {
-    Client c = new Client();
-    c.isoCountryCode = "US";
-    System.err.println(Topics.getTopicNames(c));
-  }
 }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -18,6 +18,7 @@ buildscript {
             'api': "org.slf4j:slf4j-api:${versions.slf4j}",
             'jdk14': "org.slf4j:slf4j-jdk14:${versions.slf4j}",
         ],
+        'firebase': "com.google.firebase:firebase-admin:6.12.2",
         'guava': "com.google.guava:guava:27.0.1-jre",
         'gson': "com.google.code.gson:gson:2.8.5",
         'servlet': "javax.servlet:javax.servlet-api:3.1.0",

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -19,6 +19,7 @@ buildscript {
             'jdk14': "org.slf4j:slf4j-jdk14:${versions.slf4j}",
         ],
         'firebase': "com.google.firebase:firebase-admin:6.12.2",
+        'netty': 'io.netty:netty-codec-http:4.1.46.Final',
         'guava': "com.google.guava:guava:27.0.1-jre",
         'gson': "com.google.code.gson:gson:2.8.5",
         'servlet': "javax.servlet:javax.servlet-api:3.1.0",


### PR DESCRIPTION
Closes #1221, closes #1000

Client already sends isoCountryCode, this saves it.
It will also register the client for topics `ALL~LOCATION` (global) and `ALL~LOCATION~isoCountryCode` (per country) topics.

In the future we could have `TESTINGCENTERS~LOCATION~isoCountryCode` etc. if users only want a few types of notifications.

[redacted] GCP traces:

```
2: {
time: "2020-05-14T01:53:50.355Z"
severity: "INFO"
logMessage: "who.NotificationsManager updateSubscriptions: SUCCESS - Subscribed d0zOdIG6[redacted]KusQJXig2uNK8gSFgxBD1hjmBGE4XyQQQvzbOVP to topic ALL~LOCATION
"
sourceLocation: {3}
}
3: {
time: "2020-05-14T01:53:50.660Z"
severity: "INFO"
logMessage: "who.NotificationsManager updateSubscriptions: SUCCESS - Subscribed d0zOdIG[redacted]KusQJXig2uNK8gSFgxBD1hjmBGE4XyQQQvzbOVP to topic ALL~LOCATION~US
"
sourceLocation: {3}
}
```

The topics are available in FCM console:

<img width="405" alt="Screen Shot 2020-05-13 at 6 10 06 PM" src="https://user-images.githubusercontent.com/11729521/81882478-b0398e00-9547-11ea-9291-5d2d66475b56.png">
