### PR TITLE
Fix Loading on Stats Page Charts

### DIFF
--- a/client/lib/components/recent_numbers_graph.dart
+++ b/client/lib/components/recent_numbers_graph.dart
@@ -171,6 +171,7 @@ class _RecentNumbersGraphState extends State<RecentNumbersGraph> {
   Widget graph;
   final numFmt = NumberFormat.decimalPattern();
   int titleData;
+
   @override
   Widget build(BuildContext context) {
     graph = RecentNumbersBarGraph(
@@ -210,9 +211,11 @@ class _RecentNumbersGraphState extends State<RecentNumbersGraph> {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       ThemedText(
-                        numFmt.format(titleData) == '0'
+                        loading
                             ? '-'
-                            : numFmt.format(titleData),
+                            : numFmt.format(
+                                titleData,
+                              ),
                         variant: TypographyVariant.h2,
                         style: TextStyle(
                           color: widget.dimension == DataDimension.cases
@@ -251,6 +254,8 @@ class _RecentNumbersGraphState extends State<RecentNumbersGraph> {
         return '';
     }
   }
+
+  bool get loading => widget.timeseries == null;
 
   Color get graphColor => widget.dimension == DataDimension.cases
       ? Constants.primaryDarkColor


### PR DESCRIPTION
Fix Loading on stats page charts

## Screenshots

<details>
<summary>Screenshots</summary>
First two screenshots show charts once loaded functioning properly, third shows loading functioning properly
<img alt="screenshot #1" src="https://user-images.githubusercontent.com/38309438/97121315-9c8b7980-16da-11eb-995f-c5d7bf0f1888.png" width="250px">
<img alt="screenshot #2" src="https://user-images.githubusercontent.com/38309438/97121316-9dbca680-16da-11eb-8448-299e47afddb2.png" width="250px">
<img alt="screenshot #3" src="https://user-images.githubusercontent.com/38309438/97121317-9dbca680-16da-11eb-9db8-a5e094c99f92.png" width="250px">

</details>

## How did you test the change?

- [x] iOS Simulator
- [ ] iOS Device
- [ ] Android Simulator
- [ ] Android Device
- [ ] `curl` to a dev App Engine server
- [ ] other, please describe

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
