### PR TITLE
Create placeholder IP blocking security policy

### DIFF
--- a/server/terraform/modules/myhealth/main.tf
+++ b/server/terraform/modules/myhealth/main.tf
@@ -212,8 +212,7 @@ resource "google_compute_security_policy" "policy" {
     description = "Deny access to specified IPs"
   }
 
-  # Every security policy must re-iterate the default rule at maxint32.
-  # The 'action' may be changed but not the other properties.
+  # The default rule at maxint32. Should not need to be changed.
   rule {
     action   = "allow"
     priority = "2147483647"

--- a/server/terraform/modules/myhealth/main.tf
+++ b/server/terraform/modules/myhealth/main.tf
@@ -226,7 +226,7 @@ resource "google_compute_security_policy" "policy" {
     description = "default rule"
   }
 
-  # In case  this resource is renamed in Terraform, the lifecycle must be:
+  # In case this resource is renamed in Terraform, the lifecycle must be:
   #  1: Create new policy 
   #  2: Configure backend to reference it
   #  3: Delete old policy.

--- a/server/terraform/modules/myhealth/main.tf
+++ b/server/terraform/modules/myhealth/main.tf
@@ -190,6 +190,52 @@ resource "google_compute_region_network_endpoint_group" "neg" {
   depends_on = [google_project_service.service]
 }
 
+
+# Google Cloud Armor security policy.
+resource "google_compute_security_policy" "policy" {
+  name = "lb-security-policy"
+
+  # IP Block list. 
+  rule {
+    action   = "deny(403)"
+    priority = "1000"
+    match {
+      versioned_expr = "SRC_IPS_V1"
+      config {
+        # Using an unused portion of the loopback block as a placeholder.
+        # Remove it once a real set of IP Ranges are present.
+        # Up to ten IP ranges can be created per rule.
+        src_ip_ranges = ["127.0.0.255/32","127.0.0.254"]
+      }
+    }
+    description = "Deny access to specified IPs"
+  }
+
+  rule {
+    action   = "allow"
+    priority = "2147483647"
+    match {
+      versioned_expr = "SRC_IPS_V1"
+      config {
+        src_ip_ranges = ["*"]
+      }
+    }
+    description = "default rule"
+  }
+
+  # In case  this resource is renamed in Terraform, the lifecycle must be:
+  #  1: Create new policy 
+  #  2: Configure backend to reference it
+  #  3: Delete old policy.
+  # To accomplish this, it is set to create_before_destroy, 
+  # then running apply twice completes the operation.
+  lifecycle {
+    create_before_destroy = true
+  }
+
+}
+
+
 resource "google_compute_backend_service" "backend" {
   name                            = "${var.project_id}-backend-appengine"
   load_balancing_scheme           = "EXTERNAL"
@@ -200,6 +246,7 @@ resource "google_compute_backend_service" "backend" {
   cdn_policy {
     signed_url_cache_max_age_sec = 3600
   }
+  security_policy = google_compute_security_policy.policy.id
   backend {
     capacity_scaler = 1
     group           = google_compute_region_network_endpoint_group.neg.id

--- a/server/terraform/modules/myhealth/main.tf
+++ b/server/terraform/modules/myhealth/main.tf
@@ -213,7 +213,7 @@ resource "google_compute_security_policy" "policy" {
   }
 
   # Every security policy must re-iterate the default rule at maxint32.
-  # The action may be changed but not the other properties.
+  # The 'action' may be changed but not the other properties.
   rule {
     action   = "allow"
     priority = "2147483647"

--- a/server/terraform/modules/myhealth/main.tf
+++ b/server/terraform/modules/myhealth/main.tf
@@ -196,6 +196,8 @@ resource "google_compute_security_policy" "policy" {
   name = "lb-security-policy"
 
   # IP Block list. 
+  # Up to ten IP ranges can be created per rule.
+  # Each rule is identified by its priority, from 1=highest to maxint32=default.
   rule {
     action   = "deny(403)"
     priority = "1000"
@@ -204,13 +206,14 @@ resource "google_compute_security_policy" "policy" {
       config {
         # Using an unused portion of the loopback block as a placeholder.
         # Remove it once a real set of IP Ranges are present.
-        # Up to ten IP ranges can be created per rule.
-        src_ip_ranges = ["127.0.0.255/32","127.0.0.254"]
+        src_ip_ranges = ["127.0.0.255/32", "127.0.0.254"]
       }
     }
     description = "Deny access to specified IPs"
   }
 
+  # Every security policy must re-iterate the default rule at maxint32.
+  # The action may be changed but not the other properties.
   rule {
     action   = "allow"
     priority = "2147483647"


### PR DESCRIPTION
Create a placeholder Google Cloud Armor security policy blocking IP addresses.
Uses a loopback placeholder with a CIDR and IP example.

To edit interactively, view https://console.cloud.google.com/net-security/securitypolicies/lb-security-policy/rules/1000/edit

Fixes #1758

## Screenshots

<details>
<summary>Screenshots</summary>
Add any relevant before/after screenshots here
</details>

## How did you test the change?

- [ ] iOS Simulator
- [ ] iOS Device
- [ ] Android Simulator
- [ ] Android Device
- [ ] `curl` to a dev App Engine server
- [x] other, please describe

Configured my test project with terraform apply
Manually changed settings in console, and tested that terraform apply apply un-did the changes.
Manually changed settings in console, made same settings in terraform config, and tested that apply did nothing.

## Checklist:

- [ ] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
