### PR TITLE
No privacy alert made shorter for dev builds

### DIFF
--- a/client/lib/main.dart
+++ b/client/lib/main.dart
@@ -208,7 +208,7 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
               return [
                 if (BuildInfo.DEVELOPMENT_ONLY)
                   Alert(null,
-                      'You are using a development-only build of this app not intended for public use. You agree that you have no expectation of privacy when using this build and understand that the app contents may not have been reviewed by the World Health Organization.',
+                      'No privacy on development only builds. Content not reviewed by WHO.',
                       dismissable: true),
                 if (content.unsupportedSchemaVersionAvailable)
                   Alert('App Update Required',


### PR DESCRIPTION

## How did you test the change?

- [ ] iOS Simulator
- [ ] iOS Device
- [x] Android Simulator
- [ ] Android Device
- [ ] `curl` to a dev App Engine server
- [ ] other, please describe

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).

## Screenshot

<img width="304" alt="Screen Shot 2020-10-27 at 10 25 35 AM" src="https://user-images.githubusercontent.com/679339/97338555-c362c080-183e-11eb-9dca-8e22916d2db2.png">
