### PR TITLE
DEVELOPMENT_ONLY deprecated

### DIFF
--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -75,10 +75,10 @@ jobs:
       - run: flutter doctor -v
       - run: flutter pub get
         working-directory: ./client
+      - run: git diff --exit-code
       - run: ./tools/gen-client-buildinfo.sh
       - run: flutter build ios --release --flavor staging --no-codesign
         working-directory: ./client
-      - run: git diff --exit-code
   build_android:
     # Firebase requires fat APKs, not AABs.
     name: Build Android APK (Staging)

--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -75,6 +75,7 @@ jobs:
       - run: flutter doctor -v
       - run: flutter pub get
         working-directory: ./client
+      - run: ./tools/gen-client-buildinfo.sh
       - run: flutter build ios --release --flavor staging --no-codesign
         working-directory: ./client
       - run: git diff --exit-code
@@ -93,7 +94,7 @@ jobs:
       - run: flutter pub get
         working-directory: ./client
       - run: git diff --exit-code
-      - run: DEVELOPMENT_ONLY=true ./tools/gen-client-buildinfo.sh
+      - run: ./tools/gen-client-buildinfo.sh
       - run: flutter build appbundle --release --flavor staging
         working-directory: ./client
       # TODO: generate apk from appbundle using bundletool

--- a/client/README.md
+++ b/client/README.md
@@ -31,6 +31,6 @@ The files are generated per project, indicated by the appendix on the filename.
 For example to access the `staging` server (the default), the files are:
 
 ```
-Android: client/android/app/google-services-staging.json
-iOS:     client/ios/Runner/GoogleService-Info-staging.plist
+Android: client/android/app/src/<flavor>/google-services.json
+iOS:     client/ios/config/<flavor>/GoogleService-Info.plist
 ```

--- a/client/lib/generated/build.dart
+++ b/client/lib/generated/build.dart
@@ -1,7 +1,5 @@
 class BuildInfo {
   static const POPULATED = false;
   static const GIT_SHA = "";
-  static const BUILT_AT = "";
-  static const DEVELOPMENT_ONLY = true;
   static const FLUTTER_VERSION = '''''';
 }

--- a/client/lib/pages/about_page.dart
+++ b/client/lib/pages/about_page.dart
@@ -47,8 +47,6 @@ class AboutPage extends StatelessWidget {
         'Debug Info:',
         'Pkg info: ${packageInfo?.appName}, ${packageInfo?.packageName}, ${packageInfo?.version}, ${packageInfo?.buildNumber}',
         'Git commit: ${BuildInfo.GIT_SHA}',
-        'Built at: ${BuildInfo.BUILT_AT}',
-        'Development build: ${BuildInfo.DEVELOPMENT_ONLY}',
         'Platform locale: ${Platform.localeName}',
         'Platform version: ${Platform.operatingSystem} ${Platform.operatingSystemVersion}',
         'Flutter locale: ${Localizations.localeOf(bc).toString()}',

--- a/docs/release/manual-build.md
+++ b/docs/release/manual-build.md
@@ -2,7 +2,14 @@
 
 _Note these instructions are for manual submission to the app stores, not for building the app during development. For the latter, see [here](../ONBOARDING.md)._
 
-These instructions will assume that you have the up-to-date [`git`](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), [Flutter](https://flutter.dev/docs/get-started/install), [Android Studio](https://developer.android.com/studio/index.html), [XCode](https://developer.apple.com/xcode/), and [CocoaPods](https://guides.cocoapods.org/using/getting-started.html#installation) already installed. You must use a macOS system to build the iOS app.
+These instructions will assume that you have the up-to-date.
+You'll need a Mac system for doing iOS builds.
+
+- [`git`](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+- [Flutter](https://flutter.dev/docs/get-started/install)
+- [Android Studio](https://developer.android.com/studio/index.html)
+- [XCode](https://developer.apple.com/xcode/)
+- [CocoaPods](https://guides.cocoapods.org/using/getting-started.html#installation)
 
 ## Verify your tool versions
 
@@ -67,17 +74,21 @@ flutter build ios --release --flavor prod
 The release archive is located here:
 
 ```
-TODO: FILL OUT, DO NOT MERGE
+client/build/ios/iphoneos/Runner.app
 ```
 
-Follow Apple's instructions to [create an archive](https://help.apple.com/xcode/mac/current/#/devf37a1db04), [validate the app](https://help.apple.com/xcode/mac/current/#/dev37441e273), and [upload it to App Store Connect](https://help.apple.com/xcode/mac/current/#/dev442d7f2ca).
+Follow Apple's instructions to:
+
+1. [Create Archive](https://help.apple.com/xcode/mac/current/#/devf37a1db04)
+1. [Validate the App](https://help.apple.com/xcode/mac/current/#/dev37441e273)
+1. [App Store Connect Upload](https://help.apple.com/xcode/mac/current/#/dev442d7f2ca)
 
 You should receive an email within 30 minutes notifying you that your build has been validated.
 
 ### Production vs Development Push Settings
 
-In file Runner.entitlements change 'aps-environment' to either 'development' or 'production' to select either the
-Sandbox or Production Apple Push Notification Service.
+In file Runner.entitlements change 'aps-environment' to either 'development' or 'production'
+to select either the Sandbox or Production Apple Push Notification Service.
 
 ### Submit For Review
 

--- a/docs/release/manual-build.md
+++ b/docs/release/manual-build.md
@@ -53,15 +53,22 @@ Follow Apple's instructions on [preparing for app distribution](https://help.app
 
 ### Create a Build Archive
 
-Prepare the Flutter release:
+Clean build and then build the Flutter release:
 
 ```
-DEVELOPMENT_ONLY=false ./tools/gen-client-buildinfo.sh
+./tools/gen-client-buildinfo.sh
 cd client
-flutter build ios
+
+flutter clean
+
+flutter build ios --release --flavor prod
 ```
 
-_Note: if you are on Xcode version 8.2 or earlier, you will need to close and re-open Xcode to ensure that the release configuration mode is refreshed_
+The release archive is located here:
+
+```
+TODO: FILL OUT, DO NOT MERGE
+```
 
 Follow Apple's instructions to [create an archive](https://help.apple.com/xcode/mac/current/#/devf37a1db04), [validate the app](https://help.apple.com/xcode/mac/current/#/dev37441e273), and [upload it to App Store Connect](https://help.apple.com/xcode/mac/current/#/dev442d7f2ca).
 
@@ -89,12 +96,16 @@ Follow Flutter's [instructions for signing the app](https://flutter.dev/docs/dep
 Build the app bundle:
 
 ```
-DEVELOPMENT_ONLY=false ./tools/gen-client-buildinfo.sh
+./tools/gen-client-buildinfo.sh
 cd client
-flutter build appbundle
+flutter build appbundle --release --flavor prod
 ```
 
-The release bundle for your app is created at `client/build/app/outputs/bundle/release/app.aab`.
+The release bundle for your app is created at:
+
+```
+build/app/outputs/bundle/prodRelease/app-prod-release.aab
+```
 
 ### Upload the bundle to Google Play
 

--- a/tools/gen-client-buildinfo.sh
+++ b/tools/gen-client-buildinfo.sh
@@ -1,16 +1,18 @@
+# Generate BuildInfo
+#
+# All data must be deterministic and repeatable for reproducible builds:
+# https://github.com/WorldHealthOrganization/app/issues/1084
+
 set -euv
 
 git diff --exit-code
 
 GIT_SHA="$(git rev-parse --verify HEAD)"
-BUILT_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 
 cat <<EOF >client/lib/generated/build.dart
 class BuildInfo {
   static const POPULATED = true;
   static const GIT_SHA = "$GIT_SHA";
-  static const BUILT_AT = "$BUILT_AT";
-  static const DEVELOPMENT_ONLY = $DEVELOPMENT_ONLY;
   static const FLUTTER_VERSION = '''$(flutter --version)''';
 }
 EOF


### PR DESCRIPTION
- Replaced by build flavors
- Remove "BUILT_AT" as it blocks reproducible build
- iOS CI build addition: `./tools/gen-client-buildinfo.sh`

## How did you test the change?

CI + running `./tools/gen-client-buildinfo.sh`

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
