### PR TITLE
Static Content deploy to use ProjectId

### DIFF
--- a/.github/workflows/static-content.yaml
+++ b/.github/workflows/static-content.yaml
@@ -104,8 +104,7 @@ jobs:
               log_url: process.env.LOG_URL,
             });
             return deployment.id;
-      - run: DONT_BUILD=true ./deploy-staging-static-serving.sh
-        working-directory: tools
+      - run: DONT_BUILD=true ./tools/build-and-push-static-serving.sh who-myhealth-staging-static-content-01
       - name: Destroy GCP Credentials File
         run: rm $APPLICATION_CREDENTIALS
         if: ${{ always() }}

--- a/server/README.md
+++ b/server/README.md
@@ -31,7 +31,7 @@ Services:
 
 ## Curl Testing
 
-Against staging:
+#### App Engine:
 
 ```
 # App Engine
@@ -50,8 +50,13 @@ curl -i \
 	-X POST \
 	-d '{isoCountryCode: CH}' \
 	'https://whoapp.org/WhoService/putLocation'
+```
 
-# Static Content - served from Google Cloud Storage
+#### Static Content
+
+Served from Google Cloud Storage:
+
+```
 curl https://storage.googleapis.com/who-myhealth-staging-static-content-01/\
 content/bundles/protect_yourself.en_US.yaml
 ```
@@ -86,23 +91,22 @@ Service Account:
     # service account
     gcloud auth activate-service-account --key-file xxxx.json
 
-### Deploy to Staging
+### Deploy
+
+Deployment is organized by ProjectId.
+
+#### Server
 
     ./bin/deploy-server.sh who-mh-staging
 
-Then open [https://who-app-staging.appspot.com/]().
+Then open [https://staging.whocoronavirus.org/app]() for a redirect to the app store.
 
-### Deploy to Staging - Static Content
+#### Static Content
 
-Deployed automatically on push to master by [.github/workflows/static-content.yaml](.github/workflows/static-content.yaml). Or pushed manually with:
+Deployed automatically on push to master by [.github/workflows/static-content.yaml](.github/workflows/static-content.yaml)
+(NOTE: old staging server). Or pushed manually with (new staging server):
 
-    tools/deploy-staging-static-serving.sh
-
-### Deploy to Production
-
-    ./bin/deploy-server.sh who-mh-prod
-
-Then open [https://who-app.appspot.com/]().
+    ./tools/build-and-push-static-serving.sh who-mh-staging
 
 ## Dev Environment
 

--- a/tools/build-and-push-static-serving.sh
+++ b/tools/build-and-push-static-serving.sh
@@ -3,6 +3,7 @@
 set -ev
 cd $(dirname "$0")
 
+# Only argument is ProjectId or Bucket Name (deprecated)
 # When running as a GitHub action, building and pushing are separated.
 
 if [ "$DONT_BUILD" != "true" ]; then
@@ -11,6 +12,17 @@ if [ "$DONT_BUILD" != "true" ]; then
 fi
 
 if [ "$DONT_PUSH" != "true" ]; then
+  BUCKET=$1
+  if ! [[ $BUCKET == who-* ]]; then
+    echo "Required argument: project id starting with 'who-' : $PROJECT"
+    exit 1
+  fi
+  # TODO: remove once .github/workflows/static-content.yaml is updated
+  if [[ $BUCKET == *static-content* ]]; then
+    echo "Deprecated argument for bucket name: $BUCKET"
+  else
+    BUCKET=$BUCKET-static-content
+  fi
   set -euv
-  gsutil -m -h "Cache-Control:public, max-age=600" -h "x-goog-meta-git-sha:$(git rev-parse HEAD)" -h "Content-Type:application/x-yaml;charset=utf-8" rsync -r ./staticContentBuild/ gs://$GS_BUCKET/content/bundles/
+  gsutil -m -h "Cache-Control:public, max-age=600" -h "x-goog-meta-git-sha:$(git rev-parse HEAD)" -h "Content-Type:application/x-yaml;charset=utf-8" rsync -r ./staticContentBuild/ gs://$BUCKET/content/bundles/
 fi

--- a/tools/deploy-production-static-serving.sh
+++ b/tools/deploy-production-static-serving.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-set -euv
-cd $(dirname "$0")
-
-GS_BUCKET=who-myhealth-europe-static-content-01 ./build-and-push-static-serving.sh

--- a/tools/deploy-staging-static-serving.sh
+++ b/tools/deploy-staging-static-serving.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-set -euv
-cd $(dirname "$0")
-
-GS_BUCKET=who-myhealth-staging-static-content-01 ./build-and-push-static-serving.sh


### PR DESCRIPTION
- Rebuild scripts around the ProjectID
- Removed staging / prod specific scripts
- Support legacy mode for GitHub deploy of old staging server

## How did you test the change?

- [ ] iOS Simulator
- [ ] iOS Device
- [ ] Android Simulator
- [ ] Android Device
- [ ] `curl` to a dev App Engine server
- [x] other, please describe

Repeated runs of the scripts across different project and manually running expected GitHub workflow script.

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
