### PR TITLE
`flutter analyze` tricky fixes in prep for v1.22 upgrade

### DIFF
--- a/client/flutter/lib/api/content/caching.dart
+++ b/client/flutter/lib/api/content/caching.dart
@@ -21,9 +21,7 @@ class WhoCacheManager extends BaseCacheManager {
             maxNrOfCacheObjects: 10000);
 
   factory WhoCacheManager() {
-    if (_instance == null) {
-      _instance = WhoCacheManager._init();
-    }
+    _instance ??= WhoCacheManager._init();
     return _instance;
   }
 
@@ -68,6 +66,7 @@ class WhoCacheManager extends BaseCacheManager {
   }
 
   // Store files in the temporary system path (default behavior)
+  @override
   Future<String> getFilePath() async {
     var directory = await getTemporaryDirectory();
     return paths.join(directory.path, key);

--- a/client/flutter/lib/api/content/content_bundle.dart
+++ b/client/flutter/lib/api/content/content_bundle.dart
@@ -16,7 +16,7 @@ class ContentBundle {
   /// Construct a bundle from utf-8 bytes containing YAML
   ContentBundle.fromBytes(Uint8List bytes,
       {bool unsupportedSchemaVersionAvailable = false}) {
-    String yamlString = Encoding.getByName('utf-8').decode(bytes);
+    var yamlString = Encoding.getByName('utf-8').decode(bytes);
     _init(yamlString,
         unsupportedSchemaVersionAvailable: unsupportedSchemaVersionAvailable);
   }

--- a/client/flutter/lib/api/content/content_loading.dart
+++ b/client/flutter/lib/api/content/content_loading.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:who_app/api/who_service.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:flutter/cupertino.dart';
@@ -104,7 +103,7 @@ class ContentService {
       'Accept-Encoding': 'gzip',
       'User-Agent': WhoService.userAgent,
     };
-    File file = await WhoCacheManager()
+    var file = await WhoCacheManager()
         .getSingleFile(url, headers: headers)
         .timeout(networkTimeout);
     if (file == null) {

--- a/client/flutter/lib/api/content/content_store.dart
+++ b/client/flutter/lib/api/content/content_store.dart
@@ -87,6 +87,7 @@ abstract class _ContentStore with Store implements Updateable {
   }
 
   @action
+  @override
   Future<void> update() async {
     // TODO: UserPreferences should be injected dependency.
     if (!await UserPreferences().getTermsOfServiceCompleted()) {

--- a/client/flutter/lib/api/content/schema/advice_content.dart
+++ b/client/flutter/lib/api/content/schema/advice_content.dart
@@ -32,6 +32,7 @@ class AdviceContent extends ContentBase {
 class AdviceItem with ConditionalItem {
   final String title;
   final String body;
+  @override
   final String displayCondition;
   final bool isBanner;
 

--- a/client/flutter/lib/api/content/schema/fact_content.dart
+++ b/client/flutter/lib/api/content/schema/fact_content.dart
@@ -36,6 +36,7 @@ class FactItem with ConditionalItem {
   final String body;
   final String imageName;
   final String animationName;
+  @override
   final String displayCondition;
 
   FactItem(

--- a/client/flutter/lib/api/content/schema/index_content.dart
+++ b/client/flutter/lib/api/content/schema/index_content.dart
@@ -57,6 +57,7 @@ class IndexPromo with ConditionalItem {
   final RouteLink link;
   final String buttonText;
   final String imageName;
+  @override
   final String displayCondition;
 
   IndexPromo({
@@ -95,6 +96,7 @@ class IndexItem with ConditionalItem {
   final RouteLink link;
   final String buttonText;
   final String imageName;
+  @override
   final String displayCondition;
 
   IndexItem({

--- a/client/flutter/lib/api/content/schema/poster_content.dart
+++ b/client/flutter/lib/api/content/schema/poster_content.dart
@@ -29,6 +29,7 @@ class PosterCard with ConditionalItem {
   final String title;
   final String bodyHtml;
   final String iconName;
+  @override
   final String displayCondition;
   final bool severe;
 

--- a/client/flutter/lib/api/content/schema/question_content.dart
+++ b/client/flutter/lib/api/content/schema/question_content.dart
@@ -30,6 +30,7 @@ class QuestionContent extends ContentBase {
 class QuestionItem with ConditionalItem {
   final String title;
   final String body;
+  @override
   final String displayCondition;
 
   QuestionItem(

--- a/client/flutter/lib/api/iso_country.dart
+++ b/client/flutter/lib/api/iso_country.dart
@@ -15,7 +15,7 @@ class IsoCountryList {
 
   static Future<Map<String, IsoCountry>> _countriesFromYaml(
       String csvPath) async {
-    Map<String, IsoCountry> countries = {};
+    var countries = <String, IsoCountry>{};
     final yamlString = await rootBundle.loadString(IsoCountryList.isoFilePath);
     final yaml = loadYaml(yamlString);
     yaml['countries'].forEach((countryYaml) {

--- a/client/flutter/lib/api/stats_store.dart
+++ b/client/flutter/lib/api/stats_store.dart
@@ -46,6 +46,7 @@ abstract class _StatsStore with Store implements Updateable {
   }
 
   @action
+  @override
   Future<void> update() async {
     // TODO: UserPreferences should be injected dependency.
     if (!await UserPreferences().getTermsOfServiceCompleted()) {

--- a/client/flutter/lib/api/user_preferences.dart
+++ b/client/flutter/lib/api/user_preferences.dart
@@ -76,7 +76,7 @@ class UserPreferences {
   }
 
   Future<bool> setAnalyticsEnabled(bool value) async {
-    FirebaseAnalytics analytics = FirebaseAnalytics();
+    var analytics = FirebaseAnalytics();
     if (!value) {
       await analytics.resetAnalyticsData();
     }

--- a/client/flutter/lib/components/carousel/carousel.dart
+++ b/client/flutter/lib/components/carousel/carousel.dart
@@ -60,8 +60,8 @@ class CarouselView extends StatelessWidget {
               // Anything not effected by the value of the notifier
               child: _buildPageViewIndicator(context),
               builder: (context, index, child) {
-                final bool isFirstPage = index == 0;
-                final bool isLastPage = index + 1 == items.length;
+                final isFirstPage = index == 0;
+                final isLastPage = index + 1 == items.length;
                 return Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   crossAxisAlignment: CrossAxisAlignment.center,

--- a/client/flutter/lib/components/carousel/carousel_slide.dart
+++ b/client/flutter/lib/components/carousel/carousel_slide.dart
@@ -37,15 +37,15 @@ class _CarouselSlideState extends State<CarouselSlide> {
 
   @override
   Widget build(BuildContext context) {
-    final Size screenSize = MediaQuery.of(context).size;
+    final screenSize = MediaQuery.of(context).size;
 
-    final TextStyle titleStyle = TextStyle(
+    final titleStyle = TextStyle(
       color: Constants.primaryDarkColor,
       fontSize: 36.0,
       fontWeight: FontWeight.w600,
       letterSpacing: -.5,
     );
-    final TextStyle bodyStyle = TextStyle(
+    final bodyStyle = TextStyle(
       color: Constants.textColor,
       fontSize: 16.0,
       height: 1.4,

--- a/client/flutter/lib/components/home_page_sections/home_page_donate.dart
+++ b/client/flutter/lib/components/home_page_sections/home_page_donate.dart
@@ -87,7 +87,7 @@ class _DonateBackground extends StatelessWidget {
 class _BackgroundClipper extends CustomClipper<Path> {
   @override
   Path getClip(Size size) {
-    Path path = Path();
+    var path = Path();
 
     path.moveTo(0, 46.0);
     path.arcToPoint(Offset(size.width, 79.0),

--- a/client/flutter/lib/components/home_page_sections/home_page_protect_yourself.dart
+++ b/client/flutter/lib/components/home_page_sections/home_page_protect_yourself.dart
@@ -115,12 +115,12 @@ class _HomeProtectYourselfCard extends StatelessWidget {
   }
 
   Widget _buildBody(BuildContext context, String body) {
-    final TextStyle defaultTextStyle = ThemedText.htmlStyleForVariant(
+    final defaultTextStyle = ThemedText.htmlStyleForVariant(
         TypographyVariant.body,
         textScaleFactor: MediaQuery.textScaleFactorOf(context),
         overrides: TextStyle(
             color: CupertinoColors.white, fontWeight: FontWeight.w500));
-    final TextStyle boldTextStyle =
+    final boldTextStyle =
         defaultTextStyle.copyWith(fontWeight: FontWeight.w700);
     return Html(
       data: fact.body ?? '',

--- a/client/flutter/lib/components/page_scaffold/page_scaffold.dart
+++ b/client/flutter/lib/components/page_scaffold/page_scaffold.dart
@@ -102,6 +102,7 @@ class _AlertsWrapperState extends State<AlertsWrapper>
 
   final List<Alert> _alerts;
 
+  @override
   void removeAlert(Alert a) {
     if (mounted) {
       setState(() {

--- a/client/flutter/lib/components/promo_curved_background.dart
+++ b/client/flutter/lib/components/promo_curved_background.dart
@@ -18,7 +18,7 @@ class PromoCurvedBackground extends StatelessWidget {
 class _BackgroundClipper extends CustomClipper<Path> {
   @override
   Path getClip(Size size) {
-    Path path = Path();
+    var path = Path();
 
     path.lineTo(0, size.height);
     path.arcToPoint(Offset(size.width, size.height - 33.0),

--- a/client/flutter/lib/components/protect_yourself_card.dart
+++ b/client/flutter/lib/components/protect_yourself_card.dart
@@ -24,7 +24,7 @@ class ProtectYourselfCard extends StatelessWidget {
       TextStyle defaultTextStyle = const TextStyle(
           color: Constants.textColor, fontSize: 16, height: 1.4)}) {
     Widget media = SvgPicture.asset('assets/svg/${fact.imageName}.svg');
-    final TextStyle boldTextStyle =
+    final boldTextStyle =
         defaultTextStyle.copyWith(fontWeight: FontWeight.w700);
     return ProtectYourselfCard(
       child: AspectRatio(

--- a/client/flutter/lib/components/recent_numbers_graph.dart
+++ b/client/flutter/lib/components/recent_numbers_graph.dart
@@ -29,7 +29,7 @@ class _RecentNumbersBarGraphState extends State<RecentNumbersBarGraph> {
 
   @override
   Widget build(BuildContext context) {
-    final double cardWidth = MediaQuery.of(context).size.width - (padding * 2);
+    final cardWidth = MediaQuery.of(context).size.width - (padding * 2);
 
     return BarChart(
       BarChartData(
@@ -59,12 +59,12 @@ class _RecentNumbersBarGraphState extends State<RecentNumbersBarGraph> {
   }
 
   List<BarChartRodData> _buildRods(double cardWidth) {
-    List<BarChartRodData> bars = <BarChartRodData>[];
+    var bars = <BarChartRodData>[];
 
     if (widget.timeseries != null && widget.timeseries.isNotEmpty) {
       for (var snapshot in widget.timeseries) {
         try {
-          double yAxis =
+          final yAxis =
               snapshot.valueBy(widget.aggregation, widget.dimension).toDouble();
           bars.add(
             BarChartRodData(
@@ -80,7 +80,7 @@ class _RecentNumbersBarGraphState extends State<RecentNumbersBarGraph> {
     } else {
       final daysSinceStart =
           DateTime.now().toUtc().difference(startDate).inDays;
-      for (int i = 0; i < daysSinceStart; i++) {
+      for (var i = 0; i < daysSinceStart; i++) {
         bars.add(
           BarChartRodData(
             y: 0,

--- a/client/flutter/lib/components/themed_text.dart
+++ b/client/flutter/lib/components/themed_text.dart
@@ -142,15 +142,14 @@ class ThemedText extends StatelessWidget {
 
   static TextStyle htmlStyleForVariant(TypographyVariant variant,
       {double textScaleFactor, TextStyle overrides = const TextStyle()}) {
-    TextStyle baseStyle =
-        ThemedText.styleForVariant(variant, overrides: overrides);
+    final baseStyle = ThemedText.styleForVariant(variant, overrides: overrides);
     return baseStyle
         .merge(TextStyle(fontSize: baseStyle.fontSize * textScaleFactor));
   }
 
   @override
   Widget build(BuildContext context) {
-    TextStyle styleVariant = ThemedText.styleForVariant(variant).merge(style);
+    final styleVariant = ThemedText.styleForVariant(variant).merge(style);
     return Text(
       data,
       locale: locale,
@@ -218,7 +217,7 @@ class AutoSizeThemedText extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    TextStyle styleVariant = ThemedText.styleForVariant(variant).merge(style);
+    final styleVariant = ThemedText.styleForVariant(variant).merge(style);
     return AutoSizeText(
       data,
       group: group,

--- a/client/flutter/lib/main.dart
+++ b/client/flutter/lib/main.dart
@@ -49,8 +49,7 @@ void mainImpl({@required Map<String, WidgetBuilder> routes}) async {
     _packageInfo = await PackageInfo.fromPlatform();
   }
 
-  final bool onboardingComplete =
-      await UserPreferences().getOnboardingCompletedV1();
+  final onboardingComplete = await UserPreferences().getOnboardingCompletedV1();
 
   // Comment the above lines out and uncomment this to force onboarding in development
   // final bool onboardingComplete = false;

--- a/client/flutter/lib/pages/about_page.dart
+++ b/client/flutter/lib/pages/about_page.dart
@@ -22,23 +22,23 @@ class AboutPage extends StatelessWidget {
   Widget build(BuildContext context) {
     var devInfo = false;
 
-    final String versionString = packageInfo != null
+    final versionString = packageInfo != null
         ? S.of(context).commonWorldHealthOrganizationCoronavirusAppVersion(
             packageInfo.version, packageInfo.buildNumber)
         : null;
 
-    final String copyrightString = S
+    final copyrightString = S
         .of(context)
         .commonWorldHealthOrganizationCoronavirusCopyright(DateTime.now().year);
 
     Future<void> _openTermsOfService(BuildContext context) async {
-      final String url = S.of(context).aboutPageTermsOfServiceLinkUrl;
+      final url = S.of(context).aboutPageTermsOfServiceLinkUrl;
       await launchUrl(url);
       await FirebaseAnalytics().logEvent(name: 'TermsOfService');
     }
 
     Future<void> _openPrivacyPolicy(BuildContext context) async {
-      final String url = S.of(context).legalLandingPagePrivacyPolicyLinkUrl;
+      final url = S.of(context).legalLandingPagePrivacyPolicyLinkUrl;
       await launchUrl(url);
       await FirebaseAnalytics().logEvent(name: 'PrivacyPolicy');
     }

--- a/client/flutter/lib/pages/facts_carousel_page.dart
+++ b/client/flutter/lib/pages/facts_carousel_page.dart
@@ -24,8 +24,8 @@ abstract class FactsCarouselPage extends ContentWidget<FactContent> {
         .asMap()
         .entries
         .map((entry) {
-      int index = entry.key;
-      FactItem fact = entry.value;
+      final index = entry.key;
+      final fact = entry.value;
       return CarouselSlide(
         key: UniqueKey(),
         title: fact.title,

--- a/client/flutter/lib/pages/license_page.dart
+++ b/client/flutter/lib/pages/license_page.dart
@@ -32,9 +32,9 @@ class _LicensePageState extends State<LicensePage> {
   bool _loaded = false;
 
   Future<void> _initLicenses() async {
-    int debugFlowId = -1;
+    var debugFlowId = -1;
     assert(() {
-      final Flow flow = Flow.begin();
+      final flow = Flow.begin();
       Timeline.timeSync('_initLicenses()', () {}, flow: flow);
       debugFlowId = flow.id;
       return true;
@@ -48,7 +48,7 @@ class _LicensePageState extends State<LicensePage> {
             flow: Flow.step(debugFlowId));
         return true;
       }());
-      final List<LicenseParagraph> paragraphs =
+      final paragraphs =
           await SchedulerBinding.instance.scheduleTask<List<LicenseParagraph>>(
         license.paragraphs.toList,
         Priority.animation,
@@ -70,7 +70,7 @@ class _LicensePageState extends State<LicensePage> {
             textAlign: TextAlign.center,
           ),
         ));
-        for (final LicenseParagraph paragraph in paragraphs) {
+        for (final paragraph in paragraphs) {
           if (paragraph.indent == LicenseParagraph.centeredIndent) {
             _licenses.add(Padding(
               padding: const EdgeInsets.only(top: 16.0),

--- a/client/flutter/lib/pages/main_pages/app_tab_router.dart
+++ b/client/flutter/lib/pages/main_pages/app_tab_router.dart
@@ -90,7 +90,7 @@ class AppTabRouter extends StatelessWidget {
 
   static BottomNavigationBarItem _buildSvgNavItem(
       {String iconName, String title, Color activeColor}) {
-    final String assetName = 'assets/svg/${iconName}.svg';
+    final assetName = 'assets/svg/${iconName}.svg';
     return BottomNavigationBarItem(
       icon: SvgPicture.asset(assetName),
       activeIcon: SvgPicture.asset(

--- a/client/flutter/lib/pages/main_pages/check_up_poster_page.dart
+++ b/client/flutter/lib/pages/main_pages/check_up_poster_page.dart
@@ -19,7 +19,7 @@ class CheckUpPosterPage extends ContentWidget<PosterContent> {
   @override
   Widget buildImpl(
       BuildContext context, PosterContent content, LogicContext logicContext) {
-    final bool inHomePage = !ModalRoute.of(context).canPop;
+    final inHomePage = !ModalRoute.of(context).canPop;
 
     List<Widget> _getCards() {
       return [

--- a/client/flutter/lib/pages/main_pages/home_page.dart
+++ b/client/flutter/lib/pages/main_pages/home_page.dart
@@ -22,8 +22,8 @@ class HomePage extends ContentWidget<IndexContent> {
   @override
   Widget buildImpl(context, content, logicContext) {
     List<Widget> _buildPromo() {
-      List<Widget> preHeader = [];
-      IndexPromo p = content?.promos
+      var preHeader = <Widget>[];
+      var p = content?.promos
           ?.firstWhere((element) => element.isDisplayed(logicContext));
       if (p != null) {
         preHeader.add(_HomePageSection(
@@ -41,11 +41,11 @@ class HomePage extends ContentWidget<IndexContent> {
     }
 
     List<Widget> _buildBody(BuildContext ctx) {
-      List<IndexItem> items = content?.items;
+      var items = content?.items;
       if (items == null) {
         return [LoadingIndicator()];
       }
-      List<Widget> bundleWidgets = items
+      var bundleWidgets = items
           .where((item) => item.isDisplayed(logicContext))
           .map((item) => _buildItem(ctx, item))
           .toList();

--- a/client/flutter/lib/pages/main_pages/learn_page.dart
+++ b/client/flutter/lib/pages/main_pages/learn_page.dart
@@ -39,6 +39,7 @@ class LearnPage extends ContentWidget<IndexContent> {
     ),
   ];
 
+  @override
   PageScaffold buildImpl(context, content, logicContext) {
     List<Widget> _buildPromo() {
       final p = content?.promos

--- a/client/flutter/lib/pages/main_pages/recent_numbers.dart
+++ b/client/flutter/lib/pages/main_pages/recent_numbers.dart
@@ -114,7 +114,7 @@ class _RecentNumbersPageState extends State<RecentNumbersPage> {
         body: <Widget>[
           CupertinoSliverRefreshControl(
             builder: (context, refreshIndicatorMode, pulledExtent, b, c) {
-              double topPadding = max(pulledExtent - 25.0, 0.0);
+              final topPadding = max(pulledExtent - 25.0, 0.0);
               switch (refreshIndicatorMode) {
                 case RefreshIndicatorMode.drag:
                   return pulledExtent > 10
@@ -178,7 +178,7 @@ class _RecentNumbersPageState extends State<RecentNumbersPage> {
 
   Map<DataAggregation, Widget> _buildSegmentControlChildren(
       BuildContext context, DataAggregation selectedValue) {
-    Map<DataAggregation, String> valueToDisplayText = {
+    var valueToDisplayText = {
       DataAggregation.total: S.of(context).latestNumbersPageTotalToggle,
       // TODO: This string changed, so we must change regenerate translation keys someday.
       DataAggregation.daily: 'Daily',

--- a/client/flutter/lib/pages/protect_yourself.dart
+++ b/client/flutter/lib/pages/protect_yourself.dart
@@ -20,7 +20,7 @@ class ProtectYourself extends ContentWidget<FactContent> {
   @override
   Widget buildImpl(context, content, logicContext) {
     List<Widget> _buildCards() {
-      final TextStyle normalText = TextStyle(
+      final normalText = TextStyle(
         color: Constants.textColor,
         fontSize: 16 * MediaQuery.textScaleFactorOf(context),
         height: 1.4,

--- a/client/flutter/lib/pages/question_index.dart
+++ b/client/flutter/lib/pages/question_index.dart
@@ -150,7 +150,7 @@ class _QuestionTileState extends State<QuestionTile>
 
   // flutter_html supports a subset of html: https://pub.dev/packages/flutter_html
   Widget html(String html) {
-    final double textScaleFactor = MediaQuery.of(context).textScaleFactor;
+    final textScaleFactor = MediaQuery.of(context).textScaleFactor;
 
     return Html(
       data: html,

--- a/client/flutter/lib/pages/settings_page.dart
+++ b/client/flutter/lib/pages/settings_page.dart
@@ -108,7 +108,7 @@ class _SettingsPageState extends State<SettingsPage>
   }
 
   Future<void> _provideFeedback() async {
-    const String issueUrl =
+    const issueUrl =
         'https://github.com/WorldHealthOrganization/app/issues/new/choose';
     await launchUrl(issueUrl);
   }
@@ -164,7 +164,7 @@ class _SettingsPageState extends State<SettingsPage>
 
   Widget menu(BuildContext context) {
     final divider = Container(height: 1, color: Color(0xffC9CDD6));
-    final Size size = MediaQuery.of(context).size;
+    final size = MediaQuery.of(context).size;
     return Column(children: <Widget>[
       divider,
       MenuListTile(

--- a/client/flutter/lib/pages/travel_advice.dart
+++ b/client/flutter/lib/pages/travel_advice.dart
@@ -57,6 +57,7 @@ class _Banner extends StatelessWidget {
 
   _Banner({@required this.title, @required this.body});
 
+  @override
   Widget build(BuildContext context) {
     return Container(
         decoration: BoxDecoration(


### PR DESCRIPTION
`flutter analyze` tricky fixes (occur in v1.22):
```
- annotate_overrides
- omit_local_variable_types
- unused_import
```

Partial fix for #1576

Testing:
- flutter upgrade to v1.22.1
- `flutter analyze` => virtually all fixed
- analyzed each type removal for correctness

#### How did you test the change?
* [x] iOS Simulator
* [x] Android Emulator
* [ ] iOS Device
* [ ] Android Device
* [ ] `curl` to a dev App Engine server

#### Please follow this checklist. Please check each appropriate box (put an 'x' or check it after creating the PR).

- [x] REQUIRED: Do you have an Issue **assigned to you** for this PR?
- [x] Provided detailed pull request description and a succinct title
- [x] Tested your changes, especially after any code review iterations.
- [ ] Included any relevant screenshots of UI updates.
- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verified all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
- [x] Verified your name is in the [docs/credits.yaml](https://github.com/WorldHealthOrganization/app/blob/master/docs/credits.yaml) file (if you want it to be).
