### PR TITLE
Add a period after "Pneumonia vaccines..."

### DIFF
--- a/client/flutter/assets/content_bundles/get_the_facts.en.yaml
+++ b/client/flutter/assets/content_bundles/get_the_facts.en.yaml
@@ -50,7 +50,7 @@ contents:
       image_name: streamline-gtf-spray
     -
       title_html: |
-        Pneumonia vaccines <b><u>do not</u></b> protect against the new coronavirus
+        Pneumonia vaccines <b><u>do not</u></b> protect against the new coronavirus.
       body_html: |
         <p>There are no vaccines for the new coronavirus yet. WHO supports researchers currently working to develop a new vaccine against the virus.</p>
         <p>Although vaccines against pneumonia do not prevent or protect people from the new coronavirus, they're highly recommended for other respiratory illnesses.</p>


### PR DESCRIPTION
For consistency with the other titles on the page.