### PR TITLE
Terraform validate all projects

### DIFF
--- a/server/terraform/README.md
+++ b/server/terraform/README.md
@@ -131,6 +131,10 @@ emacs main.tf
 terraform init
 terraform apply
 # Should create all resources without any errors
+
+# Add server reference in top level terraform to ensure validation
+# server/terraform/main.tf
+# `terraform apply` should not be used here, instead only individual projects
 ```
 
 ### Terraform Apply

--- a/server/terraform/main.tf
+++ b/server/terraform/main.tf
@@ -11,4 +11,14 @@ module "hack" {
   source = "./hack"
 }
 
-# TODO: prod, staging
+module "prod" {
+  source = "./prod"
+}
+
+module "prod-in-dev" {
+  source = "./prod-in-dev"
+}
+
+module "staging" {
+  source = "./staging"
+}

--- a/tools/terraform-fmt-validate.sh
+++ b/tools/terraform-fmt-validate.sh
@@ -5,5 +5,6 @@
 set -euv
 cd $(dirname "$0")/../server/terraform
 
+terraform init
 terraform fmt -recursive .
 terraform validate .


### PR DESCRIPTION
- Add init to terraform-fmt-validate.sh script
- Add links to all top level projects
- **NOTE** never do `terraform apply` at top level, only individual projects

## How did you test the change?

1. Added formatting error to staging project
1. Verify that `terraform validate .` in `server/terraform` missed the error
1. Added this code
1. Verified again that it caught the error

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
