### PR TITLE
TLS 1.2 SSL Policy

### DIFF
--- a/server/terraform/hack/main.tf
+++ b/server/terraform/hack/main.tf
@@ -2,6 +2,6 @@
 
 module "myhealth" {
   source     = "../modules/myhealth"
-  project_id = "who-myhealth12-hack"
+  project_id = "who-mh-hack"
   domain     = "hack.whocoronavirus.org"
 }

--- a/server/terraform/modules/http-load-balancer/main.tf
+++ b/server/terraform/modules/http-load-balancer/main.tf
@@ -48,6 +48,14 @@ resource "google_compute_target_https_proxy" "https-proxy" {
   name             = "${var.name}-https-proxy"
   url_map          = var.url_map
   ssl_certificates = [google_compute_managed_ssl_certificate.ssl-cert.id]
+  ssl_policy       = google_compute_ssl_policy.ssl-policy.self_link
+}
+
+resource "google_compute_ssl_policy" "ssl-policy" {
+  name            = "${var.name}-ssl-policy"
+  min_tls_version = "TLS_1_2"
+  profile         = "MODERN"
+  # https://cloud.google.com/load-balancing/docs/ssl-policies-concepts#defining_an_ssl_policy
 }
 
 resource "google_compute_global_forwarding_rule" "https-rule" {


### PR DESCRIPTION
- TLS 1.2 Minimum
   - Compatible with Android 4.4 (minimum) and iOS 6 (iOS 9 is minimum)
   - https://www.ssllabs.com/ssltest/viewClient.html?name=Android&version=4.4.2&key=62
   - https://www.ssllabs.com/ssltest/viewClient.html?name=Safari&version=9&platform=iOS%209&key=114
- "MODERN" profile for balance between compatibility and security
- Terraform implementation

Partial fix #649 

## How did you test the change?

SSL Labs confirmed TLS 1.2 and above only. TLS 1.1 and below disabled.
https://www.ssllabs.com/ssltest/analyze.html?d=hack.whocoronavirus.org&latest

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
