### PR TITLE
Fabric cleanup - remnants from transition to Firebase Crashlytics

### DIFF
--- a/client/android/app/build.gradle
+++ b/client/android/app/build.gradle
@@ -20,6 +20,10 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
+// Crashlytics
+apply plugin: 'com.google.gms.google-services'
+apply plugin: 'com.google.firebase.crashlytics'
+
 android {
     compileSdkVersion 28
 
@@ -54,13 +58,8 @@ flutter {
 }
 
 dependencies {
-    implementation 'com.google.firebase:firebase-analytics:17.2.2'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
 }
-
-// For Crashlytics
-apply plugin: 'io.fabric'
-apply plugin: 'com.google.gms.google-services'

--- a/client/android/build.gradle
+++ b/client/android/build.gradle
@@ -7,8 +7,9 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.2.0'
         classpath 'com.google.gms:google-services:4.3.3'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 

--- a/client/android/build.gradle
+++ b/client/android/build.gradle
@@ -3,17 +3,12 @@ buildscript {
     repositories {
         google()
         jcenter()
-        // Repository for crashlytics
-        maven {
-            url 'https://maven.fabric.io/public'
-        }
     }
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.gms:google-services:4.3.3'
-        classpath 'io.fabric.tools:gradle:1.26.1'
     }
 }
 


### PR DESCRIPTION
- Fabric repo and dependencies removed
- Moved crashlytics plugin above android config to match documentation
  https://firebase.flutter.dev/docs/crashlytics/overview#3-platform-integration

- Firebase Analytics classpath removed as not mentioned in documentation:
  https://firebase.flutter.dev/docs/analytics/overview#installation

## How did you test the change?

- [ ] iOS Simulator
- [ ] iOS Device
- [x] Android Simulator
- [ ] Android Device
- [ ] `curl` to a dev App Engine server
- [ ] other, please describe

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
