### PR TITLE
covid19app.who.int production domain

### DIFF
--- a/server/terraform/modules/http-load-balancer/main.tf
+++ b/server/terraform/modules/http-load-balancer/main.tf
@@ -68,12 +68,20 @@ resource "google_compute_global_forwarding_rule" "https-rule" {
   depends_on = [google_compute_global_address.ipv4]
 }
 
+resource "random_id" "certificate" {
+  byte_length = 4
+
+  keepers = {
+    domains = var.domain
+  }
+}
+
 resource "google_compute_managed_ssl_certificate" "ssl-cert" {
   provider = google-beta
 
   # Must change name when editing as Google provider doesn't support update in
   # place. Also need to create replacement resource before deleting old resource.
-  name = "${var.name}-ssl-cert"
+  name = "${var.name}-ssl-cert-${random_id.certificate.hex}"
   lifecycle {
     create_before_destroy = true
   }

--- a/server/terraform/prod/main.tf
+++ b/server/terraform/prod/main.tf
@@ -3,7 +3,7 @@
 module "myhealth" {
   source     = "../modules/myhealth"
   project_id = "who-mh-prod"
-  domain     = "myhealth.who.int"
+  domain     = "covid19app.who.int"
 
   # Production Terraform service account doesn't have permission for project
   # creation or DNS config, so skip these steps. This is done manually by WHO.


### PR DESCRIPTION
- covid19app.who.int domain added to Prod terraform
- Randomize ssl-cert name as it can't update in place
- Partial fix for #1298 

## How did you test the change?

`terraform apply` for both staging and then prod

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
