### PR TITLE
Terraform: pin dependencies and protect resources

### DIFF
--- a/server/terraform/modules/http-load-balancer/main.tf
+++ b/server/terraform/modules/http-load-balancer/main.tf
@@ -12,10 +12,9 @@ resource "google_compute_global_address" "ipv4" {
   name         = "${var.name}-address"
   ip_version   = "IPV4"
   address_type = "EXTERNAL"
-  # TODO: protect IP address is lost if destroyed
-  #lifecycle {
-  #  prevent_destroy = true
-  #}
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 

--- a/server/terraform/modules/myhealth/main.tf
+++ b/server/terraform/modules/myhealth/main.tf
@@ -22,6 +22,19 @@ provider "google-beta" {
   project = var.project_id
 }
 
+# Pin Hashicorp Dependencies
+provider "external" {
+  version = "~> 2.0.0"
+}
+
+provider "null" {
+  version = "~> 3.0.0"
+}
+
+provider "random" {
+  version = "~> 3.0.0"
+}
+
 
 # Google Project
 resource "google_project" "project" {
@@ -31,9 +44,9 @@ resource "google_project" "project" {
   project_id      = var.project_id
   billing_account = var.billing_account
   org_id          = var.org_id
-  #lifecycle {
-  #  prevent_destroy = true
-  #}
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 # Do `depends_on` this resource iff it requires APIs to be enabled
@@ -59,9 +72,9 @@ resource "google_firebase_project" "firebase" {
   project    = var.project_id
   depends_on = [google_project_service.service]
   # TODO: protect data
-  #lifecycle {
-  #  prevent_destroy = true
-  #}
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "google_firebase_project_location" "fireloc" {
@@ -79,9 +92,9 @@ resource "google_app_engine_application" "gae" {
   database_type = "CLOUD_DATASTORE_COMPATIBILITY"
   depends_on    = [google_project_service.service]
   # TODO: protect resource as it can't be recreated after being destroyed
-  #lifecycle {
-  #  prevent_destroy = true
-  #}
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 


### PR DESCRIPTION
- Pinned hashicorp providers: external, null, random
- prevent_destroy for critical resources:
   - project, app_engine, firebase, static IPv4 address

## How did you test the change?

`terraform apply` on who-mh-dev project

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
