### PR TITLE
Fix staging SSL cert

### DIFF
--- a/server/terraform/modules/http-load-balancer/main.tf
+++ b/server/terraform/modules/http-load-balancer/main.tf
@@ -81,6 +81,7 @@ resource "google_compute_managed_ssl_certificate" "ssl-cert" {
 
   # Must change name when editing as Google provider doesn't support update in
   # place. Also need to create replacement resource before deleting old resource.
+  # `terraform apply` must be done twice. 1st error: resourceInUseByAnotherResource
   name = "${var.name}-ssl-cert-${random_id.certificate.hex}"
   lifecycle {
     create_before_destroy = true

--- a/server/terraform/staging/main.tf
+++ b/server/terraform/staging/main.tf
@@ -3,6 +3,5 @@
 module "myhealth" {
   source     = "../modules/myhealth"
   project_id = "who-mh-staging"
-  # TODO: migrate to staging.whocoronavirus.org
-  domain = "staging-temp.whocoronavirus.org"
+  domain     = "staging.whocoronavirus.org"
 }


### PR DESCRIPTION
- staging-temp.whocoronavirus.org => staging.whocoronavirus.org
- Fixes #1810


## How did you test the change?

```
cd server/terraform/staging


terraform apply
...
# 1st apply error
Error: Error when reading or editing ManagedSslCertificate: googleapi: Error 400: The ssl_certificate resource 'projects/who-mh-staging/global/sslCertificates/who-mh-staging-lb-ssl-cert-c1c03f3b' is already being used by 'projects/who-mh-staging/global/targetHttpsProxies/who-mh-staging-lb-https-proxy', resourceInUseByAnotherResource


terraform apply
...
# 2nd apply worked
Apply complete! Resources: 0 added, 0 changed, 2 destroyed.
```


## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
