### PR TITLE
Terraform fmt and validate pre-commit checks fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ staticContentBuild/
 # Note: Android Studio is a modified version of IntelliJ
 *.iws
 
+# Temporary personal files to ignore
+*-ignore.*
 
 # COCOAPODS
 Pods

--- a/tools/.lintstagedrc.json
+++ b/tools/.lintstagedrc.json
@@ -5,8 +5,8 @@
   "../**/*.dart|*.dart": [
     "flutter format"
   ],
-  "../server/terraform/**/*.{tf,tfvars}": [
-    "terraform fmt -recursive"
+  "../server/terraform/**": [
+    "terraform-fmt-validate.sh"
   ],
   "../client/**": [
     "./verify-client.sh"

--- a/tools/terraform-fmt-validate.sh
+++ b/tools/terraform-fmt-validate.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Run by .linstagedrc.json
+# Ignores parameters of staged files to fmt and validate everything
+
+set -euv
+cd $(dirname "$0")/../server/terraform
+
+terraform fmt -recursive .
+terraform validate .

--- a/tools/verify-client.sh
+++ b/tools/verify-client.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 set -euv
-cd ../client
+
+cd $(dirname "$0")/../client
+
 flutter analyze --no-pub
 flutter test --no-pub

--- a/tools/verify-server.sh
+++ b/tools/verify-server.sh
@@ -7,6 +7,7 @@ cd $(dirname "$0")/../server
 
 # Terraform Checks
 cd ./terraform
+# init is needed on CI
 terraform init
 terraform validate .
 terraform fmt -check -recursive .

--- a/tools/verify-server.sh
+++ b/tools/verify-server.sh
@@ -7,7 +7,7 @@ cd $(dirname "$0")/../server
 
 # Terraform Checks
 cd ./terraform
-# init is needed on CI
+# init for CI, check but don't format
 terraform init
 terraform validate .
 terraform fmt -check -recursive .


### PR DESCRIPTION
- terraform fmt -recursive
- terraform validate   (no recursive option)
- tested with many local using pre-commit checks
- ignore files matching `*-ignore.*`

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
