### PR TITLE
add-path GitHub Actions fix

### DIFF
--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: git clone https://github.com/flutter/flutter.git --depth 1 -b $FLUTTER_VERSION _flutter
-      - run: echo "::add-path::$GITHUB_WORKSPACE/_flutter/bin"
+      - run: echo "$GITHUB_WORKSPACE/_flutter/bin" >> $GITHUB_PATH
       - run: flutter doctor -v
       - run: flutter pub get
         working-directory: ./client
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: git clone https://github.com/flutter/flutter.git --depth 1 -b $FLUTTER_VERSION _flutter
-      - run: echo "::add-path::$GITHUB_WORKSPACE/_flutter/bin"
+      - run: echo "$GITHUB_WORKSPACE/_flutter/bin" >> $GITHUB_PATH
       - run: flutter doctor -v
       - run: flutter pub get
         working-directory: ./client
@@ -60,7 +60,7 @@ jobs:
       - run: protoc --version
       - run: flutter pub global activate protoc_plugin ^19.0.1
         working-directory: ./client
-      - run: echo "::add-path::$HOME/.pub-cache/bin"
+      - run: echo "$HOME/.pub-cache/bin" >> $GITHUB_PATH
       - run: ./tools/gen-client-protos.sh
       - run: flutter format lib/**
         working-directory: ./client
@@ -71,7 +71,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: git clone https://github.com/flutter/flutter.git --depth 1 -b $FLUTTER_VERSION _flutter
-      - run: echo "::add-path::$GITHUB_WORKSPACE/_flutter/bin"
+      - run: echo "$GITHUB_WORKSPACE/_flutter/bin" >> $GITHUB_PATH
       - run: flutter doctor -v
       - run: flutter pub get
         working-directory: ./client
@@ -88,7 +88,7 @@ jobs:
         with:
           java-version: "11.0.9"
       - run: git clone https://github.com/flutter/flutter.git --depth 1 -b $FLUTTER_VERSION _flutter
-      - run: echo "::add-path::$GITHUB_WORKSPACE/_flutter/bin"
+      - run: echo "$GITHUB_WORKSPACE/_flutter/bin" >> $GITHUB_PATH
       - run: flutter doctor -v
       - run: flutter pub get
         working-directory: ./client


### PR DESCRIPTION
Fix build:
```
before:
- run: echo "::add-path::$GITHUB_WORKSPACE/_flutter/bin"

after
- run: echo "$GITHUB_WORKSPACE/_flutter/bin" >> $GITHUB_PATH
```

Documentation and Vulnerability:
https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#adding-a-system-path

https://github.com/actions/toolkit/security/advisories/GHSA-mfwh-5m23-j46w

## How did you test the change?

CI build

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
