### PR TITLE
Advay Mengle limited consent to Apache 2.0 relicensing

### DIFF
--- a/docs/legal/apache-2.0-relicensing.txt
+++ b/docs/legal/apache-2.0-relicensing.txt
@@ -16,18 +16,22 @@ Bruno Bowden - brunob@gmail.com, github@brunobowden.com
 
 
 
+# Limited Consent
 
+By adding my name and email addresses below, I additionally license under the Apache
+License 2.0 (https://www.apache.org/licenses/LICENSE-2.0.txt) each original
+contribution I have made to this git repository that meets all of the following
+conditions:
+1) The contribution was submitted to this repository under any of my listed email addresses,
+2) The contribution was previously licensed under the MIT License that existed at the root of
+   this repository at the time of the original contribution, and
+3) All rights in the contribution are either owned entirely by me OR owned entirely by me and
+   other persons, all of whom have consented in writing as recorded in this document to also
+   license their contributions under the Apache License 2.0.
+My consent is conditioned on the preservation of this notice, this document, and all associated
+agreement commits within the repository.
 
-
-
-
-
-
-
-
-
-
-
+Advay Mengle - Oct. 22, 2020 (see notes in associated commit) - source@madvay.com, 11729521+advayDev1@users.noreply.github.com, advay.mengle.dev1@gmail.com, advayDev1@users.noreply.github.com
 
 
 # Apache 2.0 and MIT Licensing


### PR DESCRIPTION
To be clear, you still need to get the consents of everyone else.

The commit contains the following legend:

This limited consent is based on the following:
* The consent by Ayman Badr on behalf of the World Health Organization to accept, and to license WHO's own contributions under, that certain form of license at https://raw.githubusercontent.com/WorldHealthOrganization/app/4d1a611bfa5ea807a8c3d2551beecfe8bc7f8cb2/LICENSE which includes a WHO copyright statement and also documents other components not licensed under the expected-new main Apache License 2.0 (which is documented in email from Ayman). Because the specific PR that Ayman referenced has been superseded, the file has been archived at https://web.archive.org/web/20200916041246/https://raw.githubusercontent.com/WorldHealthOrganization/app/4d1a611bfa5ea807a8c3d2551beecfe8bc7f8cb2/LICENSE
* @brunobowden 's representation that all of the persons listed within the "Apache 2.0 and MIT Licensing" section have consented as stated therein, in writing, to Bruno even though they have not recorded their own consent via git.  Their contributions are not necessarily tracked via the git repository.
* @brunobowden 's prior commitment that he will reach out to at least all of the people on both sheets of the contributor spreadsheet, and if he decides not to wait for any of their consent, to document that they did not consent in the final relicensing PR and document what was owned by them that he removed.

Notes:
* If not all contributors consent, it may be necessary to remove not only their direct contributions to the repository but also moves, copies, refactors, adaptations, or resurrections of deleted files, etc. of their work added in subsequent commits, even though the non-consenter's name may not appear on the subsequent commit.
* Note that not all contributors are necessarily documented via the Git history, and that some contributors that are tracked via Git are not within the commit author field but instead within the `Co-authored-by:` or `Signed-off-by:` (case-insensitive) lines in the commit message.
* It may be difficult to track these contributions, especially for contributors whose work is largely performed outside of git and then put into git by a different contributor.
* My consent is provided in limited form partly to ensure that if not all contributors consent to the relicensing, the non-consenters' work, if it has been adapted, moved, copied, resurrected, or refactored in a subsequent commit by myself, is not deemed to be relicensed by my own consent, which applies even if my name appears on the `git blame` for a particular contribution or segment of code.
* None of this constitutes legal advice, nor can I represent that it is sufficient to lawfully perform the contemplated relicensing of the repository, nor can I represent that the contributor spreadsheet lists all IP-owners for this project.
* I recommend that @brunobowden and the project seek legal advice regarding this relicensing process to ensure that the rights of all contributors are appropriately protected and to ensure that downstream recipients of the contemplated new license can use it with confidence.
