### PR TITLE
Fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,10 +19,3 @@ updates:
     labels:
       - "t:deps"
       - "c:server"
-  - package-ecosystem: "gradle"
-    directory: "/server/appengine"
-    schedule:
-      interval: "daily"
-    labels:
-      - "t:deps"
-      - "c:server"


### PR DESCRIPTION
Top level server is enough, don't need subpath
