### PR TITLE
MIT License to Apache 2.0 License

### DIFF
--- a/.github/policy-ignored-lines.txt
+++ b/.github/policy-ignored-lines.txt
@@ -1,5 +1,6 @@
 # Add one entry per line.  Each entry is a hash of a filename and source code content and the filename itself.
 
+ebaebed357e161ca0d3d98b8c779a81a3f7beff25555e79ce69b9f67055b71ae LICENSE
 1c71bd5db5093d0b48b7e3f303fe80d0ca6745b3f59a26c474cbd6e1c407b4a8 client/assets/content_bundles/your_questions_answered.en.yaml
 a4db85b5d39d2de2d745fe0a5b1b8f6b214847d3bd2126b75bd4a1ad66d958e1 client/assets/content_bundles/your_questions_answered.en.yaml
 7b98e48b1ed653316ab04f41e6f8c7f4a678730545e72c8b454157120ad8bca9 client/assets/onboarding/iso_countries.ar.yaml

--- a/LICENSE
+++ b/LICENSE
@@ -1,45 +1,227 @@
  https://github.com/WorldHealthOrganization/app
 
-Built by the WHO COVID-19 App Collective (see docs/credits.yaml).
+Copyright (c) 2020 World Health Organization
+
+Built by the WHO COVID-19 App Collective (see content/credits.yaml).
 
 The WHO visual identity assets, including but not limited to the
-WHO Logo and Emblem, are not licensed under the MIT License and are instead
-subject to the policies at
-https://www.who.int/about/who-we-are/publishing-policies/copyright
-and
-https://www.who.int/about/who-we-are/publishing-policies/logo .
+WHO Logo and Emblem, are not licensed under the Apache 2.0 License
+and are instead subject to the policies at the following:
+  https://www.who.int/about/who-we-are/publishing-policies/copyright
+  https://www.who.int/about/who-we-are/publishing-policies/logo
 
-The app icon is the exclusive property of the World Health Organization
-and is not subject to the MIT License.  No rights or licenses in copyright
+The app icon is the exclusive property of the World Health Organization and
+is not subject to the Apache 2.0 License. No rights or licenses in copyright
 or trademark in the app icon are conferred under this license agreement.
 
 Government or other organizational agency logos, marks and similar visual
 assets, including but not limited to files prefixed with `agency-`, are
 the property of the respective mark owners, and are not licensed under,
-and are excluded from the terms of, the MIT License and any other use of
-such assets must be obtained from the rights holder.
+and are excluded from the terms of, the Apache 2.0 License and any other
+use of such assets must be obtained from the rights holder.
 
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2020 World Health Organization
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
 
 This repository may contain third-party code or content licensed as follows:
 
@@ -70,7 +252,7 @@ Font Awesome Free 5.13.0 by @fontawesome - https://fontawesome.com
 --------------------------------------------------------------------------------
 Modified and original assets from https://undraw.co/ :
 
-Assets from https://undraw.co/ (including files prefixed with `undraw-`) are not governed by the MIT License,
+Assets from https://undraw.co/ (including files prefixed with `undraw-`) are not governed by the Apache 2.0 License,
 but instead are governed by the following license terms (https://undraw.co/license):
 
 Copyright 2020 Katerina Limpitsouni
@@ -85,7 +267,7 @@ Are registered trademarks of their respected owners. Are included on a promotion
 --------------------------------------------------------------------------------
 Modified and original Streamline Icons:
 
-Assets from Webalys LLC (including files prefixed with `streamline-`) are not governed by the MIT License, but instead are the property of Webalys LLC, and can be used only in the context of this open source project.
+Assets from Webalys LLC (including files prefixed with `streamline-`) are not governed by the Apache 2.0 License, but instead are the property of Webalys LLC, and can be used only in the context of this open source project.
 
 --------------------------------------------------------------------------------
 For client/lib/pages/license_page.dart:


### PR DESCRIPTION
Based on consent of contributors as recorded in:
[docs/legal/apache-2.0-relicensing.txt](https://github.com/WorldHealthOrganization/app/blob/master/docs/legal/apache-2.0-relicensing.txt)

The GitHub consents are publicly posted here:
#1645

Notes:
- Correction to commit 8a96d8f. @Moosphan gave consent over email but
commit message incorrectly states he should be excluded.
- Only GitHub consent not received was @amourakora for commit 91b2c88,
this removed a single apostrophe and is considered trivial.
- Two non-GitHub consent sought and not received:
  - Stephen Walters: He created the "WHOapp v0.1 Analytics and
    Instrumentation" doc that is under his personal account and not hosted
    on the shared Google Drive. Considered immaterial for relicensing.
    https://docs.google.com/document/d/1ZQ8GyO0Myl23u0_nhK42PO2xBkVbXjbVawjpND6zKiU/edit
  - Ellen Jewell: replied via email stating she had made no contributions
- Tracking spreadsheet for consents stored in private file on team drive:
  https://docs.google.com/spreadsheets/d/1rYWQvgWzQcCyViV56fj9KIfLpWKiLw8OJdbuRRTm-E8/edit#gid=1790111101
- Requests for suggestions on any further consents were posted over
private email, Slack and public team email group. Only replies with
specific names were for @marcmcl (Marc McLaughlin) who has a PR in
progress but which is not yet merged.
- The content of this commit have not been modified since it was
created, except for the commit message.

Replaces PR #1474

Close #1546
Close #1645

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
