### PR TITLE
Production Terraform

### DIFF
--- a/client/lib/main.dart
+++ b/client/lib/main.dart
@@ -208,7 +208,7 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
               return [
                 if (BuildInfo.DEVELOPMENT_ONLY)
                   Alert(null,
-                      'No privacy on development builds. Content not reviewed by WHO.',
+                      'No privacy on test builds. Content not reviewed by WHO.',
                       dismissable: true),
                 if (content.unsupportedSchemaVersionAvailable)
                   Alert('App Update Required',

--- a/server/terraform/README.md
+++ b/server/terraform/README.md
@@ -5,42 +5,105 @@ Beyond the normal benefits of IaC, it serves essential roles for the WHO App
 for transparency and security. Team policy is to use IaC and in particular Terraform
 for as much configuration as possible. Particularly the WHO production servers.
 
-### Prerequisites
+### Development Organization
+
+To allow development to be done more easily by the open source community. A
+development organization is maintained at whocoronavirus.org separate from
+WHO production infrastructure. This organization and the projects it hosts
+set an expectation of no privacy. Release versions of the app must never
+connect to these development servers.
+
+The development organization is outside of WHO control and responsibility.
+Along with no privacy expectations, it makes it easier to grant access and
+do development. This access does not give any access to the WHO production
+infrastructure.
+
+To start with, use a Google Cloud organization of your own. At some point,
+you can approach one of the maintainers about access to the development
+organization.
+
+### Terraform Service Account
+
+Service accounts are used by Terraform to create and edit the cloud projects.
+To maintain separation between these accounts and the projects they're
+managing, follow these instructions to create a `who-terraform-admin`
+project (this already exists in the development organization):
+
+https://github.com/GoogleCloudPlatform/community/blob/master/tutorials/managing-gcp-projects-with-terraform/index.md#create-the-terraform-admin-project
+
+This creates a Terraform service account with the permissions for:
+
+- Billing Account User
+- Project Creator
+
+Terraform access to the WHO production project is limited to only the project
+itself and not the wider organization. The service account is created within the
+project instead. The who-mh-prod-in-dev project is used to replicate this
+environment in the development organization. Starting from a newly created empty
+project, create a `who-terraform-prod-admin`
+[service account](https://console.cloud.google.com/iam-admin/serviceaccounts)
+with the following permissions:
+
+- Project Owner
+
+### Setup
 
 - [Install Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli?in=terraform/gcp-get-started)
-- Make sure you have access to `who-terraform-admin` project.
+- [Service Account Console](https://console.cloud.google.com/iam-admin/serviceaccounts?project=who-terraform-admin&folder=&organizationId=&supportedpurview=project)
+- Ask maintainers for access (limited to small group)
 - Create a new key
-  - Visit: https://console.cloud.google.com/apis/credentials/serviceaccountkey?project=who-terraform-admin&organizationId=532343229286
+  - Visit (example for development organization): https://console.cloud.google.com/apis/credentials/serviceaccountkey?project=who-terraform-admin&organizationId=532343229286
   - Service Account: select "Terraform"
-  - Click "Create", download file and configure environment:
+  - Click "Create", download file
+
+Configure the credentials:
 
 ```sh
 export GOOGLE_APPLICATION_CREDENTIALS=<path to json credentials>
 ```
 
-This uses the `terraform@who-terraform-admin.iam.gserviceaccount.com` service account in the `who-terraform-admin` project.
+This uses the `terraform@who-terraform-admin.iam.gserviceaccount.com` service account
+in the `who-terraform-admin` project. To complete the setup, navigate to a particular
+directory and apply the project:
+
+```sh
+cd server/terraform/prod-in-dev
+
+terraform init
+terraform apply
+```
+
+See the [Production Setup](#production-setup) for special instructions for the
+`who-mh-prod` and `who-mh-prod-in-dev` projects. The other projects don't need
+any special setup.
 
 ### External Documentation
 
 - [Terraform adding credentials](https://www.terraform.io/docs/providers/google/guides/getting_started.html#adding-credentials)
 - [Securely handling keys](https://cloud.google.com/iam/docs/understanding-service-accounts?_ga=2.87249435.-2051693357.1581897767#managing_service_account_keys)
 
-### Terraform service account
+### Current Projects
 
-Only needed for terraform service account setup. The account must have these permissions:
+The WHO Production server is the only server that follows the privacy policy.
+There is no expectation of privacy for the development organization projects,
+which are in the list below. The project renaming is still in progress:
 
-- Billing Account User
-- Project Creator
+| Server Name        | Purpose                                                 |
+| ------------------ | ------------------------------------------------------- |
+| who-mh-hack        | Dedicated server for penetration testing                |
+| who-mh-prod-in-dev | Replicates permissions and setup of who-mh-prod project |
+| who-mh-prod        | WHO Production infrastructure, Privacy Policy compliant |
+| who-mh-staging     | CI server updated from GitHub repo                      |
 
 ### New Project
 
-When new projects are added (e.g. prod, staging, hack, ...) - for each project:
+Follow these steps and update the project list above:
 
-```shell script
+```sh
 mkdir server/terraform/xxxx
 cd server/terraform/xxxx
 
-# new Terraform config
+# Terraform new config should be based on staging
 cp ../staging/main.tf .
 emacs main.tf
 
@@ -49,9 +112,9 @@ terraform apply
 # Should create all resources without any errors
 ```
 
-### Update Project
+### Terraform Apply
 
-The `apply` can be used to both create and update the server config:
+`terraform apply` can be used to both create and update the server config:
 
 ```sh
 # setup
@@ -73,14 +136,52 @@ destroy data and IP addresses that can't be recovered.
 # terraform destroy
 ```
 
+### Production Setup
+
+Terraform requires special setup since the service account uses an existing project.
+Terraform can't maintain the project state as the `google_project.billing_account`
+can only be edited with the "Billing Account User" permissions
+(see #terraform-service-account). The `who-mh-prod-in-dev` in the development
+organization replicates the permissions model of the `who-mh-prod` project in production.
+
+After creating an empty project with a matching project name, use `terraform apply`
+as normal to create and update the project. First time use will produce this error:
+
+```sh
+Error: Error creating ManagedZone: googleapi: Error 400: Please verify ownership of the 'prod-in-dev.whocoronavirus.org.' domain (or a parent) at http://www.google.com/webmasters/verification/ and try again, verifyManagedZoneDnsNameOwnership
+```
+
+Fix this by setting up a DNS A Record that points to the IPv4 global address.
+The DNS A Record is specified in the Terraform domain variable, e.g.
+staging.whocoronavirus.org. Use `terraform state` to get the IPv4 address it needs
+to point to:
+
+```sh
+terraform state show module.myhealth.module.lb.google_compute_global_address.ipv4
+# module.myhealth.module.lb.google_compute_global_address.ipv4:
+resource "google_compute_global_address" "ipv4" {
+address = "34.107.166.96" ...
+```
+
+If the service account has "Project Editor" access instead of "Project Owner",
+it will produce the following error. This still creates an App Engine instance
+but one that can't be edited by Terraform leaving the project permanently broken.
+
+```sh
+Error: Error creating App Engine application: googleapi: Error 403: The caller does not have permission, forbidden
+```
+
 ## Manual Setup
 
 The final setup must be completed manually for each project. This configuration should be moved to terraform if it is supported in the future.
 
-Production servers **MUST** be configured exactly as described here to:
+Production servers **MUST** be configured exactly as described here. Changes **MUST**
+be made through code and merged before being manually applied. Only exception is
+emergency changes for system reliability. In that case, this documentation must be
+promptly updated with any permanent changes to the server. The motivation is:
 
-- Provide full transparency on configuration
-- Comply with the privacy policy
+- Transparency on configuration
+- Privacy policy compliance
 
 ### Google Analytics
 
@@ -118,8 +219,10 @@ This provides the config files that the Android and iOS apps need to communicate
 1. App nickname: "WHO COVID-19"
 1. Skip "Debug signing cert"... might be needed for staging apks
 1. "Register app"
-1. "Download google-services.json" and move to `<repo>/client/android/app/`
-1. TODO: need mechanism to switch between Firebase instances
+1. "Download google-services.json"
+1. Append name based on project, e.g. "google-services-staging.json"
+1. Add to repo: `<repo>/client/android/app/`
+1. TODO: need mechanism to switch between Firebase instances, default is staging server
 1. Skip "Add Firebase SDK" and "Add initialization code"
 1. Run Android app in simulator to confirm Firebase setup
 
@@ -131,7 +234,9 @@ This provides the config files that the Android and iOS apps need to communicate
 1. App nickname: "WHO COVID-19"
 1. App Store ID: leave blank except for production
 1. "Register app"
-1. "Download GoogleService-Info.plist" and move to `<repo>/client/ios/Runner/`
-1. TODO: need mechanism to switch between Firebase instances
+1. "Download GoogleService-Info.plist"
+1. Append name based on project, e.g. "GoogleService-Info-staging.plist"
+1. Add to repo: `<repo>/client/ios/Runner/`
+1. TODO: need mechanism to switch between Firebase instances, default is staging server
 1. Skip "Add Firebase SDK" and "Add initialization code"
 1. Run iOS app in simulator to confirm Firebase setup

--- a/server/terraform/hack/main.tf
+++ b/server/terraform/hack/main.tf
@@ -2,6 +2,6 @@
 
 module "myhealth" {
   source     = "../modules/myhealth"
-  project_id = "who-myhealth10-hack"
+  project_id = "who-myhealth12-hack"
   domain     = "hack.whocoronavirus.org"
 }

--- a/server/terraform/modules/myhealth/main.tf
+++ b/server/terraform/modules/myhealth/main.tf
@@ -26,6 +26,7 @@ provider "google-beta" {
 # Google Project
 resource "google_project" "project" {
   provider        = google-beta
+  count           = var.create_project ? 1 : 0
   name            = var.project_id
   project_id      = var.project_id
   billing_account = var.billing_account
@@ -38,13 +39,14 @@ resource "google_project" "project" {
 # Do `depends_on` this resource iff it requires APIs to be enabled
 resource "google_project_service" "service" {
   for_each = toset([
+    "appengine.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
     "compute.googleapis.com",
     "dns.googleapis.com",
     "firebase.googleapis.com",
   ])
 
-  service = each.key
-
+  service            = each.key
   project            = var.project_id
   disable_on_destroy = false
   depends_on         = [google_project.project]
@@ -75,7 +77,7 @@ resource "google_app_engine_application" "gae" {
   project       = var.project_id
   location_id   = var.region
   database_type = "CLOUD_DATASTORE_COMPATIBILITY"
-  depends_on    = [google_project.project]
+  depends_on    = [google_project_service.service]
   # TODO: protect resource as it can't be recreated after being destroyed
   #lifecycle {
   #  prevent_destroy = true

--- a/server/terraform/modules/myhealth/variables.tf
+++ b/server/terraform/modules/myhealth/variables.tf
@@ -28,7 +28,14 @@ variable "org_id" {
   default = "532343229286"
 }
 
-# other settings
+# Create project: requires special permissions:
+# https://github.com/WorldHealthOrganization/app/blob/master/server/terraform/README.md#terraform-service-account
+variable "create_project" {
+  description = "Create Project. Set to false when using existing project."
+  type        = bool
+  default     = true
+}
+
 variable "create_dns_entry" {
   description = "Create a DNS A Record in Cloud DNS for the domain specified in 'domain'."
   type        = bool

--- a/server/terraform/prod-in-dev/main.tf
+++ b/server/terraform/prod-in-dev/main.tf
@@ -1,0 +1,14 @@
+# Production in Dev - testing production permissions, no privacy expectation
+
+# Replicates Production permissions which are more limited than development:
+# https://github.com/WorldHealthOrganization/app/blob/master/server/terraform/README.md#terraform-service-account
+
+module "myhealth" {
+  source     = "../modules/myhealth"
+  project_id = "who-mh-prod-in-dev"
+  domain     = "prod-in-dev.whocoronavirus.org"
+
+  # Matches configuration of prod/main.tf
+  create_project   = false
+  create_dns_entry = false
+}

--- a/server/terraform/prod/main.tf
+++ b/server/terraform/prod/main.tf
@@ -1,0 +1,12 @@
+# Production - public production service, strong privacy applies
+
+module "myhealth" {
+  source     = "../modules/myhealth"
+  project_id = "who-mh-prod"
+  domain     = "myhealth.who.int"
+
+  # Production Terraform service account doesn't have permission for project
+  # creation or DNS config, so skip these steps. This is done manually by WHO.
+  create_project   = false
+  create_dns_entry = false
+}


### PR DESCRIPTION
- Optional creation of project in Terraform
- Production uses existing project with access limited to that project
- "prod-in-dev" to replicate limited permissions for development
- Fixes to allow seamless project creation without errors:
   - depends_on dependencies fixed
   - Enabled cloudresourcemanager and appengine APIs

Documentation:
- Extensive documentation of project creation and service accounts
- Policy for keeping server config and code/docs in sync to support:
   - Transparency on configuration
   - Privacy policy compliance

Partial fix for #1298
## How did you test the change?

Terraform apply for "prod-in-dev" and also "prod"

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
