### PR TITLE
CI appbundle build

### DIFF
--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -94,6 +94,9 @@ jobs:
         working-directory: ./client
       - run: git diff --exit-code
       - run: DEVELOPMENT_ONLY=true ./tools/gen-client-buildinfo.sh
+      - run: flutter build appbundle
+        working-directory: ./client
+      # TODO: generate apk from appbundle using bundletool
       - run: flutter build apk
         working-directory: ./client
       - name: Upload Staging APK artifact


### PR DESCRIPTION
1. `flutter build appbundle`
2. `flutter build apk`

This duplicative as the apks should be generated from the appbundle
using bundletool. That will be done later.

Fixes #1725 

## How did you test the change?

CI build

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
