### PR TITLE
Endpoints changed based on build flavor

### DIFF
--- a/client/lib/api/content/content_loading.dart
+++ b/client/lib/api/content/content_loading.dart
@@ -1,3 +1,4 @@
+import 'package:who_app/api/endpoints.dart';
 import 'package:who_app/api/who_service.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:flutter/cupertino.dart';
@@ -13,8 +14,8 @@ class ContentService {
   static final Duration networkTimeout = Duration(seconds: 30);
   static final String baseAssetPath = 'assets/content_bundles'; // no trailing
 
-  ContentService({@required String endpoint})
-      : baseContentURL = '$endpoint/content/bundles';
+  ContentService({@required Endpoint endpoint})
+      : baseContentURL = '${endpoint.service}/content/bundles';
 
   /// Load a localized content bundle loaded preferentially from the network, falling back
   /// to a local asset.  If no bundle can be found with the specified name an exception is thrown.

--- a/client/lib/api/endpoints.dart
+++ b/client/lib/api/endpoints.dart
@@ -1,19 +1,29 @@
-import 'package:flutter/foundation.dart';
-
-class Endpoints {
-  static final String STAGING_SERVICE = 'https://staging.whocoronavirus.org';
-  // TODO: Move this to who.int.
-  static final String PROD_SERVICE = 'https://whoapp.org';
-
-  static final String STAGING_STATIC_CONTENT =
-      'https://storage.googleapis.com/who-myhealth-staging-static-content-01';
-  // TODO: Move this to GCS too.
-  static final String PROD_STATIC_CONTENT = 'https://whoapp.org';
-}
+// Endpoint for service
 
 class Endpoint {
-  final String service;
-  final String staticContent;
+  static const _whoMhPrefix = 'who-mh-';
+  static const _prodProjectId = 'who-mh-prod';
+  static const _prodServiceUrl = 'https://covid19app.who.int';
 
-  Endpoint({@required this.service, @required this.staticContent});
+  static bool _isProd(String projectId) {
+    return projectId == _prodProjectId;
+  }
+
+  static String _serviceUrl(String projectId) {
+    if (_isProd(projectId)) {
+      return _prodServiceUrl;
+    }
+    if (projectId.startsWith(_whoMhPrefix)) {
+      final subdomain = projectId.substring(_whoMhPrefix.length);
+      return 'https://${subdomain}.whocoronavirus.org';
+    }
+    throw Exception("Project: $projectId doesn't match prefix: $_whoMhPrefix");
+  }
+
+  final String service;
+  final bool isProd;
+
+  Endpoint(String projectId)
+      : service = _serviceUrl(projectId),
+        isProd = _isProd(projectId);
 }

--- a/server/README.md
+++ b/server/README.md
@@ -57,8 +57,9 @@ curl -i \
 Served from Google Cloud Storage:
 
 ```
-curl https://storage.googleapis.com/who-myhealth-staging-static-content-01/\
-content/bundles/protect_yourself.en_US.yaml
+curl https://staging.whocoronavirus.org/content/bundles/protect_yourself.en_US.yaml
+
+curl https://covid19app.who.int/content/bundles/protect_yourself.en_US.yaml
 ```
 
 ## Building and Deploying


### PR DESCRIPTION
- "No Privacy" alert based on "prod" server or not
- Updates App Engine and Content endpoints
- No more direct usage of Storage Bucket direct URL
- Fixes #1781

## How did you test the change?

```
flutter run --flavor prod
```
Checked:
- "No Privacy..." message not shown but shown for other flavors
- Fetched content successfully
- Discovered another issue that's orthogonal: #1799

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
