### PR TITLE
Make updateFirebaseToken synchronous

### DIFF
--- a/client/lib/main.dart
+++ b/client/lib/main.dart
@@ -255,5 +255,4 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
   void updateFirebaseToken(Notifications ret) async {
     await ret.updateFirebaseToken();
   }
-
 }

--- a/client/lib/main.dart
+++ b/client/lib/main.dart
@@ -171,7 +171,7 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
               update: (_, WhoService service, __) {
                 final ret = Notifications(service: service);
                 ret.configure();
-                ret.updateFirebaseToken();
+                updateFirebaseToken(ret);
                 return ret;
               },
             ),
@@ -247,4 +247,13 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
     var parts = Intl.getCurrentLocale().split('_');
     return Locale(parts[0], parts[1]);
   }
+
+  // To avoid a race condition where the Firebase Token and the user's
+  // location are set simultaneously, leading to an inconsistent result
+  // on the server, call updateFirebaseToken in a synchronous fashion.
+  // Note that the RPC will only occur when the value actually changes.
+  void updateFirebaseToken(Notifications ret) async {
+    await ret.updateFirebaseToken();
+  }
+
 }


### PR DESCRIPTION
To avoid a race condition where the Firebase Token and the user's
location are set simultaneously, leading to an inconsistent result
on the server, call UpdateFirebaseToken in a synchronous fashion.
Note that the RPC will only occur when the value actually changes.

Fixes issue #1524. In a crude fashion.

## Screenshots

<details>
<summary>Screenshots</summary>
Add any relevant before/after screenshots here
</details>

## How did you test the change?

- [ ] iOS Simulator
- [ ] iOS Device
- [ ] Android Simulator
- [x] Android Device
- [ ] `curl` to a dev App Engine server
- [ ] other, please describe

I tested this by running the app in the debugger and seeing that it appears to have made the right calls.

## Checklist:

- [ ] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
