### PR TITLE
Learn More Page AutoScale text

### DIFF
--- a/client/lib/components/carousel/carousel_slide.dart
+++ b/client/lib/components/carousel/carousel_slide.dart
@@ -41,7 +41,7 @@ class _CarouselSlideState extends State<CarouselSlide> {
 
     final titleStyle = TextStyle(
       color: Constants.primaryDarkColor,
-      fontSize: 36.0,
+      fontSize: 36.0 * screenSize.width.clamp(275, 550) / 550,
       fontWeight: FontWeight.w600,
       letterSpacing: -.5,
     );


### PR DESCRIPTION
AutoScale title on Get the Facts pages
Closes #1240

- This will not scale up the text on big screens
- The minimum size of the text will be half of the original rate on small screens
- The scaling down is linear based on screen width

- Screens above 550 pixels wide see no changes
- Screens below 275 pixels are shown text one half the size of the regular size
- Screens inbetween see a size equal to their size, divided by 550, multiplied by the normal size

## Screenshots
<details>
<summary>Screenshots</summary>
As I understand that autoscaling can be worrying I have tested on many devices -- including devices that this change does not affect the size of the text of.

**iPhones**
- iPhone SE
![iPhoneSE-1](https://user-images.githubusercontent.com/38309438/97048461-50500600-152f-11eb-8c1a-2f457a7c323d.png)
![iPhoneSE-2](https://user-images.githubusercontent.com/38309438/97048462-51813300-152f-11eb-934c-ecf1e49ad406.png)
![iPhoneSE-3](https://user-images.githubusercontent.com/38309438/97048463-5219c980-152f-11eb-85a0-9296623a8d3f.png)
- iPhone 8
![iPhone8-1](https://user-images.githubusercontent.com/38309438/97048490-5b0a9b00-152f-11eb-9525-ca06c65967a3.png)
![iPhone8-2](https://user-images.githubusercontent.com/38309438/97048505-5c3bc800-152f-11eb-8d6b-6420892c2de8.png)
![iPhone8-3](https://user-images.githubusercontent.com/38309438/97048515-5c3bc800-152f-11eb-84be-76207ba73ae6.png)
- iPhone 8+
![iPhone8+-1](https://user-images.githubusercontent.com/38309438/97048648-64940300-152f-11eb-99ef-0e1ff537b626.png)
![iPhone8+-2](https://user-images.githubusercontent.com/38309438/97048662-65c53000-152f-11eb-9aa1-c0a8eb8b0c11.png)
![iPhone8+-3](https://user-images.githubusercontent.com/38309438/97048672-665dc680-152f-11eb-957a-29df84332fbb.png)
- iPhone 11
![iPhone11-1](https://user-images.githubusercontent.com/38309438/97048770-707fc500-152f-11eb-8ec2-69e28c4039e6.png)
![iPhone11-2](https://user-images.githubusercontent.com/38309438/97048772-71b0f200-152f-11eb-9e9d-2621c63b572b.png)
![iPhone11-3](https://user-images.githubusercontent.com/38309438/97048773-72498880-152f-11eb-90f5-6580866fcb95.png)
**Androids**
- Galaxy Nexus
![GalaxyNexus-1](https://user-images.githubusercontent.com/38309438/97048861-960cce80-152f-11eb-9e98-d5d53c231a29.png)
![GalaxyNexus-2](https://user-images.githubusercontent.com/38309438/97048863-973dfb80-152f-11eb-9798-59aaddb9120c.png)
![GalaxyNexus-3](https://user-images.githubusercontent.com/38309438/97048864-973dfb80-152f-11eb-873a-749bab91af0e.png)
- Nexus 4
![Nexus4-1](https://user-images.githubusercontent.com/38309438/97048878-9dcc7300-152f-11eb-93c6-ad40f2d949cf.png)
![Nexus4-2](https://user-images.githubusercontent.com/38309438/97048880-9e650980-152f-11eb-95f0-c05794f5f8a0.png)
![Nexus4-3](https://user-images.githubusercontent.com/38309438/97048883-9efda000-152f-11eb-83aa-e87f43207c77.png)
-  Pixel 3
![Pixel3-1](https://user-images.githubusercontent.com/38309438/97048910-a91f9e80-152f-11eb-9c86-976706b8d742.png)
![Pixel3-2](https://user-images.githubusercontent.com/38309438/97048913-a9b83500-152f-11eb-8627-c1b699c750a7.png)
![Pixel3-3](https://user-images.githubusercontent.com/38309438/97048914-aa50cb80-152f-11eb-93d7-dc9f7e5aaa6b.png)
- Pixel 3 XL
![Pixel3XL-1](https://user-images.githubusercontent.com/38309438/97048966-c2284f80-152f-11eb-8e0d-b77d3664088b.png)
![Pixel3XL-2](https://user-images.githubusercontent.com/38309438/97048969-c3597c80-152f-11eb-920e-bcdd2ceb74b4.png)
![Pixel3XL-3](https://user-images.githubusercontent.com/38309438/97048971-c3f21300-152f-11eb-8f68-678ee9e85d13.png)

- Pixel 3a
![Pixel3a-1](https://user-images.githubusercontent.com/38309438/97048925-afae1600-152f-11eb-928e-b59634f66e69.png)
![Pixel3a-2](https://user-images.githubusercontent.com/38309438/97048928-b046ac80-152f-11eb-87de-e506c8aca15f.png)
![Pixel3a-3](https://user-images.githubusercontent.com/38309438/97048930-b0df4300-152f-11eb-9417-98a93df13b95.png)
- Pixel 3a XL
![Pixel3aXL-1](https://user-images.githubusercontent.com/38309438/97048993-c9e7f400-152f-11eb-8132-98046d13c4aa.png)
![Pixel3aXL-2](https://user-images.githubusercontent.com/38309438/97048995-cb192100-152f-11eb-8c3d-aa1a763c04e8.png)
![Pixel3aXL-3](https://user-images.githubusercontent.com/38309438/97048997-cb192100-152f-11eb-83e4-7c4a2c6a9571.png)
- Pixel 4
![Pixel4-1](https://user-images.githubusercontent.com/38309438/97049022-d5d3b600-152f-11eb-8f19-52271fb10b38.png)
![Pixel4-2](https://user-images.githubusercontent.com/38309438/97049025-d66c4c80-152f-11eb-8082-c20c472f4286.png)
![Pixel4-3](https://user-images.githubusercontent.com/38309438/97049027-d704e300-152f-11eb-9d3c-2aaddb2d1005.png)
- Pixel 4 XL
![Pixel4XL-1](https://user-images.githubusercontent.com/38309438/97049040-dd935a80-152f-11eb-87d2-02fba4c295e1.png)
![Pixel4XL-2](https://user-images.githubusercontent.com/38309438/97049042-de2bf100-152f-11eb-9c33-7966046a5d33.png)
![Pixel4XL-3](https://user-images.githubusercontent.com/38309438/97049043-dec48780-152f-11eb-83b1-a86d7e1b773b.png)

</details>

## How did you test the change?

- [x] iOS Simulator
- [ ] iOS Device
- [x] Android Simulator
- [ ] Android Device
- [ ] `curl` to a dev App Engine server
- [ ] other, please describe

## Checklist:

- [ ] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
