### PR TITLE
iTune invalid bundle fix

### DIFF
--- a/client/ios/Flutter/AppFrameworkInfo.plist
+++ b/client/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>8.0</string>
+  <string>9.0</string>
 </dict>
 </plist>


### PR DESCRIPTION
- Based on this comment:
https://flutter.dev/docs/deployment/ios#updating-the-apps-deployment-version

Error:
```
ERROR ITMS-90208: "Invalid Bundle. The bundle Runner.app/Frameworks/App.framework
does not support the minimum OS Version specified in the Info.plist."
```

Tested on CI and with new deployment

## Screenshots

<details>
<summary>Screenshots</summary>
Add any relevant before/after screenshots here
</details>

## How did you test the change?

- [ ] iOS Simulator
- [ ] iOS Device
- [ ] Android Simulator
- [ ] Android Device
- [ ] `curl` to a dev App Engine server
- [ ] other, please describe

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
