### PR TITLE
Re-TOS & re-onboard all users

### DIFF
--- a/client/flutter/lib/api/user_preferences.dart
+++ b/client/flutter/lib/api/user_preferences.dart
@@ -28,6 +28,19 @@ class UserPreferences {
         .setBool(UserPreferenceKey.OnboardingCompleted.toString(), value);
   }
 
+  /// Was the user shown the introductory pages as part of onboarding, using updated key for V1 launch
+  Future<bool> getOnboardingCompletedV1() async {
+    return (await SharedPreferences.getInstance())
+            .getBool(UserPreferenceKey.OnboardingCompletedV1.toString()) ??
+        false;
+  }
+
+  /// Was the user shown the introductory pages as part of onboarding, using updated key for V1 launch
+  Future<bool> setOnboardingCompletedV1(bool value) async {
+    return (await SharedPreferences.getInstance())
+        .setBool(UserPreferenceKey.OnboardingCompletedV1.toString(), value);
+  }
+
   Future<bool> getTermsOfServiceCompleted() async {
     return (await SharedPreferences.getInstance())
             .getBool(UserPreferenceKey.TermsOfServiceCompleted.toString()) ??
@@ -114,6 +127,7 @@ class UserPreferences {
 
 enum UserPreferenceKey {
   OnboardingCompleted,
+  OnboardingCompletedV1,
   TermsOfServiceCompleted,
   AnalyticsEnabled,
   NotificationsEnabled,

--- a/client/flutter/lib/main.dart
+++ b/client/flutter/lib/main.dart
@@ -45,7 +45,7 @@ void mainImpl({@required Map<String, WidgetBuilder> routes}) async {
   }
 
   final bool onboardingComplete =
-      await UserPreferences().getOnboardingCompleted();
+      await UserPreferences().getOnboardingCompletedV1();
 
   // Comment the above lines out and uncomment this to force onboarding in development
   // final bool onboardingComplete = false;
@@ -67,14 +67,14 @@ void mainImpl({@required Map<String, WidgetBuilder> routes}) async {
 }
 
 Future<void> _onFlutterError(FlutterErrorDetails details) async {
-  if (await UserPreferences().getOnboardingCompleted()) {
+  if (await UserPreferences().getOnboardingCompletedV1()) {
     // Pass all uncaught errors from the framework to Crashlytics.
     await Crashlytics.instance.recordFlutterError(details);
   }
 }
 
 Future<void> _onError(Object error, StackTrace stack) async {
-  if (await UserPreferences().getOnboardingCompleted()) {
+  if (await UserPreferences().getOnboardingCompletedV1()) {
     await Crashlytics.instance.recordError(error, stack);
   }
 }

--- a/client/flutter/lib/pages/onboarding/onboarding_page.dart
+++ b/client/flutter/lib/pages/onboarding/onboarding_page.dart
@@ -121,7 +121,10 @@ class _OnboardingPageState extends State<OnboardingPage> {
     await UserPreferences().setTermsOfServiceCompleted(true);
     // Enable auto init so that analytics will work
     await _firebaseMessaging.setAutoInitEnabled(true);
-    await UserPreferences().setAnalyticsEnabled(true);
+    if (!await UserPreferences().getOnboardingCompleted() ||
+        await UserPreferences().getAnalyticsEnabled()) {
+      await UserPreferences().setAnalyticsEnabled(true);
+    }
 
     // ignore: unawaited_futures
     store.update();
@@ -144,7 +147,7 @@ class _OnboardingPageState extends State<OnboardingPage> {
   }
 
   void _onDone() async {
-    await UserPreferences().setOnboardingCompleted(true);
+    await UserPreferences().setOnboardingCompletedV1(true);
     await Navigator.of(context, rootNavigator: true).pushReplacementNamed(
       '/home',
     );


### PR DESCRIPTION
Closes #1302

Keeps the user's preference for disabling analytics if they previously opted out (tested locally). Note this will still show the user the notification permission request screen even if they have already turned it on or rejected the native dialog.

---

#### Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).

- [x] REQUIRED: Do you have an Issue **assigned to you** for this PR?
- [x] Provided detailed pull request description and a succinct title
- [x] Tested your changes, especially after any code review iterations.
- [x] ~Included any relevant screenshots of UI updates.~
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [content/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/content/credits.yaml) file (if you want it to be).
