### PR TITLE
Chris Juneja relicensing consent + Tabassum Wajid added to Credits

### DIFF
--- a/docs/credits.yaml
+++ b/docs/credits.yaml
@@ -34,6 +34,7 @@ team:
   - Bruno Bowden
   - Chris Grey
   - Chris Hosmer
+  - Chris Juneja
   - Clément Mouchet
   - creativecreatorormaybenot
   - Dan Field

--- a/docs/credits.yaml
+++ b/docs/credits.yaml
@@ -142,6 +142,7 @@ team:
   - Stephen Elson
   - Stevan Milovanovic
   - Stoney Gamble
+  - Tabassum Wajid
   - Tedros Adhanom Ghebreyesus
   - Toby Felgenner
   - Thierry Borowiec

--- a/docs/legal/apache-2.0-relicensing.txt
+++ b/docs/legal/apache-2.0-relicensing.txt
@@ -103,6 +103,7 @@ Angela Yeung
 Anshul Patria
 Bill Pugh
 Chris Hosmer
+Chris Juneja
 Daniel Kraft
 David Kaneda
 Diana Alayon


### PR DESCRIPTION
- Chris Juneja consent for Apache 2.0 relicensing
- Tabassum Wajid added to credits

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
