### PR TITLE
Learn More Headline Opaque Shadow

### DIFF
--- a/client/lib/components/learn_page_promo.dart
+++ b/client/lib/components/learn_page_promo.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:who_app/api/linking.dart';
@@ -5,6 +7,18 @@ import 'package:who_app/components/button.dart';
 import 'package:who_app/components/promo_curved_background.dart';
 import 'package:who_app/components/themed_text.dart';
 import 'package:who_app/constants.dart';
+
+const shadow = Shadow(
+  blurRadius: 20.0,
+);
+
+// 4X shadows is used to make it more opaque and offset from the background
+const opaqueShadow = <Shadow>[
+  shadow,
+  shadow,
+  shadow,
+  shadow,
+];
 
 class LearnPagePromo extends StatelessWidget {
   final String title;
@@ -51,6 +65,7 @@ class LearnPagePromo extends StatelessWidget {
                   textAlign: TextAlign.center,
                   style: TextStyle(
                     color: CupertinoColors.white,
+                    shadows: opaqueShadow,
                   ),
                 ),
                 ThemedText(
@@ -59,6 +74,7 @@ class LearnPagePromo extends StatelessWidget {
                   textAlign: TextAlign.center,
                   style: TextStyle(
                     color: CupertinoColors.white,
+                    shadows: opaqueShadow,
                   ),
                 ),
                 SizedBox(


### PR DESCRIPTION
Added blurred text behind the subtitle text

Related to suggestion in #1511

Closes #1571 

## Screenshots

<details>
<summary>Screenshots</summary>

<img alt="Screenshot" src="https://user-images.githubusercontent.com/38309438/97115154-4acef900-16b2-11eb-8196-ea814a27c583.png" width="250px">

</details>

## How did you test the change?

- [x] iOS Simulator
- [ ] iOS Device
- [x] Android Simulator
- [ ] Android Device
- [ ] `curl` to a dev App Engine server
- [ ] other, please describe

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
