### PR TITLE
ProjectID in Alert

### DIFF
--- a/client/lib/api/content/content_loading.dart
+++ b/client/lib/api/content/content_loading.dart
@@ -15,7 +15,7 @@ class ContentService {
   static final String baseAssetPath = 'assets/content_bundles'; // no trailing
 
   ContentService({@required Endpoint endpoint})
-      : baseContentURL = '${endpoint.service}/content/bundles';
+      : baseContentURL = '${endpoint.serviceUrl}/content/bundles';
 
   /// Load a localized content bundle loaded preferentially from the network, falling back
   /// to a local asset.  If no bundle can be found with the specified name an exception is thrown.

--- a/client/lib/api/endpoints.dart
+++ b/client/lib/api/endpoints.dart
@@ -9,21 +9,27 @@ class Endpoint {
     return projectId == _prodProjectId;
   }
 
+  static String _projectIdShort(String projectId) {
+    if (!projectId.startsWith(_whoMhPrefix)) {
+      throw Exception(
+          "Project: $projectId doesn't match prefix: $_whoMhPrefix");
+    }
+    return projectId.substring(_whoMhPrefix.length);
+  }
+
   static String _serviceUrl(String projectId) {
     if (_isProd(projectId)) {
       return _prodServiceUrl;
     }
-    if (projectId.startsWith(_whoMhPrefix)) {
-      final subdomain = projectId.substring(_whoMhPrefix.length);
-      return 'https://${subdomain}.whocoronavirus.org';
-    }
-    throw Exception("Project: $projectId doesn't match prefix: $_whoMhPrefix");
+    return 'https://${_projectIdShort(projectId)}.whocoronavirus.org';
   }
 
-  final String service;
   final bool isProd;
+  final String projectIdShort;
+  final String serviceUrl;
 
   Endpoint(String projectId)
-      : service = _serviceUrl(projectId),
-        isProd = _isProd(projectId);
+      : isProd = _isProd(projectId),
+        projectIdShort = _projectIdShort(projectId),
+        serviceUrl = _serviceUrl(projectId);
 }

--- a/client/lib/main.dart
+++ b/client/lib/main.dart
@@ -165,7 +165,7 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
             ),
             ProxyProvider(
                 update: (_, Endpoint endpoint, __) => WhoService(
-                      endpoint: endpoint.service,
+                      endpoint: endpoint.serviceUrl,
                     )),
             ProxyProvider(
               update: (_, WhoService service, __) {
@@ -211,7 +211,9 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
                 observerFn: (_, ContentStore content) {
               return [
                 if (!endpoint.isProd)
-                  Alert(null, 'No privacy on test builds.', dismissable: true),
+                  Alert(
+                      null, 'No privacy on server - ${endpoint.projectIdShort}',
+                      dismissable: true),
                 if (content.unsupportedSchemaVersionAvailable)
                   Alert('App Update Required',
                       'This information may be outdated. You must update this app to receive more recent COVID-19 info.'),


### PR DESCRIPTION
Short projectID in alert, e.g. "hack" or "staging"

## How did you test the change?

Multiple build flavors, including hidden for "prod"

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
