### PR TITLE
Fix CI by regenerating protobuf files

### DIFF
--- a/client/lib/proto/api/who/who.pbenum.dart
+++ b/client/lib/proto/api/who/who.pbenum.dart
@@ -5,7 +5,7 @@
 // @dart = 2.3
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
-// ignore_for_file: UNDEFINED_SHOWN_NAME,UNUSED_SHOWN_NAME
+// ignore_for_file: UNDEFINED_SHOWN_NAME
 import 'dart:core' as $core;
 import 'package:protobuf/protobuf.dart' as $pb;
 


### PR DESCRIPTION
Fix CI by regenerating protobuf files. See failing check at https://github.com/WorldHealthOrganization/app/pull/1736/checks?check_run_id=1396513114