### PR TITLE
`flutter analyze` simple fixes in prep for v1.22 upgrade

### DIFF
--- a/client/flutter/lib/api/content/caching.dart
+++ b/client/flutter/lib/api/content/caching.dart
@@ -6,7 +6,7 @@ import 'package:path/path.dart' as paths;
 
 class WhoCacheManager extends BaseCacheManager {
   // Change this key when the cache database becomes incompatible with the prior cache.
-  static const key = "whoCache2";
+  static const key = 'whoCache2';
 
   static WhoCacheManager _instance;
 
@@ -41,12 +41,12 @@ class WhoCacheManager extends BaseCacheManager {
               ConnectivityResult.none) {
             // Avoid waiting until timeout
             throw Exception(
-                "No internet connectivity - will not attempt download");
+                'No internet connectivity - will not attempt download');
           }
           return (await webHelper.downloadFile(url, authHeaders: headers)).file;
         } catch (err) {
           print(
-              "Error refreshing expired file, returning cached version: $url");
+              'Error refreshing expired file, returning cached version: $url');
         }
       } else {
         print('Using cached $url until ${cacheFile.validTill}');
@@ -56,13 +56,13 @@ class WhoCacheManager extends BaseCacheManager {
     try {
       if (await Connectivity().checkConnectivity() == ConnectivityResult.none) {
         // Avoid waiting until timeout
-        throw Exception("No internet connectivity - will not attempt download");
+        throw Exception('No internet connectivity - will not attempt download');
       }
-      print("Downloading file: $url");
+      print('Downloading file: $url');
       final download = await webHelper.downloadFile(url, authHeaders: headers);
       return download.file;
     } catch (e) {
-      print("Error downloading file: $url, $e");
+      print('Error downloading file: $url, $e');
       return null;
     }
   }

--- a/client/flutter/lib/api/content/content_bundle.dart
+++ b/client/flutter/lib/api/content/content_bundle.dart
@@ -30,8 +30,8 @@ class ContentBundle {
 
   void _init(String yamlString,
       {bool unsupportedSchemaVersionAvailable = false}) {
-    this.yaml = loadYaml(yamlString);
-    this.unsupportedSchemaVersionAvailable = unsupportedSchemaVersionAvailable;
+    yaml = loadYaml(yamlString);
+    unsupportedSchemaVersionAvailable = unsupportedSchemaVersionAvailable;
     if (schemaVersion > maxSupportedSchemaVersion) {
       throw ContentBundleSchemaVersionException();
     }
@@ -110,7 +110,7 @@ class ContentBase {
 
   ContentBase(this.bundle, {@required String schemaName}) {
     if (bundle.contentType != schemaName) {
-      throw Exception("Unsupported content type: ${bundle.contentType}");
+      throw Exception('Unsupported content type: ${bundle.contentType}');
     }
   }
 }

--- a/client/flutter/lib/api/content/content_loading.dart
+++ b/client/flutter/lib/api/content/content_loading.dart
@@ -23,7 +23,7 @@ class ContentService {
       Locale locale, String countryIsoCode, String name) async {
     final languageCode = locale.languageCode;
     final countryCode = countryIsoCode ?? locale.countryCode;
-    final languageAndCountry = "${languageCode}_${countryCode}";
+    final languageAndCountry = '${languageCode}_${countryCode}';
     var unsupportedSchemaVersionAvailable = false;
 
     ContentBundle networkBundle;
@@ -36,7 +36,7 @@ class ContentService {
         networkBundle = await _loadFromNetwork(name, languageAndCountry);
       } catch (err) {
         print(
-            "Loading $name : Network bundle for $languageAndCountry not found: $err");
+            'Loading $name : Network bundle for $languageAndCountry not found: $err');
         if (err is ContentBundleSchemaVersionException) {
           unsupportedSchemaVersionAvailable = true;
         }
@@ -49,15 +49,15 @@ class ContentService {
     if (localBundle == null && networkBundle == null) {
       // No bundle found.
       throw ContentBundleNotFoundException(
-          "Loading $name : Content bundle not found");
+          'Loading $name : Content bundle not found');
     } else if ((networkBundle?.contentVersion ?? 0) >
         (localBundle?.contentVersion ?? 0)) {
       print(
-          "Loading $name : Using #network bundle v${networkBundle?.contentVersion ?? 0} instead of local v${localBundle?.contentVersion ?? 0}");
+          'Loading $name : Using #network bundle v${networkBundle?.contentVersion ?? 0} instead of local v${localBundle?.contentVersion ?? 0}');
       return networkBundle;
     } else {
       print(
-          "Loading $name : Using *local bundle v${localBundle?.contentVersion ?? 0} instead of network v${networkBundle?.contentVersion ?? 0}");
+          'Loading $name : Using *local bundle v${localBundle?.contentVersion ?? 0} instead of network v${networkBundle?.contentVersion ?? 0}');
       return localBundle;
     }
   }
@@ -73,7 +73,7 @@ class ContentService {
           name, languageAndCountry, unsupportedSchemaVersionAvailable);
     } catch (err) {
       print(
-          "Loading $name : Local asset bundle for $languageAndCountry not found: $err");
+          'Loading $name : Local asset bundle for $languageAndCountry not found: $err');
     }
 
     // Attempt to load the language-only path from local resources.
@@ -82,7 +82,7 @@ class ContentService {
           name, languageCode, unsupportedSchemaVersionAvailable);
     } catch (err) {
       print(
-          "Loading $name : Local asset bundle for $languageCode not found: $err");
+          'Loading $name : Local asset bundle for $languageCode not found: $err');
     }
 
     // Attempt to load the English bundle from local resources.
@@ -90,7 +90,7 @@ class ContentService {
       return await _loadFromAssets(
           name, 'en', unsupportedSchemaVersionAvailable);
     } catch (err) {
-      print("Loading $name : Local asset bundle for en not found: $err");
+      print('Loading $name : Local asset bundle for en not found: $err');
     }
 
     return null;
@@ -100,15 +100,15 @@ class ContentService {
   Future<ContentBundle> _loadFromNetwork(String name, String suffix) async {
     var url = '$baseContentURL/${_fileName(name, suffix)}';
     final headers = {
-      "Accept": "application/yaml",
-      "Accept-Encoding": "gzip",
-      "User-Agent": WhoService.userAgent,
+      'Accept': 'application/yaml',
+      'Accept-Encoding': 'gzip',
+      'User-Agent': WhoService.userAgent,
     };
     File file = await WhoCacheManager()
         .getSingleFile(url, headers: headers)
         .timeout(networkTimeout);
     if (file == null) {
-      throw Exception("File not retrieved from network or cache: $url");
+      throw Exception('File not retrieved from network or cache: $url');
     }
     print('loaded $url');
     return ContentBundle.fromBytes(await file.readAsBytes());

--- a/client/flutter/lib/api/content/schema/advice_content.dart
+++ b/client/flutter/lib/api/content/schema/advice_content.dart
@@ -11,18 +11,18 @@ typedef AdviceDataSource = Future<AdviceContent> Function(Locale);
 class AdviceContent extends ContentBase {
   List<AdviceItem> items;
 
-  AdviceContent(ContentBundle bundle) : super(bundle, schemaName: "advice") {
+  AdviceContent(ContentBundle bundle) : super(bundle, schemaName: 'advice') {
     try {
-      this.items = bundle.contentItems
+      items = bundle.contentItems
           .map((item) => AdviceItem(
                 isBanner: item['is_banner'] ?? false,
-                title: (item['title'] ?? "").trim(),
-                body: (item['body'] ?? "").trim(), // remove trailing newline
+                title: (item['title'] ?? '').trim(),
+                body: (item['body'] ?? '').trim(), // remove trailing newline
                 displayCondition: item['display_condition'],
               ))
           .toList();
     } catch (err) {
-      print("Error loading fact data: $err");
+      print('Error loading fact data: $err');
       throw ContentBundleDataException();
     }
   }

--- a/client/flutter/lib/api/content/schema/fact_content.dart
+++ b/client/flutter/lib/api/content/schema/fact_content.dart
@@ -11,9 +11,9 @@ typedef FactsDataSource = Future<FactContent> Function(Locale);
 class FactContent extends ContentBase {
   List<FactItem> items;
 
-  FactContent(ContentBundle bundle) : super(bundle, schemaName: "fact") {
+  FactContent(ContentBundle bundle) : super(bundle, schemaName: 'fact') {
     try {
-      this.items = bundle.contentItems
+      items = bundle.contentItems
           .map((item) => FactItem(
                 title: item['title_html'],
                 body: item['body_html'],
@@ -23,7 +23,7 @@ class FactContent extends ContentBase {
               ))
           .toList();
     } catch (err) {
-      print("Error loading fact data: $err");
+      print('Error loading fact data: $err');
       throw ContentBundleDataException();
     }
   }

--- a/client/flutter/lib/api/content/schema/index_content.dart
+++ b/client/flutter/lib/api/content/schema/index_content.dart
@@ -14,11 +14,11 @@ class IndexContent extends ContentBase {
   List<IndexItem> items;
   List<IndexPromo> promos;
 
-  IndexContent(ContentBundle bundle) : super(bundle, schemaName: "index") {
+  IndexContent(ContentBundle bundle) : super(bundle, schemaName: 'index') {
     try {
       final yamlPromos = bundle.contentPromos;
       if (yamlPromos != null) {
-        this.promos = bundle.contentPromos
+        promos = bundle.contentPromos
             .map((yamlPromo) => IndexPromo(
                   promoType: yamlPromo['promo_type'],
                   buttonText: yamlPromo['button_text'],
@@ -30,7 +30,7 @@ class IndexContent extends ContentBase {
                 ))
             .toList();
       }
-      this.items = bundle.contentItems
+      items = bundle.contentItems
           .map((item) => IndexItem(
                 itemType: item['item_type'],
                 title: item['title'],
@@ -42,7 +42,7 @@ class IndexContent extends ContentBase {
               ))
           .toList();
     } catch (err) {
-      print("Error loading Index data: $err");
+      print('Error loading Index data: $err');
       throw ContentBundleDataException();
     }
   }
@@ -70,7 +70,7 @@ class IndexPromo with ConditionalItem {
   });
 
   IndexPromoType get type {
-    switch (this.promoType) {
+    switch (promoType) {
       case 'check_your_symptoms':
         return IndexPromoType.CheckYourSymptoms;
       case 'protect_yourself':
@@ -108,7 +108,7 @@ class IndexItem with ConditionalItem {
   });
 
   IndexItemType get type {
-    switch (this.itemType) {
+    switch (itemType) {
       case 'recent_numbers':
         return IndexItemType.recent_numbers;
       case 'protect_yourself':

--- a/client/flutter/lib/api/content/schema/poster_content.dart
+++ b/client/flutter/lib/api/content/schema/poster_content.dart
@@ -5,11 +5,11 @@ import 'package:who_app/api/content/schema/conditional_content.dart';
 class PosterContent extends ContentBase {
   List<PosterCard> cards;
 
-  PosterContent(ContentBundle bundle) : super(bundle, schemaName: "poster") {
+  PosterContent(ContentBundle bundle) : super(bundle, schemaName: 'poster') {
     try {
-      this.cards = bundle.contentItems.map(_cardFromContent).toList();
+      cards = bundle.contentItems.map(_cardFromContent).toList();
     } catch (err) {
-      print("Error loading poster data: $err");
+      print('Error loading poster data: $err');
       throw ContentBundleDataException();
     }
   }

--- a/client/flutter/lib/api/content/schema/question_content.dart
+++ b/client/flutter/lib/api/content/schema/question_content.dart
@@ -10,9 +10,9 @@ typedef QuestionIndexDataSource = Future<QuestionContent> Function(Locale);
 class QuestionContent extends ContentBase {
   List<QuestionItem> items;
 
-  QuestionContent(ContentBundle bundle) : super(bundle, schemaName: "qa") {
+  QuestionContent(ContentBundle bundle) : super(bundle, schemaName: 'qa') {
     try {
-      this.items = bundle.contentItems
+      items = bundle.contentItems
           .map((item) => QuestionItem(
                 title: item['title_html'],
                 body: item['body_html'],
@@ -20,7 +20,7 @@ class QuestionContent extends ContentBase {
               ))
           .toList();
     } catch (err) {
-      print("Error loading question data: $err");
+      print('Error loading question data: $err');
       throw ContentBundleDataException();
     }
   }

--- a/client/flutter/lib/api/linking.dart
+++ b/client/flutter/lib/api/linking.dart
@@ -26,10 +26,10 @@ class RouteLink {
   });
 
   Future open(BuildContext context) {
-    return this.isExternal
-        ? launchUrl(this.url)
+    return isExternal
+        ? launchUrl(url)
         : Navigator.of(context, rootNavigator: true)
-            .pushNamed(this.route, arguments: this.args);
+            .pushNamed(route, arguments: args);
   }
 
   RouteLink.fromUri(String uri) {

--- a/client/flutter/lib/api/who_service.dart
+++ b/client/flutter/lib/api/who_service.dart
@@ -26,7 +26,7 @@ class WhoService {
     final url = '$serviceUrl/putDeviceToken';
     final response = await http.post(url, headers: headers, body: postBody);
     if (response.statusCode != 200) {
-      throw Exception("Error status code: ${response.statusCode}");
+      throw Exception('Error status code: ${response.statusCode}');
     }
     return true;
   }
@@ -40,7 +40,7 @@ class WhoService {
     final url = '$serviceUrl/putLocation';
     final response = await http.post(url, headers: headers, body: postBody);
     if (response.statusCode != 200) {
-      throw Exception("Error status code: ${response.statusCode}");
+      throw Exception('Error status code: ${response.statusCode}');
     }
     return true;
   }
@@ -61,7 +61,7 @@ class WhoService {
     final url = '$serviceUrl/getCaseStats';
     final response = await http.post(url, headers: headers, body: postBody);
     if (response.statusCode != 200) {
-      throw Exception("Error status code: ${response.statusCode}");
+      throw Exception('Error status code: ${response.statusCode}');
     }
     final ret = GetCaseStatsResponse.create();
     ret.mergeFromProto3Json(jsonDecode(response.body));
@@ -86,11 +86,11 @@ class WhoService {
 
   static String get _platform {
     if (io.Platform.isIOS) {
-      return "IOS";
+      return 'IOS';
     }
     if (io.Platform.isAndroid) {
-      return "ANDROID";
+      return 'ANDROID';
     }
-    return "WEB";
+    return 'WEB';
   }
 }

--- a/client/flutter/lib/components/carousel/carousel.dart
+++ b/client/flutter/lib/components/carousel/carousel.dart
@@ -49,7 +49,7 @@ class CarouselView extends StatelessWidget {
           child: PageView(
             controller: pageController,
             onPageChanged: (i) => pageIndexNotifier.value = i,
-            children: this.items,
+            children: items,
           ),
         ),
         Align(
@@ -93,7 +93,7 @@ class CarouselView extends StatelessWidget {
 
   Future<void> goToLastPage() {
     analytics.logEvent(name: 'CarouselLastPage');
-    return pageController.animateToPage(this.items.length - 1,
+    return pageController.animateToPage(items.length - 1,
         duration: Duration(milliseconds: 500), curve: Curves.easeInOut);
   }
 
@@ -128,7 +128,7 @@ class CarouselView extends StatelessWidget {
               child: FittedBox(
                 child: PageViewIndicator(
                   pageIndexNotifier: pageIndexNotifier,
-                  length: this.items.length,
+                  length: items.length,
                   normalBuilder: (animationController, index) => Circle(
                     size: 20.0,
                     color: Constants.neutralTextLightColor.withOpacity(0.2),

--- a/client/flutter/lib/components/carousel/carousel_slide.dart
+++ b/client/flutter/lib/components/carousel/carousel_slide.dart
@@ -92,7 +92,7 @@ class _CarouselSlideState extends State<CarouselSlide> {
         child: Row(
           children: <Widget>[
             SizedBox(width: 4.0),
-            Text("Learn More", style: titleStyle.copyWith(fontSize: 18.0)),
+            Text('Learn More', style: titleStyle.copyWith(fontSize: 18.0)),
             SizedBox(width: 6.0),
             Icon(Icons.lightbulb_outline, color: titleStyle.color)
           ],
@@ -110,13 +110,13 @@ class _CarouselSlideState extends State<CarouselSlide> {
   TextStyle _titleHtmlStyle(dom.Node node, TextStyle baseStyle) {
     if (node is dom.Element) {
       switch (node.localName) {
-        case "em":
+        case 'em':
           return baseStyle.merge(TextStyle(
               fontStyle: FontStyle.normal,
               decoration: TextDecoration.underline));
-        case "b":
+        case 'b':
           return baseStyle.merge(TextStyle(fontWeight: FontWeight.w800));
-        case "u":
+        case 'u':
           return baseStyle
               .merge(TextStyle(decoration: TextDecoration.underline));
       }

--- a/client/flutter/lib/components/content_widget.dart
+++ b/client/flutter/lib/components/content_widget.dart
@@ -20,7 +20,7 @@ abstract class ContentWidget<T extends ContentBase> extends StatelessWidget {
         final content = getContent();
         final logicContext = dataSource.logicContext;
         print(
-            '$this rebuild / ${this.hashCode} / content: ${content.hashCode} v${content?.bundle?.contentVersion} / logicContext: ${logicContext.hashCode}');
+            '$this rebuild / ${hashCode} / content: ${content.hashCode} v${content?.bundle?.contentVersion} / logicContext: ${logicContext.hashCode}');
         return buildImpl(context, content, logicContext);
       },
     );

--- a/client/flutter/lib/components/home_page_sections/home_page_header.dart
+++ b/client/flutter/lib/components/home_page_sections/home_page_header.dart
@@ -25,7 +25,7 @@ class HomePageHeader extends StatelessWidget {
   });
 
   String get svgAssetName {
-    return this.imageName != null ? 'assets/svg/${this.imageName}.svg' : null;
+    return imageName != null ? 'assets/svg/${imageName}.svg' : null;
   }
 
   Color get backgroundColor {
@@ -49,7 +49,7 @@ class HomePageHeader extends StatelessWidget {
       children: <Widget>[
         Positioned.fill(
           child: PromoCurvedBackground(
-            color: this.backgroundColor,
+            color: backgroundColor,
           ),
         ),
         SafeArea(
@@ -66,8 +66,8 @@ class HomePageHeader extends StatelessWidget {
                     Positioned(
                       bottom: 0.0,
                       right: 0.0,
-                      child: this.svgAssetName != null
-                          ? SvgPicture.asset(this.svgAssetName)
+                      child: svgAssetName != null
+                          ? SvgPicture.asset(svgAssetName)
                           : Container(),
                     ),
                     Container(
@@ -78,7 +78,7 @@ class HomePageHeader extends StatelessWidget {
                           Padding(
                             padding: EdgeInsets.only(top: 28.0),
                             child: AutoSizeThemedText(
-                              this.title,
+                              title,
                               variant: TypographyVariant.title,
                               maxFontSize: 40,
                               style: TextStyle(
@@ -89,7 +89,7 @@ class HomePageHeader extends StatelessWidget {
                           Padding(
                             padding: const EdgeInsets.only(top: 8.0),
                             child: ThemedText(
-                              this.subtitle,
+                              subtitle,
                               variant: TypographyVariant.body,
                               style: TextStyle(
                                 color: CupertinoColors.white,
@@ -108,7 +108,7 @@ class HomePageHeader extends StatelessWidget {
                               color: CupertinoColors.white,
                               child: Container(
                                 child: ThemedText(
-                                  this.buttonText,
+                                  buttonText,
                                   variant: TypographyVariant.button,
                                   style:
                                       TextStyle(color: Constants.primaryColor),
@@ -116,7 +116,7 @@ class HomePageHeader extends StatelessWidget {
                                 ),
                               ),
                               onPressed: () {
-                                return this.link.open(context);
+                                return link.open(context);
                               },
                             ),
                           ),

--- a/client/flutter/lib/components/home_page_sections/home_page_information_card.dart
+++ b/client/flutter/lib/components/home_page_sections/home_page_information_card.dart
@@ -14,7 +14,7 @@ class HomePageInformationCard extends StatelessWidget {
   final String imageName;
 
   String get assetName =>
-      this.imageName != null ? 'assets/svg/${this.imageName}.svg' : null;
+      imageName != null ? 'assets/svg/${imageName}.svg' : null;
 
   const HomePageInformationCard({
     @required this.buttonText,
@@ -28,12 +28,12 @@ class HomePageInformationCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final inner = _HomePageInformationCardInner(
-      buttonText: this.buttonText,
-      link: this.link,
-      subtitle: this.subtitle,
-      title: this.title,
+      buttonText: buttonText,
+      link: link,
+      subtitle: subtitle,
+      title: title,
     );
-    return this.assetName != null
+    return assetName != null
         ? Stack(
             children: <Widget>[
               Container(
@@ -42,8 +42,8 @@ class HomePageInformationCard extends StatelessWidget {
               ),
               Positioned(
                 right: 28.0,
-                child: Container(
-                    height: 96, child: SvgPicture.asset(this.assetName)),
+                child:
+                    Container(height: 96, child: SvgPicture.asset(assetName)),
               )
             ],
           )
@@ -71,7 +71,7 @@ class _HomePageInformationCardInner extends StatelessWidget {
       child: Button(
         color: Constants.illustrationBlue1Color,
         onPressed: () {
-          return this.link.open(context);
+          return link.open(context);
         },
         borderRadius: BorderRadius.circular(8.0),
         child: Container(
@@ -80,7 +80,7 @@ class _HomePageInformationCardInner extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: <Widget>[
               ThemedText(
-                this.title,
+                title,
                 variant: TypographyVariant.h3,
                 style: TextStyle(
                   color: Constants.primaryDarkColor,
@@ -90,7 +90,7 @@ class _HomePageInformationCardInner extends StatelessWidget {
                 height: 6.0,
               ),
               ThemedText(
-                this.subtitle,
+                subtitle,
                 variant: TypographyVariant.body,
                 style: TextStyle(
                   color: Constants.neutralTextDarkColor,
@@ -108,14 +108,14 @@ class _HomePageInformationCardInner extends StatelessWidget {
                     padding:
                         EdgeInsets.symmetric(horizontal: 32.0, vertical: 12.0),
                     child: ThemedText(
-                      this.buttonText,
+                      buttonText,
                       variant: TypographyVariant.button,
                       style: TextStyle(
                         color: Constants.primaryColor,
                       ),
                     ),
                     onPressed: () {
-                      return this.link.open(context);
+                      return link.open(context);
                     },
                   )
                 ],

--- a/client/flutter/lib/components/home_page_sections/home_page_protect_yourself.dart
+++ b/client/flutter/lib/components/home_page_sections/home_page_protect_yourself.dart
@@ -96,15 +96,14 @@ class _HomeProtectYourselfCard extends StatelessWidget {
             children: <Widget>[
               Padding(
                 padding: const EdgeInsets.fromLTRB(28.0, 36.0, 28.0, 20.0),
-                child: _buildBody(context, this.fact.body),
+                child: _buildBody(context, fact.body),
               ),
               Expanded(
                 child: Container(
                   alignment: Alignment.bottomCenter,
                   child: AspectRatio(
                     aspectRatio: 316 / 240,
-                    child: SvgPicture.asset(
-                        'assets/svg/${this.fact.imageName}.svg'),
+                    child: SvgPicture.asset('assets/svg/${fact.imageName}.svg'),
                   ),
                 ),
               )

--- a/client/flutter/lib/components/home_page_sections/home_page_recent_numbers.dart
+++ b/client/flutter/lib/components/home_page_sections/home_page_recent_numbers.dart
@@ -167,7 +167,7 @@ class _HomeStatCard extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: <Widget>[
                 ThemedText(
-                  this.stat,
+                  stat,
                   variant: TypographyVariant.h2,
                   softWrap: true,
                   style: TextStyle(
@@ -180,7 +180,7 @@ class _HomeStatCard extends StatelessWidget {
                   height: 4.0,
                 ),
                 ThemedText(
-                  this.title,
+                  title,
                   variant: TypographyVariant.button,
                   style: TextStyle(
                     color: Constants.primaryDarkColor,

--- a/client/flutter/lib/components/learn_page_promo.dart
+++ b/client/flutter/lib/components/learn_page_promo.dart
@@ -14,7 +14,7 @@ class LearnPagePromo extends StatelessWidget {
   final String imageName;
 
   String get assetName {
-    return this.imageName != null ? 'assets/svg/${this.imageName}.svg' : null;
+    return imageName != null ? 'assets/svg/${imageName}.svg' : null;
   }
 
   const LearnPagePromo(
@@ -36,9 +36,8 @@ class LearnPagePromo extends StatelessWidget {
             color: Constants.primaryDarkColor,
           ),
         ),
-        if (this.assetName != null)
-          Positioned.fill(
-              child: FittedBox(child: SvgPicture.asset(this.assetName))),
+        if (assetName != null)
+          Positioned.fill(child: FittedBox(child: SvgPicture.asset(assetName))),
         SafeArea(
             bottom: false,
             child: Container(
@@ -80,7 +79,7 @@ class LearnPagePromo extends StatelessWidget {
                     ),
                   ),
                   onPressed: () {
-                    return this.link.open(context);
+                    return link.open(context);
                   },
                 ),
                 SizedBox(

--- a/client/flutter/lib/components/listItem.dart
+++ b/client/flutter/lib/components/listItem.dart
@@ -4,7 +4,7 @@ class ListItem extends StatelessWidget {
   final Widget titleWidget;
   final String message;
 
-  ListItem({this.titleWidget, this.message = ""});
+  ListItem({this.titleWidget, this.message = ''});
 
   @override
   Widget build(BuildContext context) {
@@ -12,9 +12,9 @@ class ListItem extends StatelessWidget {
       padding: const EdgeInsets.all(8.0),
       child: Column(
         children: <Widget>[
-          this.titleWidget ?? Container(),
+          titleWidget ?? Container(),
           Text(
-            this.message,
+            message,
             style: TextStyle(fontSize: 21),
             textAlign: TextAlign.center,
           ),

--- a/client/flutter/lib/components/page_button.dart
+++ b/client/flutter/lib/components/page_button.dart
@@ -23,7 +23,7 @@ class PageButton extends StatefulWidget {
     this.backgroundColor,
     this.title,
     this.onPressed, {
-    this.description = "",
+    this.description = '',
     this.borderRadius = 16,
     this.verticalPadding = 15.0,
     this.horizontalPadding = 8.0,
@@ -71,15 +71,15 @@ class _PageButtonState extends State<PageButton> {
       color: widget.backgroundColor,
       child: Padding(
         padding: EdgeInsets.symmetric(
-          vertical: this.widget.verticalPadding,
-          horizontal: this.widget.horizontalPadding,
+          vertical: widget.verticalPadding,
+          horizontal: widget.horizontalPadding,
         ),
         child: Column(
-          crossAxisAlignment: this.widget.crossAxisAlignment,
-          mainAxisAlignment: this.widget.mainAxisAlignment,
+          crossAxisAlignment: widget.crossAxisAlignment,
+          mainAxisAlignment: widget.mainAxisAlignment,
           children: <Widget>[
             Text(
-              this.widget.title,
+              widget.title,
               textAlign: TextAlign.left,
               style: widget.titleStyle?.copyWith(
                     letterSpacing: Constants.buttonTextSpacing,
@@ -92,9 +92,9 @@ class _PageButtonState extends State<PageButton> {
             ),
             // Makes sure text is centered properly when no description is provided
             SizedBox(height: widget.description.isNotEmpty ? 4 : 0),
-            this.widget.description.isNotEmpty
+            widget.description.isNotEmpty
                 ? Text(
-                    this.widget.description,
+                    widget.description,
                     textAlign: TextAlign.left,
                     textScaleFactor: (0.9 + 0.5 * contentScale(context)) *
                         MediaQuery.textScaleFactorOf(context),

--- a/client/flutter/lib/components/page_scaffold/page_scaffold.dart
+++ b/client/flutter/lib/components/page_scaffold/page_scaffold.dart
@@ -43,21 +43,21 @@ class PageScaffold extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Material(
-      color: this.color,
+      color: color,
       child: Padding(
-        padding: this.padding,
+        padding: padding,
         child: Stack(
           children: <Widget>[
             CustomScrollView(
               // Disables scrolling when there's insufficient content to scroll
               primary: false,
               slivers: [
-                ...this.beforeHeader,
-                if (this.showHeader)
-                  (this.header ??
+                ...beforeHeader,
+                if (showHeader)
+                  (header ??
                       PageHeader(
-                        title: this.title,
-                        heroTag: this.heroTag ?? this.title,
+                        title: title,
+                        heroTag: heroTag ?? title,
                         borderColor: headingBorderColor,
                         showBackButton: showBackButton,
                         titleStyle: headerTitleStyle,
@@ -65,7 +65,7 @@ class PageScaffold extends StatelessWidget {
                         appBarBottom: appBarBottom,
                         trailing: trailing,
                       )),
-                ...this.body,
+                ...body,
                 SliverToBoxAdapter(
                   child: SizedBox(height: 170),
                 ),

--- a/client/flutter/lib/components/promo_curved_background.dart
+++ b/client/flutter/lib/components/promo_curved_background.dart
@@ -10,7 +10,7 @@ class PromoCurvedBackground extends StatelessWidget {
   Widget build(BuildContext context) {
     return ClipPath(
       clipper: _BackgroundClipper(),
-      child: Container(color: this.color),
+      child: Container(color: color),
     );
   }
 }

--- a/client/flutter/lib/components/protect_yourself_card.dart
+++ b/client/flutter/lib/components/protect_yourself_card.dart
@@ -54,12 +54,12 @@ class ProtectYourselfCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ClipRRect(
-      borderRadius: this.borderRadius,
+      borderRadius: borderRadius,
       child: Container(
         color: CupertinoColors.white,
         child: Column(
           children: <Widget>[
-            this.child,
+            child,
             Padding(
               padding: EdgeInsets.symmetric(horizontal: 16.0, vertical: 20.0),
               child: message,

--- a/client/flutter/lib/components/recent_numbers_graph.dart
+++ b/client/flutter/lib/components/recent_numbers_graph.dart
@@ -152,9 +152,9 @@ class _RecentNumbersGraphState extends State<RecentNumbersGraph> {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       ThemedText(
-                        numFmt.format(this.titleData) == "0"
-                            ? "-"
-                            : numFmt.format(this.titleData),
+                        numFmt.format(titleData) == '0'
+                            ? '-'
+                            : numFmt.format(titleData),
                         variant: TypographyVariant.h2,
                         style: TextStyle(
                           color: widget.dimension == DataDimension.cases
@@ -163,7 +163,7 @@ class _RecentNumbersGraphState extends State<RecentNumbersGraph> {
                         ),
                       ),
                       ThemedText(
-                        this.graphTitle,
+                        graphTitle,
                         variant: TypographyVariant.h4,
                         style: TextStyle(
                           color: widget.dimension == DataDimension.cases
@@ -182,26 +182,26 @@ class _RecentNumbersGraphState extends State<RecentNumbersGraph> {
     );
   }
 
-  String get graphTitle => "$graphAggregation $graphDimension";
+  String get graphTitle => '$graphAggregation $graphDimension';
   String get graphAggregation {
     switch (widget.aggregation) {
       case DataAggregation.total:
-        return "Total";
+        return 'Total';
       case DataAggregation.daily:
-        return "Daily";
+        return 'Daily';
       default:
-        return "";
+        return '';
     }
   }
 
   String get graphDimension {
     switch (widget.dimension) {
       case DataDimension.cases:
-        return "cases";
+        return 'cases';
       case DataDimension.deaths:
-        return "deaths";
+        return 'deaths';
       default:
-        return "";
+        return '';
     }
   }
 }

--- a/client/flutter/lib/components/stat_card.dart
+++ b/client/flutter/lib/components/stat_card.dart
@@ -23,7 +23,7 @@ class StatCard extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
             Text(
-              this.title.toUpperCase(),
+              title.toUpperCase(),
               style: TextStyle(
                 color: Constants.neutralTextLightColor,
                 fontSize: 13,
@@ -35,7 +35,7 @@ class StatCard extends StatelessWidget {
               height: 8.0,
             ),
             ThemedText(
-              this.stat,
+              stat,
               variant: TypographyVariant.h2,
               softWrap: true,
               style: TextStyle(

--- a/client/flutter/lib/components/themed_text.dart
+++ b/client/flutter/lib/components/themed_text.dart
@@ -150,21 +150,20 @@ class ThemedText extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    TextStyle style =
-        ThemedText.styleForVariant(this.variant).merge(this.style);
+    TextStyle styleVariant = ThemedText.styleForVariant(variant).merge(style);
     return Text(
-      this.data,
-      locale: this.locale,
-      maxLines: this.maxLines,
-      overflow: this.overflow,
-      semanticsLabel: this.semanticsLabel,
-      softWrap: this.softWrap,
-      strutStyle: this.strutStyle,
-      style: style,
-      textAlign: this.textAlign,
-      textDirection: this.textDirection,
-      textScaleFactor: this.textScaleFactor,
-      textWidthBasis: this.textWidthBasis,
+      data,
+      locale: locale,
+      maxLines: maxLines,
+      overflow: overflow,
+      semanticsLabel: semanticsLabel,
+      softWrap: softWrap,
+      strutStyle: strutStyle,
+      style: styleVariant,
+      textAlign: textAlign,
+      textDirection: textDirection,
+      textScaleFactor: textScaleFactor,
+      textWidthBasis: textWidthBasis,
     );
   }
 }
@@ -219,28 +218,27 @@ class AutoSizeThemedText extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    TextStyle style =
-        ThemedText.styleForVariant(this.variant).merge(this.style);
+    TextStyle styleVariant = ThemedText.styleForVariant(variant).merge(style);
     return AutoSizeText(
-      this.data,
-      group: this.group,
-      locale: this.locale,
-      maxFontSize: this.maxFontSize,
-      maxLines: this.maxLines,
-      minFontSize: this.minFontSize,
-      overflow: this.overflow,
-      overflowReplacement: this.overflowReplacement,
-      presetFontSizes: this.presetFontSizes,
-      semanticsLabel: this.semanticsLabel,
-      softWrap: this.softWrap,
-      stepGranularity: this.stepGranularity,
-      strutStyle: this.strutStyle,
-      style: style,
-      textAlign: this.textAlign,
-      textDirection: this.textDirection,
-      textKey: this.textKey,
-      textScaleFactor: this.textScaleFactor,
-      wrapWords: this.wrapWords,
+      data,
+      group: group,
+      locale: locale,
+      maxFontSize: maxFontSize,
+      maxLines: maxLines,
+      minFontSize: minFontSize,
+      overflow: overflow,
+      overflowReplacement: overflowReplacement,
+      presetFontSizes: presetFontSizes,
+      semanticsLabel: semanticsLabel,
+      softWrap: softWrap,
+      stepGranularity: stepGranularity,
+      strutStyle: strutStyle,
+      style: styleVariant,
+      textAlign: textAlign,
+      textDirection: textDirection,
+      textKey: textKey,
+      textScaleFactor: textScaleFactor,
+      wrapWords: wrapWords,
     );
   }
 }

--- a/client/flutter/lib/main.dart
+++ b/client/flutter/lib/main.dart
@@ -125,7 +125,7 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
         _getCurrentLocale(),
       ).textDirection,
       child: MaterialApp(
-        title: "WHO COVID-19",
+        title: 'WHO COVID-19',
         localizationsDelegates: [
           GlobalMaterialLocalizations.delegate,
           GlobalWidgetsLocalizations.delegate,
@@ -212,8 +212,8 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
                       'You are using a development-only build of this app not intended for public use. You agree that you have no expectation of privacy when using this build and understand that the app contents may not have been reviewed by the World Health Organization.',
                       dismissable: true),
                 if (content.unsupportedSchemaVersionAvailable)
-                  Alert("App Update Required",
-                      "This information may be outdated. You must update this app to receive more recent COVID-19 info."),
+                  Alert('App Update Required',
+                      'This information may be outdated. You must update this app to receive more recent COVID-19 info.'),
               ];
             }),
           ],

--- a/client/flutter/lib/pages/about_page.dart
+++ b/client/flutter/lib/pages/about_page.dart
@@ -116,14 +116,14 @@ class AboutPage extends StatelessWidget {
                     // Sort order is random A-Z or Z-A.
                     final orderSign = Random.secure().nextBool() ? 1 : -1;
                     final strategyTeam = [
-                      "Advay Mengle",
-                      "Bob Lee",
-                      "Bruno Bowden",
-                      "Daniel Kraft",
-                      "David Kaneda",
-                      "Dean Hachamovitch",
-                      "Hunter Spinks",
-                      "Karen Wong",
+                      'Advay Mengle',
+                      'Bob Lee',
+                      'Bruno Bowden',
+                      'Daniel Kraft',
+                      'David Kaneda',
+                      'Dean Hachamovitch',
+                      'Hunter Spinks',
+                      'Karen Wong',
                     ];
                     strategyTeam.sort((x, y) => (orderSign *
                         x.toLowerCase().compareTo(y.toLowerCase())));
@@ -131,7 +131,7 @@ class AboutPage extends StatelessWidget {
                     team.sort(
                         (x, y) => x.toLowerCase().compareTo(y.toLowerCase()));
                     var teamNames = S.of(context).aboutPageThanksToText(
-                        '${strategyTeam.join(", ")}; and ${team.join(", ")}');
+                        '${strategyTeam.join(', ')}; and ${team.join(', ')}');
                     return ThemedText(
                       teamNames,
                       variant: TypographyVariant.body,

--- a/client/flutter/lib/pages/facts_carousel_page.dart
+++ b/client/flutter/lib/pages/facts_carousel_page.dart
@@ -51,7 +51,7 @@ abstract class FactsCarouselPage extends ContentWidget<FactContent> {
 
   SvgPicture _getSVG(String imageName) {
     return imageName != null
-        ? SvgPicture.asset("assets/svg/${imageName}.svg")
+        ? SvgPicture.asset('assets/svg/${imageName}.svg')
         : null;
   }
 }

--- a/client/flutter/lib/pages/license_page.dart
+++ b/client/flutter/lib/pages/license_page.dart
@@ -103,7 +103,7 @@ class _LicensePageState extends State<LicensePage> {
   @override
   Widget build(BuildContext context) {
     return PageScaffold(
-      title: "Licenses",
+      title: 'Licenses',
       body: [
         SliverPadding(
           padding: EdgeInsets.all(24.0),

--- a/client/flutter/lib/pages/main_pages/check_up_poster_page.dart
+++ b/client/flutter/lib/pages/main_pages/check_up_poster_page.dart
@@ -68,7 +68,7 @@ class CheckUpPosterPage extends ContentWidget<PosterContent> {
     return PageScaffold(
       showBackButton: !inHomePage,
       // TODO: localize
-      title: "Check-Up",
+      title: 'Check-Up',
       body: <Widget>[
         content != null && logicContext != null
             ? _buildBody()
@@ -86,8 +86,8 @@ class _Card extends StatelessWidget {
   final Color iconColor;
 
   String get assetName {
-    return this.content.iconName != null
-        ? 'assets/svg/streamline-sc-${this.content.iconName}.svg'
+    return content.iconName != null
+        ? 'assets/svg/streamline-sc-${content.iconName}.svg'
         : null;
   }
 
@@ -100,7 +100,7 @@ class _Card extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
         SvgPicture.asset(
-          this.assetName,
+          assetName,
           color: iconColor,
           width: iconSize,
           height: iconSize,

--- a/client/flutter/lib/pages/main_pages/home_page.dart
+++ b/client/flutter/lib/pages/main_pages/home_page.dart
@@ -154,13 +154,10 @@ class _HomePageSection extends StatelessWidget {
     return SliverToBoxAdapter(
       child: Container(
         color: CupertinoColors.white,
-        padding: this.padding,
+        padding: padding,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: <Widget>[
-            if (this.header != null) this.header,
-            this.content
-          ],
+          children: <Widget>[if (header != null) header, content],
         ),
       ),
     );
@@ -188,20 +185,20 @@ class _HomePageSectionHeader extends StatelessWidget {
         spacing: 16.0,
         children: <Widget>[
           ThemedText(
-            this.title,
+            title,
             variant: TypographyVariant.h3,
           ),
           CupertinoButton(
             padding: EdgeInsets.zero,
             child: ThemedText(
-              this.linkText,
+              linkText,
               variant: TypographyVariant.button,
               style: TextStyle(
                 color: Constants.neutralTextLightColor,
               ),
             ),
             onPressed: () {
-              return this.link.open(context);
+              return link.open(context);
             },
           ),
         ],

--- a/client/flutter/lib/pages/main_pages/learn_page.dart
+++ b/client/flutter/lib/pages/main_pages/learn_page.dart
@@ -39,7 +39,7 @@ class LearnPage extends ContentWidget<IndexContent> {
     ),
   ];
 
-  buildImpl(context, content, logicContext) {
+  PageScaffold buildImpl(context, content, logicContext) {
     List<Widget> _buildPromo() {
       final p = content?.promos
           ?.firstWhere((element) => element.isDisplayed(logicContext));
@@ -85,14 +85,14 @@ class LearnPage extends ContentWidget<IndexContent> {
       headingBorderColor: Color(0x0),
       heroTag: HeroTags.learn,
       // TODO: localize
-      title: "Learn",
+      title: 'Learn',
       showHeader: content != null,
       header: SliverToBoxAdapter(
           child: Padding(
               padding:
                   EdgeInsets.only(left: 16, right: 16, top: 36, bottom: 12),
               // TODO: localize
-              child: PageHeader.buildTitle("Learn",
+              child: PageHeader.buildTitle('Learn',
                   textStyle: TextStyle(fontSize: 40)))),
       beforeHeader: <Widget>[
         _buildPromos(),
@@ -127,7 +127,7 @@ class _MenuItem extends StatelessWidget {
   final String imageName;
 
   String get assetName {
-    return imageName != null ? 'assets/svg/${this.imageName}.svg' : null;
+    return imageName != null ? 'assets/svg/${imageName}.svg' : null;
   }
 
   @override

--- a/client/flutter/lib/pages/main_pages/recent_numbers.dart
+++ b/client/flutter/lib/pages/main_pages/recent_numbers.dart
@@ -21,21 +21,21 @@ extension StatSnapshotSlicing on StatSnapshot {
       case DataAggregation.daily:
         switch (dim) {
           case DataDimension.cases:
-            return this.dailyCases.toInt();
+            return dailyCases.toInt();
           case DataDimension.deaths:
-            return this.dailyDeaths.toInt();
+            return dailyDeaths.toInt();
         }
-        throw UnsupportedError("Unknown dimension");
+        throw UnsupportedError('Unknown dimension');
       case DataAggregation.total:
         switch (dim) {
           case DataDimension.cases:
-            return this.totalCases.toInt();
+            return totalCases.toInt();
           case DataDimension.deaths:
-            return this.totalDeaths.toInt();
+            return totalDeaths.toInt();
         }
-        throw UnsupportedError("Unknown dimension");
+        throw UnsupportedError('Unknown dimension');
     }
-    throw UnsupportedError("Unknown aggregation");
+    throw UnsupportedError('Unknown aggregation');
   }
 }
 
@@ -43,11 +43,11 @@ extension CaseStatsSlicing on CaseStats {
   int valueBy(DataDimension dim) {
     switch (dim) {
       case DataDimension.cases:
-        return this.hasCases() ? this.cases.toInt() : null;
+        return hasCases() ? cases.toInt() : null;
       case DataDimension.deaths:
-        return this.hasDeaths() ? this.deaths.toInt() : null;
+        return hasDeaths() ? deaths.toInt() : null;
     }
-    throw UnsupportedError("Unknown dimension");
+    throw UnsupportedError('Unknown dimension');
   }
 }
 
@@ -93,16 +93,15 @@ class _RecentNumbersPageState extends State<RecentNumbersPage> {
               children: [
                 CupertinoSlidingSegmentedControl(
                   backgroundColor: Color(0xffEFEFEF),
-                  children:
-                      _buildSegmentControlChildren(context, this.aggregation),
-                  groupValue: this.aggregation,
+                  children: _buildSegmentControlChildren(context, aggregation),
+                  groupValue: aggregation,
                   onValueChanged: (value) {
                     widget.analytics.logEvent(
                         name: 'RecentNumberAggregation',
-                        parameters: {'index': this.aggregation.index});
+                        parameters: {'index': aggregation.index});
                     setState(
                       () {
-                        this.aggregation = value;
+                        aggregation = value;
                       },
                     );
                   },
@@ -150,7 +149,7 @@ class _RecentNumbersPageState extends State<RecentNumbersPage> {
                     if (countryCode != null) ...[
                       _JurisdictionStats(
                         aggregation: aggregation,
-                        emoji: countryList.countries[countryCode]?.emoji ?? "",
+                        emoji: countryList.countries[countryCode]?.emoji ?? '',
                         name: countryList.countries[countryCode]?.name ??
                             countryCode,
                         stats: widget.statsStore.countryStats,
@@ -228,7 +227,7 @@ class _JurisdictionStats extends StatelessWidget {
         ),
         ConstrainedBox(
           child: RecentNumbersGraph(
-            aggregation: this.aggregation,
+            aggregation: aggregation,
             timeseries: stats?.timeseries,
             dimension: DataDimension.cases,
           ),
@@ -237,7 +236,7 @@ class _JurisdictionStats extends StatelessWidget {
         Container(height: 24.0),
         ConstrainedBox(
           child: RecentNumbersGraph(
-            aggregation: this.aggregation,
+            aggregation: aggregation,
             timeseries: stats?.timeseries,
             dimension: DataDimension.deaths,
           ),
@@ -262,7 +261,7 @@ class RegionText extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.all(30.0),
       child: ThemedText(
-        "$emoji $country",
+        '$emoji $country',
         variant: TypographyVariant.h3,
       ),
     );

--- a/client/flutter/lib/pages/onboarding/country_list_page.dart
+++ b/client/flutter/lib/pages/onboarding/country_list_page.dart
@@ -32,10 +32,10 @@ class CountryListPage extends StatelessWidget {
   }
 
   List<Widget> _buildCountries() {
-    if (this.countries == null || this.countries.isEmpty) {
+    if (countries == null || countries.isEmpty) {
       return [LoadingIndicator()];
     }
-    return (this.countries?.values ?? [])
+    return (countries?.values ?? [])
         .map((country) => _buildCountryItem(country))
         .toList();
   }
@@ -46,7 +46,7 @@ class CountryListPage extends StatelessWidget {
         color: CupertinoColors.white,
         child: InkWell(
           onTap: () async {
-            await this.onCountrySelected(country);
+            await onCountrySelected(country);
           },
           child: Column(
             children: <Widget>[
@@ -67,7 +67,7 @@ class CountryListPage extends StatelessWidget {
                       ),
                     ),
                   ),
-                  if (this.selectedCountryCode == country.alpha2Code)
+                  if (selectedCountryCode == country.alpha2Code)
                     Container(
                       padding:
                           EdgeInsets.only(top: 16.0, bottom: 16.0, right: 12.0),

--- a/client/flutter/lib/pages/onboarding/country_select_page.dart
+++ b/client/flutter/lib/pages/onboarding/country_select_page.dart
@@ -96,7 +96,7 @@ class CountrySelectPage extends StatelessWidget {
                   ),
                   child: Material(
                     child: FlatButton(
-                      onPressed: this.countryName != null ? this.onNext : null,
+                      onPressed: countryName != null ? onNext : null,
                       color: Constants.whoBackgroundBlueColor,
                       disabledColor:
                           Constants.neutralTextLightColor.withOpacity(0.3),
@@ -133,7 +133,7 @@ class CountrySelectPage extends StatelessWidget {
     return Material(
       color: CupertinoColors.white,
       child: InkWell(
-        onTap: this.onOpenCountryList,
+        onTap: onOpenCountryList,
         child: Container(
           decoration: BoxDecoration(
               border: Border(
@@ -174,10 +174,10 @@ class CountrySelectPage extends StatelessWidget {
                   ),
                   // TODO: localize
                   child: ThemedText(
-                    this.countryName ?? 'Select',
+                    countryName ?? 'Select',
                     variant: TypographyVariant.body,
                     style: TextStyle(
-                      color: this.countryName != null
+                      color: countryName != null
                           ? Constants.neutralTextColor
                           : Constants.emergencyRedColor,
                     ),

--- a/client/flutter/lib/pages/onboarding/legal_landing_page.dart
+++ b/client/flutter/lib/pages/onboarding/legal_landing_page.dart
@@ -88,7 +88,7 @@ class LegalLandingPage extends StatelessWidget {
                         url: S.of(context).legalLandingPagePrivacyPolicyLinkUrl,
                         onLinkTap: (v) => launchUrl(v),
                       ),
-                      TextSpan(text: "."),
+                      TextSpan(text: '.'),
                     ],
                   ),
                   textAlign: TextAlign.center,

--- a/client/flutter/lib/pages/onboarding/onboarding_page.dart
+++ b/client/flutter/lib/pages/onboarding/onboarding_page.dart
@@ -53,7 +53,7 @@ class _OnboardingPageState extends State<OnboardingPage> {
     if (_selectedCountry == null && countryList.countries.isNotEmpty) {
       // On first load of country list, the default is the locale country.
       final currentCountryCode = Localizations.localeOf(context).countryCode;
-      if (this.mounted) {
+      if (mounted) {
         setState(() {
           _selectedCountry = countryList.countries[currentCountryCode];
         });

--- a/client/flutter/lib/pages/onboarding/permission_request_page.dart
+++ b/client/flutter/lib/pages/onboarding/permission_request_page.dart
@@ -17,7 +17,7 @@ class PermissionRequestPage extends StatelessWidget {
   const PermissionRequestPage(
       {Key key,
       @required this.pageTitle,
-      this.pageDescription = "",
+      this.pageDescription = '',
       @required this.buttonTitle,
       @required this.onGrantPermission,
       @required this.onSkip,
@@ -32,7 +32,7 @@ class PermissionRequestPage extends StatelessWidget {
           Align(
             alignment: Alignment(1, -0.3),
             child: Image.asset(
-              this.backgroundImageSrc,
+              backgroundImageSrc,
               fit: BoxFit.fitWidth,
               alignment: Alignment.center,
             ),
@@ -59,7 +59,7 @@ class PermissionRequestPage extends StatelessWidget {
                             header: true,
                             container: true,
                             child: Text(
-                              this.pageTitle,
+                              pageTitle,
                               style: TextStyle(
                                 fontWeight: FontWeight.w800,
                                 color: Color(0xff1A458E),
@@ -74,7 +74,7 @@ class PermissionRequestPage extends StatelessWidget {
                           Semantics(
                             container: true,
                             child: Text(
-                              this.pageDescription,
+                              pageDescription,
                               style: TextStyle(
                                 color: Constants.textColor,
                                 height: 1.4,

--- a/client/flutter/lib/pages/question_index.dart
+++ b/client/flutter/lib/pages/question_index.dart
@@ -166,7 +166,7 @@ class _QuestionTileState extends State<QuestionTile>
       customEdgeInsets: (dom.Node node) {
         if (node is dom.Element) {
           switch (node.localName) {
-            case "p":
+            case 'p':
               return EdgeInsets.only(bottom: 8);
               break;
             default:
@@ -179,12 +179,12 @@ class _QuestionTileState extends State<QuestionTile>
       customTextStyle: (dom.Node node, TextStyle baseStyle) {
         if (node is dom.Element) {
           switch (node.localName) {
-            case "h2":
+            case 'h2':
               return baseStyle.merge(TextStyle(
                   fontSize: 20,
                   color: Color(0xff3C4245),
                   fontWeight: FontWeight.w500));
-            case "b":
+            case 'b':
               return baseStyle.merge(TextStyle(fontWeight: FontWeight.bold));
           }
         }

--- a/client/flutter/lib/pages/settings_page.dart
+++ b/client/flutter/lib/pages/settings_page.dart
@@ -43,7 +43,7 @@ class _SettingsPageState extends State<SettingsPage>
     }
   }
 
-  _init() async {
+  void _init() async {
     _analyticsEnabled = await UserPreferences().getAnalyticsEnabled();
     _notificationsEnabled = await widget.notifications.isEnabled();
     setState(() {});
@@ -55,14 +55,14 @@ class _SettingsPageState extends State<SettingsPage>
     super.dispose();
   }
 
-  _toggleAnalytics(bool value) async {
+  void _toggleAnalytics(bool value) async {
     await UserPreferences().setAnalyticsEnabled(value);
     setState(() {
       _analyticsEnabled = value;
     });
   }
 
-  _toggleNotifications(bool setEnabled) async {
+  void _toggleNotifications(bool setEnabled) async {
     var enabled;
     if (setEnabled) {
       enabled = await widget.notifications.attemptEnableNotifications(

--- a/client/flutter/lib/pages/travel_advice.dart
+++ b/client/flutter/lib/pages/travel_advice.dart
@@ -23,7 +23,7 @@ class TravelAdvice extends ContentWidget<AdviceContent> {
         return item.isBanner
             ? _Banner(title: item.title, body: item.body)
             : _TravelAdviceListItem(
-                title: item.title ?? "", description: item.body ?? "");
+                title: item.title ?? '', description: item.body ?? '');
       }).toList();
     }
 
@@ -128,13 +128,13 @@ class _TravelAdviceListItem extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: <Widget>[
                 ThemedText(
-                  this.title,
+                  title,
                   variant: TypographyVariant.h4,
                   style:
                       TextStyle(height: 1.37, color: Constants.bodyTextColor),
                 ),
                 ThemedText(
-                  this.description,
+                  description,
                   variant: TypographyVariant.body,
                   style:
                       TextStyle(fontSize: 18, color: Constants.bodyTextColor),

--- a/client/flutter/test/who_settings_test.dart
+++ b/client/flutter/test/who_settings_test.dart
@@ -13,7 +13,7 @@ void main() {
 
   Widget testableWidget({Widget child}) {
     return CupertinoApp(
-      title: "WHO",
+      title: 'WHO',
       localizationsDelegates: [
         GlobalMaterialLocalizations.delegate,
         GlobalWidgetsLocalizations.delegate,
@@ -34,6 +34,6 @@ void main() {
       notifications: Notifications(service: WhoService(endpoint: '')),
     )));
     await tester.pumpAndSettle();
-    expect(find.text("Settings"), findsWidgets);
+    expect(find.text('Settings'), findsWidgets);
   });
 }


### PR DESCRIPTION
`flutter analyze` simple fixes (occur in v1.22):
```
- always_declare_return_types
- prefer_single_quotes
- referenced_before_declaration
- unnecessary_this
```

Testing:
- flutter upgrade to v1.22.1
- `flutter analyze` => ~300 issues (majority fixed)

#### How did you test the change?
* [x] iOS Simulator
* [x] Android Emulator
* [ ] iOS Device
* [ ] Android Device
* [ ] `curl` to a dev App Engine server
-->

<!-- FILL OUT THE CHECKLIST BELOW -->

---

#### Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).

- [ ] REQUIRED: Do you have an Issue **assigned to you** for this PR?
- [x] Provided detailed pull request description and a succinct title
- [x] Tested your changes, especially after any code review iterations.
- [ ] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [docs/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/docs/credits.yaml) file (if you want it to be).
