### PR TITLE
App Engine ingress disable appspot domain

### DIFF
--- a/server/terraform/modules/http-load-balancer/main.tf
+++ b/server/terraform/modules/http-load-balancer/main.tf
@@ -12,10 +12,9 @@ resource "google_compute_global_address" "ipv4" {
   name         = "${var.name}-address"
   ip_version   = "IPV4"
   address_type = "EXTERNAL"
-  # TODO: protect IP address is lost if destroyed
-  #lifecycle {
-  #  prevent_destroy = true
-  #}
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 

--- a/server/terraform/modules/myhealth/main.tf
+++ b/server/terraform/modules/myhealth/main.tf
@@ -173,7 +173,18 @@ module "ingress" {
   create_cmd_body       = "beta app services update default --ingress internal-and-cloud-load-balancing"
 
   # Appears to run when resource is replaced but not when it is destroyed
-  # Don't revert setting so it can't be accidentally removed
+  # Don't revert setting so it can't be accidentally be left insecure
   destroy_cmd_entrypoint = "gcloud"
   destroy_cmd_body       = "info"
+
+  # Command fails if App Engine instance doesn't exist... but adding dependency causes error
+  # depends_on = [google_app_engine_application.gae]
+  #
+  #Error: Invalid count argument
+  #  on .terraform/modules/myhealth.ingress/main.tf line 57, in resource "random_id" "cache":
+  #  57:   count = (! local.skip_download) ? 1 : 0
+  #The "count" value depends on resource attributes that cannot be determined
+  #until apply, so Terraform cannot predict how many instances will be created.
+  #To work around this, use the -target argument to first apply only the
+  #resources that the count depends on.
 }


### PR DESCRIPTION
Network Security
- App Engine ingress set to `internal-and-cloud-load-balancing`
- Disables who-mh-hack.appspot.com domain
- Partial fix for #649

Other Terraform:
- Pinned hashicorp providers: external, null, random
- prevent_destroy for critical resources:
   - project, app_engine, firebase, static IPv4 address

## Testing

Verified through `gcloud` and disabled redirect for https://who-mh-hack.appspot.com/app

```
# Browser Verify: Redirect
# https://who-mh-hack.appspot.com/app

$ gcloud app services describe default
id: default
name: apps/who-mh-hack/services/default
networkSettings:
  ingressTrafficAllowed: INGRESS_TRAFFIC_ALLOWED_ALL
...
$ terraform apply
...
$ gcloud app services describe default
id: default
name: apps/who-mh-hack/services/default
networkSettings:
  ingressTrafficAllowed: INGRESS_TRAFFIC_ALLOWED_INTERNAL_AND_LB
...

# Browser Verify: 403 Forbidden
# https://who-mh-hack.appspot.com/app
```

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
