### PR TITLE
who-mh-staging + robust bucket creation

### DIFF
--- a/server/terraform/staging/main.tf
+++ b/server/terraform/staging/main.tf
@@ -1,4 +1,4 @@
-# hack - penetration testing and ethical hacking, no privacy expectation
+# staging - default development server, no privacy expectation
 
 module "myhealth" {
   source     = "../modules/myhealth"

--- a/server/terraform/staging/main.tf
+++ b/server/terraform/staging/main.tf
@@ -1,0 +1,8 @@
+# hack - penetration testing and ethical hacking, no privacy expectation
+
+module "myhealth" {
+  source     = "../modules/myhealth"
+  project_id = "who-mh-staging"
+  # TODO: migrate to staging.whocoronavirus.org
+  domain = "staging-temp.whocoronavirus.org"
+}


### PR DESCRIPTION
who-mh-staging as new project. Fixes #1702 

Logging `depends_on` for robust bucket creation
- Bucket creation initially fails as project doesn't exist:
   - `Error: Error creating Bucket: googleapi: Error 404: Project does not exist: who-mh-staging`
- Then Terraforms believes that bucket exists but fails trying to find it:
   - `Error: googleapi: Error 404: Bucket europe-west1-logs-bucket does not exist`
- Workaround was to delete the resource in terraform.tfstate then recreate it
- This fix will ensure that none of these errors happen in the first place

## How did you test the change?

`terraform apply`

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
