### PR TITLE
🏡 New home promo ; 🆕 use newer content ; and more fixes

### DIFF
--- a/client/flutter/assets/content_bundles/home_index.en.yaml
+++ b/client/flutter/assets/content_bundles/home_index.en.yaml
@@ -1,14 +1,14 @@
 schema_version: 1
-content_version: 3
+content_version: 4
 contents:
   type: index
   promos:
     -
-      promo_type: check_your_symptoms
-      title: Track Your Symptoms
-      subtitle: Keep track of how you're feeling to stay on top of your health
-      button_text: Track Now
-      href: /symptom-checker
+      promo_type: protect_yourself
+      title: Protect yourself
+      subtitle: Learn how to keep yourself safe during this pandemic.
+      button_text: Learn more
+      href: /protect-yourself
       image_name: undraw-home-promo-symptoms
   items:
     -

--- a/client/flutter/ios/.gitignore
+++ b/client/flutter/ios/.gitignore
@@ -3,6 +3,7 @@
 *.moved-aside
 *.pbxuser
 *.perspectivev3
+.last_build_id
 **/*sync/
 .sconsign.dblite
 .tags*

--- a/client/flutter/ios/Podfile.lock
+++ b/client/flutter/ios/Podfile.lock
@@ -1,4 +1,11 @@
 PODS:
+  - connectivity (0.0.1):
+    - Flutter
+    - Reachability
+  - connectivity_for_web (0.1.0):
+    - Flutter
+  - connectivity_macos (0.0.1):
+    - Flutter
   - Crashlytics (3.14.0):
     - Fabric (~> 1.10.2)
   - Fabric (1.10.2)
@@ -112,6 +119,7 @@ PODS:
     - Flutter
   - PromisesObjC (1.2.8)
   - Protobuf (3.11.4)
+  - Reachability (3.2)
   - share (0.5.2):
     - Flutter
   - shared_preferences (0.0.1):
@@ -131,6 +139,9 @@ PODS:
     - Flutter
 
 DEPENDENCIES:
+  - connectivity (from `.symlinks/plugins/connectivity/ios`)
+  - connectivity_for_web (from `.symlinks/plugins/connectivity_for_web/ios`)
+  - connectivity_macos (from `.symlinks/plugins/connectivity_macos/ios`)
   - firebase_analytics (from `.symlinks/plugins/firebase_analytics/ios`)
   - firebase_crashlytics (from `.symlinks/plugins/firebase_crashlytics/ios`)
   - firebase_messaging (from `.symlinks/plugins/firebase_messaging/ios`)
@@ -169,8 +180,15 @@ SPEC REPOS:
     - nanopb
     - PromisesObjC
     - Protobuf
+    - Reachability
 
 EXTERNAL SOURCES:
+  connectivity:
+    :path: ".symlinks/plugins/connectivity/ios"
+  connectivity_for_web:
+    :path: ".symlinks/plugins/connectivity_for_web/ios"
+  connectivity_macos:
+    :path: ".symlinks/plugins/connectivity_macos/ios"
   firebase_analytics:
     :path: ".symlinks/plugins/firebase_analytics/ios"
   firebase_crashlytics:
@@ -205,6 +223,9 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/url_launcher_web/ios"
 
 SPEC CHECKSUMS:
+  connectivity: c4130b2985d4ef6fd26f9702e886bd5260681467
+  connectivity_for_web: 2b8584556930d4bd490d82b836bcf45067ce345b
+  connectivity_macos: e2e9731b6b22dda39eb1b128f6969d574460e191
   Crashlytics: 540b7e5f5da5a042647227a5e3ac51d85eed06df
   Fabric: 706c8b8098fff96c33c0db69cbf81f9c551d0d74
   Firebase: f378c80340dd41c0ad0914af740c021eb282a04b
@@ -232,6 +253,7 @@ SPEC CHECKSUMS:
   path_provider_macos: f760a3c5b04357c380e2fddb6f9db6f3015897e0
   PromisesObjC: c119f3cd559f50b7ae681fa59dc1acd19173b7e6
   Protobuf: 176220c526ad8bd09ab1fb40a978eac3fef665f7
+  Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   share: bae0a282aab4483288913fc4dc0b935d4b491f2e
   shared_preferences: 430726339841afefe5142b9c1f50cb6bd7793e01
   shared_preferences_macos: f3f29b71ccbb56bf40c9dd6396c9acf15e214087

--- a/client/flutter/lib/api/content/content_store.dart
+++ b/client/flutter/lib/api/content/content_store.dart
@@ -76,6 +76,15 @@ abstract class _ContentStore with Store implements Updateable {
   @observable
   PosterContent symptomPoster;
 
+  Future<void> updateBundle<T extends ContentBase>(String name, T old,
+      T Function(ContentBundle) constructor, void Function(T) setter) async {
+    final newValue =
+        constructor(await service.load(locale, countryIsoCode, name));
+    if (newValue?.bundle?.contentVersion != old?.bundle?.contentVersion) {
+      setter(newValue);
+    }
+  }
+
   @action
   Future<void> update() async {
     // TODO: UserPreferences should be injected dependency.
@@ -89,53 +98,39 @@ abstract class _ContentStore with Store implements Updateable {
 
     // Note the logic enforcing that only *newer* versions replace older versions in
     // the *cache* must be enforced elsewhere.
-    final travelAdvice2 = AdviceContent(
-        await service.load(locale, countryIsoCode, 'travel_advice'));
-    if (travelAdvice?.bundle?.contentVersion !=
-        travelAdvice2?.bundle?.contentVersion) {
-      travelAdvice = travelAdvice2;
-    }
-    final getTheFacts2 = FactContent(
-        await service.load(locale, countryIsoCode, 'get_the_facts'));
-    if (getTheFacts?.bundle?.contentVersion !=
-        getTheFacts2?.bundle?.contentVersion) {
-      getTheFacts = getTheFacts2;
-    }
-    final protectYourself2 = FactContent(
-        await service.load(locale, countryIsoCode, 'protect_yourself'));
-    if (protectYourself?.bundle?.contentVersion !=
-        protectYourself2?.bundle?.contentVersion) {
-      protectYourself = protectYourself2;
-    }
-    final homeIndex2 =
-        IndexContent(await service.load(locale, countryIsoCode, 'home_index'));
-    if (homeIndex?.bundle?.contentVersion !=
-        homeIndex2?.bundle?.contentVersion) {
-      homeIndex = homeIndex2;
-    }
-    final learnIndex2 =
-        IndexContent(await service.load(locale, countryIsoCode, 'learn_index'));
-    if (learnIndex?.bundle?.contentVersion !=
-        learnIndex2?.bundle?.contentVersion) {
-      learnIndex = learnIndex2;
-    }
-    final newsIndex2 =
-        IndexContent(await service.load(locale, countryIsoCode, 'news_index'));
-    if (newsIndex?.bundle?.contentVersion !=
-        newsIndex2?.bundle?.contentVersion) {
-      newsIndex = newsIndex2;
-    }
-    final questionsAnswered2 = QuestionContent(
-        await service.load(locale, countryIsoCode, 'your_questions_answered'));
-    if (questionsAnswered?.bundle?.contentVersion !=
-        questionsAnswered2?.bundle?.contentVersion) {
-      questionsAnswered = questionsAnswered2;
-    }
-    final symptomPoster2 = PosterContent(
-        await service.load(locale, countryIsoCode, 'symptom_poster'));
-    if (symptomPoster?.bundle?.contentVersion !=
-        symptomPoster2?.bundle?.contentVersion) {
-      symptomPoster = symptomPoster2;
-    }
+    await Future.wait([
+      updateBundle<IndexContent>(
+          'home_index', homeIndex, (cb) => IndexContent(cb), (v) {
+        homeIndex = v;
+      }),
+      updateBundle<AdviceContent>(
+          'travel_advice', travelAdvice, (cb) => AdviceContent(cb), (v) {
+        travelAdvice = v;
+      }),
+      updateBundle<FactContent>(
+          'get_the_facts', getTheFacts, (cb) => FactContent(cb), (v) {
+        getTheFacts = v;
+      }),
+      updateBundle<FactContent>(
+          'protect_yourself', protectYourself, (cb) => FactContent(cb), (v) {
+        protectYourself = v;
+      }),
+      updateBundle<IndexContent>(
+          'learn_index', learnIndex, (cb) => IndexContent(cb), (v) {
+        learnIndex = v;
+      }),
+      updateBundle<IndexContent>(
+          'news_index', newsIndex, (cb) => IndexContent(cb), (v) {
+        newsIndex = v;
+      }),
+      updateBundle<QuestionContent>('your_questions_answered',
+          questionsAnswered, (cb) => QuestionContent(cb), (v) {
+        questionsAnswered = v;
+      }),
+      updateBundle<PosterContent>(
+          'symptom_poster', symptomPoster, (cb) => PosterContent(cb), (v) {
+        symptomPoster = v;
+      })
+    ]);
   }
 }

--- a/client/flutter/lib/api/content/content_store.dart
+++ b/client/flutter/lib/api/content/content_store.dart
@@ -80,7 +80,8 @@ abstract class _ContentStore with Store implements Updateable {
       T Function(ContentBundle) constructor, void Function(T) setter) async {
     final newValue =
         constructor(await service.load(locale, countryIsoCode, name));
-    if (newValue?.bundle?.contentVersion != old?.bundle?.contentVersion) {
+    if ((newValue?.bundle?.contentVersion ?? 0) >
+        (old?.bundle?.contentVersion ?? 0)) {
       setter(newValue);
     }
   }

--- a/client/flutter/lib/api/updateable.dart
+++ b/client/flutter/lib/api/updateable.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+
+import 'package:connectivity/connectivity.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -8,11 +11,17 @@ abstract class Updateable {
 class PeriodicUpdater with WidgetsBindingObserver {
   final Updateable updateable;
   final WidgetsBinding binding;
+  final bool updateOnAppSwitch;
+  final bool updateOnConnectivityChange;
+
+  StreamSubscription<ConnectivityResult> connectivitySub;
 
   PeriodicUpdater({
     @required this.updateable,
     @required this.binding,
     bool installImmediately = false,
+    this.updateOnAppSwitch = true,
+    this.updateOnConnectivityChange = true,
   }) {
     if (installImmediately) {
       install();
@@ -21,19 +30,39 @@ class PeriodicUpdater with WidgetsBindingObserver {
 
   void install() {
     print('installing $this');
-    binding.addObserver(this);
+    if (updateOnAppSwitch) {
+      binding.addObserver(this);
+    }
+
+    if (updateOnConnectivityChange) {
+      assert(connectivitySub == null);
+      connectivitySub = Connectivity()
+          .onConnectivityChanged
+          .listen((ConnectivityResult result) {
+        _update();
+      });
+    }
   }
 
   void dispose() {
     print('disposing $this');
-    binding.removeObserver(this);
+    if (updateOnAppSwitch) {
+      binding.removeObserver(this);
+    }
+
+    if (connectivitySub != null) {
+      connectivitySub.cancel();
+      connectivitySub = null;
+    }
   }
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     switch (state) {
       case AppLifecycleState.resumed:
-        _update();
+        if (updateOnAppSwitch) {
+          _update();
+        }
         break;
       case AppLifecycleState.inactive:
       case AppLifecycleState.paused:

--- a/client/flutter/lib/api/user_preferences.dart
+++ b/client/flutter/lib/api/user_preferences.dart
@@ -5,6 +5,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:uuid/uuid.dart';
 import 'package:uuid/uuid_util.dart';
+import 'package:who_app/main.dart';
 
 // TODO: Delete this class.  The use of this class directly by new UI code is discouraged.
 // Instead, rely on a Provider-supplied UserPreferencesStore and manipulate the properties therein.
@@ -18,6 +19,18 @@ class UserPreferences {
   }
 
   UserPreferences._internal();
+
+  Future<String> getLastRunVersion() async {
+    return (await SharedPreferences.getInstance())
+            .getString(UserPreferenceKey.LastRunVersion.toString()) ??
+        false;
+  }
+
+  Future<bool> setLastRunVersion() async {
+    return (await SharedPreferences.getInstance()).setString(
+        UserPreferenceKey.LastRunVersion.toString(),
+        '${packageInfo.version}+${packageInfo.buildNumber}');
+  }
 
   /// Was the user shown the introductory pages as part of onboarding
   Future<bool> getOnboardingCompleted() async {
@@ -129,4 +142,5 @@ enum UserPreferenceKey {
   FirebaseToken,
   CountryISOCode,
   ExperimentCohort,
+  LastRunVersion,
 }

--- a/client/flutter/pubspec.lock
+++ b/client/flutter/pubspec.lock
@@ -148,6 +148,34 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.14.13"
+  connectivity:
+    dependency: "direct main"
+    description:
+      name: connectivity
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.9+2"
+  connectivity_for_web:
+    dependency: transitive
+    description:
+      name: connectivity_for_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.1+2"
+  connectivity_macos:
+    dependency: transitive
+    description:
+      name: connectivity_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.0+4"
+  connectivity_platform_interface:
+    dependency: transitive
+    description:
+      name: connectivity_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.6"
   convert:
     dependency: transitive
     description:

--- a/client/flutter/pubspec.yaml
+++ b/client/flutter/pubspec.yaml
@@ -54,6 +54,7 @@ dependencies:
   notification_permissions: ^0.4.4
   expressions: 0.1.5
   observer_provider: 0.0.1+2
+  connectivity: '>=0.4.9+2 <2.0.0'
 
   intl: ^0.16.0
   flutter_localizations:


### PR DESCRIPTION
- Home promo per David's mocks
- Refactor the content updating to be parallel async
- Don't wait for timeout when there is no network connectivity
- Refresh content on connectivity change
- When there is a network version and a binary asset version, choose the newer content
- Let the underlying cache store data for many years, so we can still return old cached content if it is newer than the binary asset content
- Actually return new network versions
- Adds `connectivity` dep (which is run by flutter.dev, which depends on Reachability pod)

Fixes #1490 ; Fixes #1452 ; Fixes #1429

TESTED = Locally on my Android phone with various combos of network connectivity and varying versions of the home content I was modifying.

![Screenshot_20200910-124159](https://user-images.githubusercontent.com/11729521/92793578-60d36500-f363-11ea-890b-d7c0c331cc65.png)
