### PR TITLE
Made daily default on stats page

### DIFF
--- a/client/lib/pages/main_pages/recent_numbers.dart
+++ b/client/lib/pages/main_pages/recent_numbers.dart
@@ -179,6 +179,7 @@ class _RecentNumbersPageState extends State<RecentNumbersPage> {
   Map<DataAggregation, Widget> _buildSegmentControlChildren(
       BuildContext context, DataAggregation selectedValue) {
     var valueToDisplayText = {
+      // TODO: Localize - need to regenerate translation keys as this string was changed
       DataAggregation.daily: 'Daily',
       DataAggregation.total: S.of(context).latestNumbersPageTotalToggle,
     };

--- a/client/lib/pages/main_pages/recent_numbers.dart
+++ b/client/lib/pages/main_pages/recent_numbers.dart
@@ -181,7 +181,6 @@ class _RecentNumbersPageState extends State<RecentNumbersPage> {
     var valueToDisplayText = {
       DataAggregation.daily: 'Daily',
       DataAggregation.total: S.of(context).latestNumbersPageTotalToggle,
-      // TODO: This string changed, so we must change regenerate translation keys someday.
     };
     return valueToDisplayText.map((value, displayText) {
       return MapEntry<DataAggregation, Widget>(

--- a/client/lib/pages/main_pages/recent_numbers.dart
+++ b/client/lib/pages/main_pages/recent_numbers.dart
@@ -62,7 +62,7 @@ class RecentNumbersPage extends StatefulWidget {
 }
 
 class _RecentNumbersPageState extends State<RecentNumbersPage> {
-  var aggregation = DataAggregation.total;
+  var aggregation = DataAggregation.daily;
   var dimension = DataDimension.cases;
 
   @override
@@ -179,9 +179,9 @@ class _RecentNumbersPageState extends State<RecentNumbersPage> {
   Map<DataAggregation, Widget> _buildSegmentControlChildren(
       BuildContext context, DataAggregation selectedValue) {
     var valueToDisplayText = {
+      DataAggregation.daily: 'Daily',
       DataAggregation.total: S.of(context).latestNumbersPageTotalToggle,
       // TODO: This string changed, so we must change regenerate translation keys someday.
-      DataAggregation.daily: 'Daily',
     };
     return valueToDisplayText.map((value, displayText) {
       return MapEntry<DataAggregation, Widget>(


### PR DESCRIPTION
- Changed the default Aggregation emun to be the value of the daily cases
- Changed the order of the daily and total values so it loops through the daily first, intern switching the default stat.

## Screenshots
![Simulator Screen Shot - iPhone 12 Pro Max - 2020-10-26 at 12 56 31](https://user-images.githubusercontent.com/58492005/97221911-cbf9bf00-178a-11eb-8773-a2b506ee2344.png)

<details>
<summary>Screenshots</summary>
Add any relevant before/after screenshots here
</details>

## How did you test the change?

- [x] iOS Simulator
- [x] iOS Device
- [ ] Android Simulator
- [ ] Android Device
- [ ] `curl` to a dev App Engine server
- [ ] other, please describe

## Checklist:

- [ ] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
