### PR TITLE
Require Load Balancer for all App Engine traffic

### DIFF
--- a/server/bin/deploy-server.sh
+++ b/server/bin/deploy-server.sh
@@ -8,5 +8,9 @@ PROJECT=$1
 ../tools/verify-server.sh
 
 ./gradlew build
-gcloud beta app deploy --quiet --project=$PROJECT appengine/build/war
-gcloud beta app deploy --quiet --project=$PROJECT appengine/build/war/WEB-INF/cron.yaml
+gcloud beta app --quiet --project=$PROJECT deploy appengine/build/war
+gcloud beta app --quiet --project=$PROJECT deploy appengine/build/war/WEB-INF/cron.yaml
+
+# Force everything through the load balancer for security
+gcloud beta app --quiet --project=$PROJECT services update default \
+  --ingress internal-and-cloud-load-balancing


### PR DESCRIPTION
- App Engine ingress set to `internal-and-cloud-load-balancing`
- Disables who-mh-hack.appspot.com domain
- Partial fix for #649

## How did you test the change?

```
server/bin/deploy-server.sh who-mh-hack
```

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
