### PR TITLE
Properly set firebase auto init option when notifications / analytics settings are changed

### DIFF
--- a/client/lib/api/user_preferences.dart
+++ b/client/lib/api/user_preferences.dart
@@ -104,17 +104,12 @@ class UserPreferences {
   Future<void> _updateFirebaseAutoInit() async {
     // Updates the firebase auto init option. This method is called
     // after a user modifies either analytics or notifications.
-    var analyticsEnabled = await getAnalyticsEnabled();
-    var notificationsEnabled = await getNotificationsEnabled();
-
     var firebaseMessaging = FirebaseMessaging();
-    if (!analyticsEnabled && !notificationsEnabled) {
-      // If a user disables both analytics and notifications, set to false
-      await firebaseMessaging.setAutoInitEnabled(false);
-    } else {
-      // If either analytics or notifications are enabled, set to true
-      await firebaseMessaging.setAutoInitEnabled(true);
-    }
+
+    // Enable Firebase Auto Init iff either notifications or analytics is enabled
+    var firebase_auto_init =
+        (await getNotificationsEnabled()) || (await getAnalyticsEnabled());
+    await firebaseMessaging.setAutoInitEnabled(firebase_auto_init);
   }
 
   Future<String> getFirebaseToken() async {


### PR DESCRIPTION
Properly set firebase auto init option when notifications / analytics settings are changed. Fixes #1308

`firebaseMessaging.setAutoInitEnabled(false)` is called whenever both notifications and analytics are turned off. Otherwise, when either of them are turned on, `firebaseMessaging.setAutoInitEnabled(true)` is called.

## How did you test the change?

Logged to the console whenever `setAutoInitEnabled` was called and then manually tested on the iOS simulator to ensure it is called correctly in various scenarios.

- [x] iOS Simulator
- [ ] iOS Device
- [ ] Android Simulator
- [ ] Android Device
- [ ] `curl` to a dev App Engine server
- [ ] other, please describe

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
