### PR TITLE
Fixes #1290, Fixes #1467: Load country specific-content, and fix country list bug

### DIFF
--- a/client/flutter/lib/api/content/content_loading.dart
+++ b/client/flutter/lib/api/content/content_loading.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'package:who_app/api/user_preferences.dart';
 import 'package:who_app/api/who_service.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:flutter/cupertino.dart';
@@ -20,10 +19,10 @@ class ContentService {
 
   /// Load a localized content bundle loaded preferentially from the network, falling back
   /// to a local asset.  If no bundle can be found with the specified name an exception is thrown.
-  Future<ContentBundle> load(Locale locale, String name) async {
+  Future<ContentBundle> load(
+      Locale locale, String countryIsoCode, String name) async {
     var languageCode = locale.languageCode;
-    var countryCode =
-        (await UserPreferences().getCountryIsoCode()) ?? locale.countryCode;
+    var countryCode = countryIsoCode ?? locale.countryCode;
     var languageAndCountry = "${languageCode}_${countryCode}";
     var unsupportedSchemaVersionAvailable = false;
 

--- a/client/flutter/lib/api/content/content_store.dart
+++ b/client/flutter/lib/api/content/content_store.dart
@@ -17,15 +17,22 @@ import 'package:who_app/api/user_preferences.dart';
 part 'content_store.g.dart';
 
 class ContentStore extends _ContentStore with _$ContentStore {
-  ContentStore({@required ContentService service, @required Locale locale})
-      : super(service: service, locale: locale);
+  ContentStore(
+      {@required ContentService service,
+      @required Locale locale,
+      @required String countryIsoCode})
+      : super(service: service, locale: locale, countryIsoCode: countryIsoCode);
 }
 
 abstract class _ContentStore with Store implements Updateable {
   final Locale locale;
   final ContentService service;
+  final String countryIsoCode;
 
-  _ContentStore({@required this.service, @required this.locale});
+  _ContentStore(
+      {@required this.service,
+      @required this.locale,
+      @required this.countryIsoCode});
 
   bool _unsupportedSchemaVersionAvailable(ContentBase cb) =>
       cb?.bundle?.unsupportedSchemaVersionAvailable ?? false;
@@ -78,50 +85,53 @@ abstract class _ContentStore with Store implements Updateable {
     }
     print('ContentStore update');
 
-    logicContext = await LogicContext.generate();
+    logicContext = await LogicContext.generate(isoCountryCode: countryIsoCode);
     // Note the logic enforcing that only *newer* versions replace older versions in
     // the *cache* must be enforced elsewhere.
-    final travelAdvice2 =
-        AdviceContent(await service.load(locale, 'travel_advice'));
+    final travelAdvice2 = AdviceContent(
+        await service.load(locale, countryIsoCode, 'travel_advice'));
     if (travelAdvice?.bundle?.contentVersion !=
         travelAdvice2?.bundle?.contentVersion) {
       travelAdvice = travelAdvice2;
     }
-    final getTheFacts2 =
-        FactContent(await service.load(locale, 'get_the_facts'));
+    final getTheFacts2 = FactContent(
+        await service.load(locale, countryIsoCode, 'get_the_facts'));
     if (getTheFacts?.bundle?.contentVersion !=
         getTheFacts2?.bundle?.contentVersion) {
       getTheFacts = getTheFacts2;
     }
-    final protectYourself2 =
-        FactContent(await service.load(locale, 'protect_yourself'));
+    final protectYourself2 = FactContent(
+        await service.load(locale, countryIsoCode, 'protect_yourself'));
     if (protectYourself?.bundle?.contentVersion !=
         protectYourself2?.bundle?.contentVersion) {
       protectYourself = protectYourself2;
     }
-    final homeIndex2 = IndexContent(await service.load(locale, 'home_index'));
+    final homeIndex2 =
+        IndexContent(await service.load(locale, countryIsoCode, 'home_index'));
     if (homeIndex?.bundle?.contentVersion !=
         homeIndex2?.bundle?.contentVersion) {
       homeIndex = homeIndex2;
     }
-    final learnIndex2 = IndexContent(await service.load(locale, 'learn_index'));
+    final learnIndex2 =
+        IndexContent(await service.load(locale, countryIsoCode, 'learn_index'));
     if (learnIndex?.bundle?.contentVersion !=
         learnIndex2?.bundle?.contentVersion) {
       learnIndex = learnIndex2;
     }
-    final newsIndex2 = IndexContent(await service.load(locale, 'news_index'));
+    final newsIndex2 =
+        IndexContent(await service.load(locale, countryIsoCode, 'news_index'));
     if (newsIndex?.bundle?.contentVersion !=
         newsIndex2?.bundle?.contentVersion) {
       newsIndex = newsIndex2;
     }
-    final questionsAnswered2 =
-        QuestionContent(await service.load(locale, 'your_questions_answered'));
+    final questionsAnswered2 = QuestionContent(
+        await service.load(locale, countryIsoCode, 'your_questions_answered'));
     if (questionsAnswered?.bundle?.contentVersion !=
         questionsAnswered2?.bundle?.contentVersion) {
       questionsAnswered = questionsAnswered2;
     }
-    final symptomChecker2 =
-        SymptomCheckerContent(await service.load(locale, 'symptom_checker'));
+    final symptomChecker2 = SymptomCheckerContent(
+        await service.load(locale, countryIsoCode, 'symptom_checker'));
     if (symptomChecker?.bundle?.contentVersion !=
         symptomChecker2?.bundle?.contentVersion) {
       symptomChecker = symptomChecker2;

--- a/client/flutter/lib/api/display_conditions.dart
+++ b/client/flutter/lib/api/display_conditions.dart
@@ -26,12 +26,13 @@ class LogicContext {
 
   static final _refDate = DateTime(2020);
 
-  static Future<LogicContext> generate() async {
+  static Future<LogicContext> generate(
+      {@required String isoCountryCode}) async {
     final now = DateTime.now().toUtc();
     final diff = now.toLocal().difference(_refDate).inDays;
     return LogicContext(
       cohort: await UserPreferences().getCohort(),
-      isoCountryCode: await UserPreferences().getCountryIsoCode(),
+      isoCountryCode: isoCountryCode,
       isoDateTimeUTC: now.toIso8601String(),
       localDays: diff,
     );

--- a/client/flutter/lib/api/user_preferences.dart
+++ b/client/flutter/lib/api/user_preferences.dart
@@ -6,6 +6,10 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:uuid/uuid.dart';
 import 'package:uuid/uuid_util.dart';
 
+// TODO: Delete this class.  The use of this class directly by new UI code is discouraged.
+// Instead, rely on a Provider-supplied UserPreferencesStore and manipulate the properties therein.
+// To avoid inconsistencies, a user preference must be implemented either in this class
+// or UserPreferencesStore, but not both.
 class UserPreferences {
   static final UserPreferences _singleton = UserPreferences._internal();
 
@@ -112,16 +116,6 @@ class UserPreferences {
       await prefs.setInt(UserPreferenceKey.ExperimentCohort.toString(), cohort);
     }
     return cohort;
-  }
-
-  Future<bool> setCountryIsoCode(String value) async {
-    return (await SharedPreferences.getInstance())
-        .setString(UserPreferenceKey.CountryISOCode.toString(), value);
-  }
-
-  Future<String> getCountryIsoCode() async {
-    return (await SharedPreferences.getInstance())
-        .getString(UserPreferenceKey.CountryISOCode.toString());
   }
 }
 

--- a/client/flutter/lib/api/user_preferences_store.dart
+++ b/client/flutter/lib/api/user_preferences_store.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/foundation.dart';
+import 'package:mobx/mobx.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:who_app/api/user_preferences.dart';
+
+// Whenever this file is modified, regenerate the .g.dart file using the command:
+// flutter packages pub run build_runner build
+part 'user_preferences_store.g.dart';
+
+class UserPreferencesStore extends _UserPreferencesStore
+    with _$UserPreferencesStore {
+  UserPreferencesStore.empty();
+
+  static Future<UserPreferencesStore> readFromSharedPreferences() async {
+    final ret = UserPreferencesStore.empty();
+    ret.obsCountryIsoCode = await _getCountryIsoCode();
+    return ret;
+  }
+
+  static Future<String> _getCountryIsoCode() async {
+    return (await SharedPreferences.getInstance())
+        .getString(UserPreferenceKey.CountryISOCode.toString());
+  }
+}
+
+abstract class _UserPreferencesStore with Store {
+  _UserPreferencesStore();
+
+  @observable
+  @protected
+  String obsCountryIsoCode;
+
+  String get countryIsoCode {
+    return obsCountryIsoCode;
+  }
+
+  @action
+  Future<bool> setCountryIsoCode(String newValue) async {
+    obsCountryIsoCode = newValue;
+    return _setPrefCountryIsoCode(newValue);
+  }
+
+  static Future<bool> _setPrefCountryIsoCode(String value) async {
+    return (await SharedPreferences.getInstance())
+        .setString(UserPreferenceKey.CountryISOCode.toString(), value);
+  }
+}

--- a/client/flutter/lib/api/user_preferences_store.g.dart
+++ b/client/flutter/lib/api/user_preferences_store.g.dart
@@ -1,0 +1,43 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'user_preferences_store.dart';
+
+// **************************************************************************
+// StoreGenerator
+// **************************************************************************
+
+// ignore_for_file: non_constant_identifier_names, unnecessary_brace_in_string_interps, unnecessary_lambdas, prefer_expression_function_bodies, lines_longer_than_80_chars, avoid_as, avoid_annotating_with_dynamic
+
+mixin _$UserPreferencesStore on _UserPreferencesStore, Store {
+  final _$obsCountryIsoCodeAtom =
+      Atom(name: '_UserPreferencesStore.obsCountryIsoCode');
+
+  @override
+  String get obsCountryIsoCode {
+    _$obsCountryIsoCodeAtom.reportRead();
+    return super.obsCountryIsoCode;
+  }
+
+  @override
+  set obsCountryIsoCode(String value) {
+    _$obsCountryIsoCodeAtom.reportWrite(value, super.obsCountryIsoCode, () {
+      super.obsCountryIsoCode = value;
+    });
+  }
+
+  final _$setCountryIsoCodeAsyncAction =
+      AsyncAction('_UserPreferencesStore.setCountryIsoCode');
+
+  @override
+  Future<bool> setCountryIsoCode(String newValue) {
+    return _$setCountryIsoCodeAsyncAction
+        .run(() => super.setCountryIsoCode(newValue));
+  }
+
+  @override
+  String toString() {
+    return '''
+obsCountryIsoCode: ${obsCountryIsoCode}
+    ''';
+  }
+}

--- a/client/flutter/lib/pages/main_pages/routes.dart
+++ b/client/flutter/lib/pages/main_pages/routes.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:who_app/api/content/content_loading.dart';
 import 'package:who_app/api/content/content_store.dart';
 import 'package:who_app/api/stats_store.dart';
+import 'package:who_app/api/user_preferences_store.dart';
 import 'package:who_app/api/who_service.dart';
 import 'package:who_app/generated/l10n.dart';
 import 'package:who_app/pages/about_page.dart';
@@ -24,8 +25,10 @@ class Routes {
     '/home': (context) =>
         AppTabRouter(AppTabRouter.defaultTabs, AppTabRouter.defaultNavItems),
     '/about': (context) => AboutPage(),
-    '/onboarding': (context) =>
-        OnboardingPage(service: Provider.of<WhoService>(context)),
+    '/onboarding': (context) => OnboardingPage(
+          service: Provider.of<WhoService>(context),
+          prefs: Provider.of<UserPreferencesStore>(context),
+        ),
     '/travel-advice': (context) => TravelAdvice(
           dataSource: Provider.of<ContentStore>(context),
         ),

--- a/client/flutter/lib/pages/onboarding/onboarding_page.dart
+++ b/client/flutter/lib/pages/onboarding/onboarding_page.dart
@@ -2,6 +2,7 @@ import 'package:provider/provider.dart';
 import 'package:who_app/api/content/content_store.dart';
 import 'package:who_app/api/iso_country.dart';
 import 'package:who_app/api/user_preferences.dart';
+import 'package:who_app/api/user_preferences_store.dart';
 import 'package:who_app/api/who_service.dart';
 import 'package:who_app/pages/onboarding/country_list_page.dart';
 import 'package:who_app/pages/onboarding/country_select_page.dart';
@@ -11,9 +12,11 @@ import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/cupertino.dart';
 
 class OnboardingPage extends StatefulWidget {
-  const OnboardingPage({Key key, @required this.service}) : super(key: key);
+  const OnboardingPage({Key key, @required this.service, @required this.prefs})
+      : super(key: key);
 
   final WhoService service;
+  final UserPreferencesStore prefs;
 
   @override
   _OnboardingPageState createState() => _OnboardingPageState();
@@ -80,7 +83,12 @@ class _OnboardingPageState extends State<OnboardingPage> {
         children: <Widget>[
           LegalLandingPage(onNext: () => _onLegalDone(store)),
           CountrySelectPage(
-            onOpenCountryList: _toNextPage,
+            onOpenCountryList: () async {
+              await setState(() {
+                _showCountryListPage = true;
+              });
+              await _toNextPage();
+            },
             onNext: _onChooseCountry,
             countryName: _selectedCountry?.name,
           ),
@@ -104,7 +112,7 @@ class _OnboardingPageState extends State<OnboardingPage> {
   }
 
   Future<void> _onChooseCountry() async {
-    await UserPreferences().setCountryIsoCode(_selectedCountry.alpha2Code);
+    await widget.prefs.setCountryIsoCode(_selectedCountry.alpha2Code);
     await setState(() {
       _showCountryListPage = false;
     });

--- a/client/flutter/lib/pages/symptom_checker/symptom_checker_view.dart
+++ b/client/flutter/lib/pages/symptom_checker/symptom_checker_view.dart
@@ -4,6 +4,7 @@ import 'package:who_app/api/content/content_loading.dart';
 import 'package:who_app/api/content/content_store.dart';
 import 'package:who_app/api/content/schema/symptom_checker_content.dart';
 import 'package:who_app/api/display_conditions.dart';
+import 'package:who_app/api/user_preferences_store.dart';
 import 'package:who_app/components/dialogs.dart';
 import 'package:who_app/components/page_scaffold/page_header.dart';
 import 'package:who_app/components/themed_text.dart';
@@ -45,9 +46,16 @@ class _SymptomCheckerViewState extends State<SymptomCheckerView>
     // TODO: Reduce this boilerplate
     Locale locale = Localizations.localeOf(context);
     try {
-      final logicContext = await LogicContext.generate();
-      final store =
-          ContentStore(service: widget.contentService, locale: locale);
+      final countryIsoCode =
+          (await UserPreferencesStore.readFromSharedPreferences())
+              .countryIsoCode;
+      final logicContext =
+          await LogicContext.generate(isoCountryCode: countryIsoCode);
+      final store = ContentStore(
+        service: widget.contentService,
+        locale: locale,
+        countryIsoCode: countryIsoCode,
+      );
       await store.update();
       var content = store.symptomChecker;
       await Dialogs.showUpgradeDialogIfNeededFor(context, content);

--- a/client/flutter/pubspec.lock
+++ b/client/flutter/pubspec.lock
@@ -427,6 +427,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.4"
+  observer_provider:
+    dependency: "direct main"
+    description:
+      name: observer_provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1+2"
   package_config:
     dependency: transitive
     description:

--- a/client/flutter/pubspec.yaml
+++ b/client/flutter/pubspec.yaml
@@ -53,6 +53,7 @@ dependencies:
   fl_chart: ^0.8.7
   notification_permissions: ^0.4.4
   expressions: 0.1.5
+  observer_provider: 0.0.1+2
 
   intl: ^0.16.0
   flutter_localizations:


### PR DESCRIPTION
By default we will use locale-country, but once a user selects a country,
we will actually use that country in the content YAML loading.

This starts the proper refactor of UserPreferences into a Store to use
it as an observable dependency.

Dependency: observer_producer - a verified dep I open-sourced from work

Fixes #1290, Fixes #1467

TESTED=Look at the logs as you change the country showing which YAML files are loaded.