### PR TITLE
Update release documentation for processes on QA testing, preparing a release

### DIFF
--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -59,6 +59,7 @@ We use Firebase App Distribution to distribute apps to testers before the app ge
 ### Push to stores
 
 1. [ ] Determine drop-dead time for:
+
    - Stopping code churn
    - Finalizing release in Github
    - Pushing build from GitHub to WHO
@@ -68,7 +69,7 @@ We use Firebase App Distribution to distribute apps to testers before the app ge
 1. [ ] Get all [checkoffs](#checkoffs).
 1. [ ] Prepare a new release version; see [prepare-release.md](prepare-release.md) for more information on the steps needed for this.
 1. [ ] WHO will check out the code from GitHub at the specified release tag. They will **build and sign** the iOS / Android binaries using **their keys**. More information on the steps WHO should perform to create a manual build is found in [manual-build.md](manual-build.md).
-1. [ ] iOS: WHO will upload build to TestFlight. 
+1. [ ] iOS: WHO will upload build to TestFlight.
 1. [ ] Android: WHO will upload build to the Play Store and create a new "Alpha" release.
 1. [ ] Double check that WHO has uploaded and updated the text / image assets that we want.
 

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -58,13 +58,12 @@ We use Firebase App Distribution to distribute apps to testers before the app ge
 
 ### Push to stores
 
-1. Determine drop-dead time for:
-
-- [ ] Stopping code churn
-- [ ] Finalizing release in Github
-- [ ] Pushing build from GitHub to WHO
-- [ ] Alpha release planned date
-- [ ] Production release planned date
+1. [ ] Determine drop-dead time for:
+   - Stopping code churn
+   - Finalizing release in Github
+   - Pushing build from GitHub to WHO
+   - Alpha release planned date
+   - Production release planned date
 
 1. [ ] Get all [checkoffs](#checkoffs).
 1. [ ] Prepare a new release version; see [prepare-release.md](prepare-release.md) for more information on the steps needed for this.

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -45,6 +45,17 @@ Items that are still under discussion / not ready to be used for v1.0 currently 
    1. [ ] Design
    1. [ ] Compliance
 
+## QA testing with Firebase App Distribution
+
+We use Firebase App Distribution to distribute apps to testers before the app gets deployed onto the App Store / Play Store. We currently do this only for Android; we do not release code for iOS until the TestFlight phase.
+
+1. [ ] Build the app on a local developer's computer. The app can be signed with a Debug certificate and can be built by running `flutter build apk`. Note that the version does not necessarily need to be incremented here.
+1. [ ] Upload the release apk to Firebase App Distribution. Make sure it is shared with "internal-testers-app-team" and provide the following text in the release notes: "Not a demo -- this release is only meant for internal testing."
+1. [ ] QA testers will fill out any issues they find on a Bug Bash form.
+1. [ ] We will triage these issues as needed. If a serious issue is detected, fix the issue and restart the release process.
+
+:construction: This process may soon be automated by [#1293](https://github.com/WorldHealthOrganization/app/pull/1293)
+
 ### Push to stores
 
 1. Determine drop-dead time for:
@@ -55,28 +66,18 @@ Items that are still under discussion / not ready to be used for v1.0 currently 
 - [ ] Alpha release planned date
 - [ ] Production release planned date
 
-1. [ ] Get all [checkoffs](#checkoffs)
-1. [ ] Upload all assets needed to Google Drive and share it with the WHO
-1. [ ] WHO will check out the code from GitHub at the specified release tag. They will **build and sign** the iOS / Android binaries using **their keys**.
-1. [ ] WHO will fill in store information and update screenshots from the Google Drive folder.
-1. [ ] iOS: WHO will upload build to TestFlight. They will also submit the build for app review and select "Manually release this version".
+1. [ ] Get all [checkoffs](#checkoffs).
+1. [ ] Prepare a new release version; see [prepare-release.md](prepare-release.md) for more information on the steps needed for this.
+1. [ ] WHO will check out the code from GitHub at the specified release tag. They will **build and sign** the iOS / Android binaries using **their keys**. More information on the steps WHO should perform to create a manual build is found in [manual-build.md](manual-build.md).
+1. [ ] iOS: WHO will upload build to TestFlight. 
 1. [ ] Android: WHO will upload build to the Play Store and create a new "Alpha" release.
 1. [ ] Double check that WHO has uploaded and updated the text / image assets that we want.
 
-## QA and testing
-
-We use Firebase App Distribution, TestFlight beta, and the Google Play Alpha channel for testing.
-
-1. [ ] Set up a new release on TestFlight beta with an open link for testing iOS with QA.
-1. [ ] Upload the release apk to Firebase App Distribution -- we use an open link with Firebase App Distribution for testing Android with QA.
-1. [ ] Publish beta testing URLs for both Android and iOS to Slack.
-1. [ ] Promote the apk on the Play Store to the Alpha channel -- we use closed Alpha testing for non-QA testing for Android.
-1. [ ] QA testers will fill out any issues they find on a Bug Bash form.
-1. [ ] We will triage these issues as needed. If a serious issue is detected, fix the issue and restart the release process.
-
 ## Release to production
 
-1. [ ] Once the App Store review approval has been granted, WHO should manually release the new version.
+1. [ ] Upload all assets needed to a Google Drive folder and share it with the WHO.
+1. [ ] WHO will fill in store information and update screenshots from the Google Drive folder.
+1. [ ] iOS: WHO will submit the build for app review and select "Manually release this version". WHO should manually release the new version.
 1. [ ] WHO should promote the Play Store release to "Production".
 
 ## :construction: Post-release tasks

--- a/docs/release/manual-build.md
+++ b/docs/release/manual-build.md
@@ -23,7 +23,7 @@ Tools • Dart 2.8.1
 In order to ensure reproducibility, you will always build from a specified `TAG_NAME` (e.g. `v0.1.0`) and should not change bundle/application ids or version or build numbers that are stored in the git repository.
 
 ```
-git clone -b TAG_NAME https://github.com/WorldHealthOrganization/app.git
+git clone -b release/$TAG_NAME https://github.com/WorldHealthOrganization/app-private-who.git
 cd app
 ```
 

--- a/docs/release/manual-build.md
+++ b/docs/release/manual-build.md
@@ -23,7 +23,7 @@ Tools • Dart 2.8.1
 In order to ensure reproducibility, you will always build from a specified `TAG_NAME` (e.g. `v0.1.0`) and should not change bundle/application ids or version or build numbers that are stored in the git repository.
 
 ```
-git clone -b release/$TAG_NAME https://github.com/WorldHealthOrganization/app-private-who.git
+git clone -b $TAG_NAME https://github.com/WorldHealthOrganization/app-private-who.git
 cd app
 ```
 

--- a/docs/release/prepare-release.md
+++ b/docs/release/prepare-release.md
@@ -1,0 +1,30 @@
+# Preparing a new release
+
+_Note these instructions are only for creating a release version of the app that can be used by WHO, not for the entire release lifecycle. For the latter, see [here](../README.md)._
+
+## Add the WHO private repo
+
+The WHO private repo has production configuration and private assets that are not in this repository. Clone this repository and fetch its branches:
+
+```
+git remote add release https://github.com/WorldHealthOrganization/app-private-who.git
+git fetch release
+```
+
+## Create a new release branch
+
+Create a release branch; it should be named `release/vX.X.X` where `X.X.X` is the app version. Merge in the release branch from the previous version, so that the produciton configuration and private assets are added, and finally push this branch to the private repository.
+
+```
+git checkout -b release/v0.11.0
+git merge release/v0.10.0
+git push release release/v0.11.0
+```
+
+## Create a tag and release
+
+Go to the "Releases" section of the app-private-who GitHub repository. Create a new tag with the release name (such as `v0.11.0`), and add a description of what has been changed.
+
+## Next steps
+
+Steps for building the app on the WHO's end are found in [manual-build.md](manual-build.md).


### PR DESCRIPTION
Update release documentation with the latest processes we have been using. I've updated:
- the QA testing process
- the process of preparing a release for the WHO to use
- the WHO's process of pulling a release and building it

@hspinks let me know if I covered all the steps you've been taking in prepare-release.md.