### PR TITLE
Architecture diagram is not current

### DIFF
--- a/docs/devdesign/architecture.md
+++ b/docs/devdesign/architecture.md
@@ -1,4 +1,4 @@
 ## System Architecture
 
-- We keep our live diagram in LucidChart: https://www.lucidchart.com/documents/view/3ce4e176-551f-4e71-9ec5-1c2e38071dea/0_0
 - Our most recently drafted revision is archived here: [PDF](https://drive.google.com/file/d/1bgTcZKqHWrLYfhQIM-l--ZpuH2NCGvjV/view?usp=sharing), [Visio](https://drive.google.com/file/d/1BgeRzAIs0-gmyPqpd_iZ2b1ABFGg9CQb/view?usp=sharing), and is committed as a CSV [here](./System-Architecture.csv)
+- This diagram may not reflect the most recent architecture.


### PR DESCRIPTION
Remove my lucidchart - my subscription is no longer alive and I of course am not updating the diagram at that URL.

Note also that the architecture diagram has its own special license (still under a partial MIT license).  I'm happy to relicense if the other authors are as well.

Some missing things from the diagram include but are not limited to:
- The TerraForm work that has been done recently and how those tools have admin access to production
- The storage of a portion of the server logs in Belgium (while others appear to be global)
- The location (presumably in the US) of the members of the current team who will access the logs and user databases
- The load balancers/reverse proxies that may live in front of the app engine
- and other things I may not be aware of (I only looked cursorily)
