### PR TITLE
WHO Prod Project

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,3 @@
-## Summary
-
-Add description here
-
-Closes #XXXX
-
 ## Screenshots
 
 <details>
@@ -22,5 +16,4 @@ Add any relevant before/after screenshots here
 
 ## Checklist:
 
-- [ ] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
-- [ ] Verify all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
+- [ ] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).

--- a/server/appengine/src/main/java/who/Environment.java
+++ b/server/appengine/src/main/java/who/Environment.java
@@ -37,6 +37,7 @@ public enum Environment {
         return PRODUCTION;
       // Workaround for bug in App Engine. Not sure where those 2 chars at the beginning come from.
       case "o~who-myhealth-europe":
+      case "o~myhealthapp-291008":
         return PRODUCTION;
       case "test":
         return TEST;


### PR DESCRIPTION
- App Engine to identify WHO production project in GCP (see #1298)
- Remove "summary" from PR Template as commit message should suffice

## Screenshots

<details>
<summary>Screenshots</summary>
Add any relevant before/after screenshots here
</details>

## How did you test the change?

- [ ] iOS Simulator
- [ ] iOS Device
- [ ] Android Simulator
- [ ] Android Device
- [x] `curl` to a dev App Engine server
- [ ] other, please describe

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md).
- [x] Verify all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE) file in the root of the repository.
