### PR TITLE
Logging retention of 30 days made explicit

### DIFF
--- a/server/terraform/modules/myhealth/main.tf
+++ b/server/terraform/modules/myhealth/main.tf
@@ -82,8 +82,6 @@ resource "google_app_engine_application" "gae" {
   #}
 }
 
-# Logging storage
-# The _Default logging bucket is created automatically and set to 30 
 # Logging Storage 30 Days Retention
 # Ensures that logging records are retained for 30 days only
 # Matches the standard retention period of the _Default logging bucket: 

--- a/server/terraform/modules/myhealth/main.tf
+++ b/server/terraform/modules/myhealth/main.tf
@@ -82,6 +82,15 @@ resource "google_app_engine_application" "gae" {
   #}
 }
 
+# Logging storage
+# The _Default logging bucket is created automatically and set to 30 
+# days retention; this resource ensures it is kept at that length.
+resource "google_logging_project_bucket_config" "default" {
+    project    = var.project_id # google_project.project.name
+    location  = "global"
+    retention_days = 30
+    bucket_id = "_Default"
+}
 
 # Load Balancer
 module "lb" {

--- a/server/terraform/modules/myhealth/main.tf
+++ b/server/terraform/modules/myhealth/main.tf
@@ -86,10 +86,10 @@ resource "google_app_engine_application" "gae" {
 # The _Default logging bucket is created automatically and set to 30 
 # days retention; this resource ensures it is kept at that length.
 resource "google_logging_project_bucket_config" "default" {
-    project    = var.project_id # google_project.project.name
-    location  = "global"
-    retention_days = 30
-    bucket_id = "_Default"
+  project        = var.project_id # google_project.project.name
+  location       = "global"
+  retention_days = 30
+  bucket_id      = "_Default"
 }
 
 # Load Balancer


### PR DESCRIPTION
Adds a new section to the MyHealth Service Terraform configuration: Logging bucket configuration.
This has Terraform maintain the logging retention on the default bucket at 30 days.

Fixes issue #1625 .

## How did you test the change?

- [ ] iOS Simulator
- [ ] iOS Device
- [ ] Android Simulator
- [ ] Android Device
- [ ] `curl` to a dev App Engine server
- [x] other, please describe

Ran Terraform Apply several times. Also tested with different values to values to manually verify that this setting applies.

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
