### PR TITLE
WIP: Client race condition fixes (putLocation and putDeviceToken in single request )

### DIFF
--- a/api/who/who.proto
+++ b/api/who/who.proto
@@ -16,7 +16,7 @@ service WhoService {
   // The client should not pass a precise location.
   rpc putLocation(PutLocationRequest) returns (Void);
   
-  rpc putNotificationSettings(PutNotificationSettingsRequest) returns (Void);
+  rpc putClientSettings(PutClientSettingsRequest) returns (Void);
 
   rpc getCaseStats(GetCaseStatsRequest) returns (GetCaseStatsResponse);
 }
@@ -30,11 +30,11 @@ message PutLocationRequest {
   string isoCountryCode = 12;
 }
 
-message PutNotificationSettingsRequest {
+message PutClientSettingsRequest {
   // Firebase Cloud messaging registration token
   string token = 1;
   
-  // Approximate location. The client should not pass a precise location.
+  // User's selected location, ISO 3166-1 alpha-2 (uppercase) code.
   string isoCountryCode = 12;
 }
 

--- a/api/who/who.proto
+++ b/api/who/who.proto
@@ -15,6 +15,8 @@ service WhoService {
 
   // The client should not pass a precise location.
   rpc putLocation(PutLocationRequest) returns (Void);
+  
+  rpc putNotificationSettings(PutNotificationSettingsRequest) returns (Void);
 
   rpc getCaseStats(GetCaseStatsRequest) returns (GetCaseStatsResponse);
 }
@@ -25,6 +27,14 @@ message PutDeviceTokenRequest {
 
 message PutLocationRequest {
   // ISO 3166-1 alpha-2 (uppercase) code
+  string isoCountryCode = 12;
+}
+
+message PutNotificationSettingsRequest {
+  // Firebase Cloud messaging registration token
+  string token = 1;
+  
+  // Approximate location. The client should not pass a precise location.
   string isoCountryCode = 12;
 }
 

--- a/client/lib/api/notifications.dart
+++ b/client/lib/api/notifications.dart
@@ -105,8 +105,7 @@ class Notifications {
   Future setFirebaseToken(String newToken) async {
     var existingToken = await _userPrefs.getFirebaseToken();
     var countryCode = await prefs.countryIsoCode;
-    // If countryCode has not yet been set, no need to update the server.
-    if (existingToken != newToken && countryCode != null) {
+    if (existingToken != newToken) {
       await service.putClientSettings(
           token: newToken, isoCountryCode: countryCode);
       await _userPrefs.setFirebaseToken(newToken);

--- a/client/lib/api/notifications.dart
+++ b/client/lib/api/notifications.dart
@@ -107,7 +107,7 @@ class Notifications {
     var countryCode = await prefs.countryIsoCode;
     // If countryCode has not yet been set, no need to update the server.
     if (existingToken != newToken && countryCode != null) {
-      await service.putNotificationSettings(
+      await service.putClientSettings(
           token: newToken, isoCountryCode: countryCode);
       await _userPrefs.setFirebaseToken(newToken);
     }

--- a/client/lib/api/notifications.dart
+++ b/client/lib/api/notifications.dart
@@ -107,7 +107,8 @@ class Notifications {
     var countryCode = await prefs.countryIsoCode;
     // If countryCode has not yet been set, no need to update the server.
     if (existingToken != newToken && countryCode != null) {
-      await service.putNotificationSettings(token: newToken, isoCountryCode: countryCode);
+      await service.putNotificationSettings(
+          token: newToken, isoCountryCode: countryCode);
       await _userPrefs.setFirebaseToken(newToken);
     }
   }

--- a/client/lib/api/notifications.dart
+++ b/client/lib/api/notifications.dart
@@ -2,12 +2,14 @@ import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/widgets.dart';
 import 'package:notification_permissions/notification_permissions.dart';
 import 'package:who_app/api/user_preferences.dart';
+import 'package:who_app/api/user_preferences_store.dart';
 import 'package:who_app/api/who_service.dart';
 
 class Notifications {
   final WhoService service;
+  final UserPreferencesStore prefs;
 
-  Notifications({@required this.service});
+  Notifications({@required this.service, @required this.prefs});
 
   final FirebaseMessaging _firebaseMessaging = FirebaseMessaging.instance;
   final UserPreferences _userPrefs = UserPreferences();
@@ -97,16 +99,15 @@ class Notifications {
     final tokenToSet =
         notificationsEnabled ? await _firebaseMessaging.getToken() : null;
 
-    final storedToken = await _userPrefs.getFirebaseToken();
-    if (tokenToSet != storedToken) {
-      await setFirebaseToken(tokenToSet);
-    }
+    await setFirebaseToken(tokenToSet);
   }
 
   Future setFirebaseToken(String newToken) async {
-    var exitsingToken = await _userPrefs.getFirebaseToken();
-    if (exitsingToken != newToken) {
-      await service.putDeviceToken(newToken);
+    var existingToken = await _userPrefs.getFirebaseToken();
+    var countryCode = await prefs.countryIsoCode;
+    // If countryCode has not yet been set, no need to update the server.
+    if (existingToken != newToken && countryCode != null) {
+      await service.putNotificationSettings(token: newToken, isoCountryCode: countryCode);
       await _userPrefs.setFirebaseToken(newToken);
     }
   }

--- a/client/lib/api/who_service.dart
+++ b/client/lib/api/who_service.dart
@@ -12,32 +12,18 @@ class WhoService {
 
   WhoService({@required String endpoint}) : serviceUrl = '$endpoint/WhoService';
 
-  /// Put device token.
-  Future<bool> putDeviceToken(String token) async {
+  /// Put Notification Settings
+  Future<bool> putNotificationSettings({String token, String isoCountryCode}) async {
     final headers = await _getHeaders();
-    final req = PutDeviceTokenRequest.create();
+    final req = PutNotificationSettingsRequest.create();
     if (token != null) {
       req.token = token;
     } else {
       req.clearToken();
     }
-    final postBody = jsonEncode(req.toProto3Json());
-
-    final url = '$serviceUrl/putDeviceToken';
-    final response = await http.post(url, headers: headers, body: postBody);
-    if (response.statusCode != 200) {
-      throw Exception('Error status code: ${response.statusCode}');
-    }
-    return true;
-  }
-
-  /// Put location
-  Future<bool> putLocation({String isoCountryCode}) async {
-    final headers = await _getHeaders();
-    final req = PutLocationRequest.create();
     req.isoCountryCode = isoCountryCode;
     final postBody = jsonEncode(req.toProto3Json());
-    final url = '$serviceUrl/putLocation';
+    final url = '$serviceUrl/putNotificationSettings';
     final response = await http.post(url, headers: headers, body: postBody);
     if (response.statusCode != 200) {
       throw Exception('Error status code: ${response.statusCode}');

--- a/client/lib/api/who_service.dart
+++ b/client/lib/api/who_service.dart
@@ -13,7 +13,8 @@ class WhoService {
   WhoService({@required String endpoint}) : serviceUrl = '$endpoint/WhoService';
 
   /// Put Notification Settings
-  Future<bool> putNotificationSettings({String token, String isoCountryCode}) async {
+  Future<bool> putNotificationSettings(
+      {String token, String isoCountryCode}) async {
     final headers = await _getHeaders();
     final req = PutNotificationSettingsRequest.create();
     if (token != null) {

--- a/client/lib/api/who_service.dart
+++ b/client/lib/api/who_service.dart
@@ -12,7 +12,7 @@ class WhoService {
 
   WhoService({@required String endpoint}) : serviceUrl = '$endpoint/WhoService';
 
-  /// Put Notification Settings
+  /// Put Client Settings
   Future<bool> putClientSettings({String token, String isoCountryCode}) async {
     final headers = await _getHeaders();
     final req = PutClientSettingsRequest.create();

--- a/client/lib/api/who_service.dart
+++ b/client/lib/api/who_service.dart
@@ -13,10 +13,9 @@ class WhoService {
   WhoService({@required String endpoint}) : serviceUrl = '$endpoint/WhoService';
 
   /// Put Notification Settings
-  Future<bool> putNotificationSettings(
-      {String token, String isoCountryCode}) async {
+  Future<bool> putClientSettings({String token, String isoCountryCode}) async {
     final headers = await _getHeaders();
-    final req = PutNotificationSettingsRequest.create();
+    final req = PutClientSettingsRequest.create();
     if (token != null) {
       req.token = token;
     } else {
@@ -24,7 +23,7 @@ class WhoService {
     }
     req.isoCountryCode = isoCountryCode;
     final postBody = jsonEncode(req.toProto3Json());
-    final url = '$serviceUrl/putNotificationSettings';
+    final url = '$serviceUrl/putClientSettings';
     final response = await http.post(url, headers: headers, body: postBody);
     if (response.statusCode != 200) {
       throw Exception('Error status code: ${response.statusCode}');

--- a/client/lib/main.dart
+++ b/client/lib/main.dart
@@ -167,9 +167,9 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
                 update: (_, Endpoint endpoint, __) => WhoService(
                       endpoint: endpoint.serviceUrl,
                     )),
-            ProxyProvider(
-              update: (_, WhoService service, __) {
-                final ret = Notifications(service: service);
+            ProxyProvider2(
+              update: (_, WhoService service, UserPreferencesStore prefs, __) {
+                final ret = Notifications(service: service, prefs: prefs);
                 ret.configure();
                 ret.updateFirebaseToken();
                 return ret;

--- a/client/lib/pages/onboarding/onboarding_page.dart
+++ b/client/lib/pages/onboarding/onboarding_page.dart
@@ -118,9 +118,12 @@ class _OnboardingPageState extends State<OnboardingPage> {
       _showCountryListPage = false;
     });
     await _toNextPage();
+    var fcmToken = await UserPreferences().getFirebaseToken();
     try {
       await widget.service
-          .putLocation(isoCountryCode: _selectedCountry.alpha2Code);
+          .putNotificationSettings(
+          token: fcmToken,
+          isoCountryCode: _selectedCountry.alpha2Code);
     } catch (error) {
       print('Error sending location to API: $error');
     }

--- a/client/lib/pages/onboarding/onboarding_page.dart
+++ b/client/lib/pages/onboarding/onboarding_page.dart
@@ -120,10 +120,8 @@ class _OnboardingPageState extends State<OnboardingPage> {
     await _toNextPage();
     var fcmToken = await UserPreferences().getFirebaseToken();
     try {
-      await widget.service
-          .putNotificationSettings(
-          token: fcmToken,
-          isoCountryCode: _selectedCountry.alpha2Code);
+      await widget.service.putNotificationSettings(
+          token: fcmToken, isoCountryCode: _selectedCountry.alpha2Code);
     } catch (error) {
       print('Error sending location to API: $error');
     }

--- a/client/lib/pages/onboarding/onboarding_page.dart
+++ b/client/lib/pages/onboarding/onboarding_page.dart
@@ -120,10 +120,10 @@ class _OnboardingPageState extends State<OnboardingPage> {
     await _toNextPage();
     var fcmToken = await UserPreferences().getFirebaseToken();
     try {
-      await widget.service.putNotificationSettings(
+      await widget.service.putClientSettings(
           token: fcmToken, isoCountryCode: _selectedCountry.alpha2Code);
     } catch (error) {
-      print('Error sending location to API: $error');
+      print('Error sending client settings to API: $error');
     }
   }
 

--- a/client/lib/pages/settings_page.dart
+++ b/client/lib/pages/settings_page.dart
@@ -255,7 +255,7 @@ class _SettingsPageState extends State<SettingsPage>
     var fcmToken = await UserPreferences().getFirebaseToken();
 
     try {
-      await widget.service.putNotificationSettings(
+      await widget.service.putClientSettings(
           token: fcmToken, isoCountryCode: _selectedCountry.alpha2Code);
     } catch (error) {
       print('Error sending location to API: $error');

--- a/client/lib/pages/settings_page.dart
+++ b/client/lib/pages/settings_page.dart
@@ -252,10 +252,14 @@ class _SettingsPageState extends State<SettingsPage>
       _selectedCountry = country;
     });
     await widget.prefs.setCountryIsoCode(_selectedCountry.alpha2Code);
+    var fcmToken = await UserPreferences().getFirebaseToken();
+
 
     try {
       await widget.service
-          .putLocation(isoCountryCode: _selectedCountry.alpha2Code);
+          .putNotificationSettings(
+            token: fcmToken,
+            isoCountryCode: _selectedCountry.alpha2Code);
     } catch (error) {
       print('Error sending location to API: $error');
     }

--- a/client/lib/pages/settings_page.dart
+++ b/client/lib/pages/settings_page.dart
@@ -254,12 +254,9 @@ class _SettingsPageState extends State<SettingsPage>
     await widget.prefs.setCountryIsoCode(_selectedCountry.alpha2Code);
     var fcmToken = await UserPreferences().getFirebaseToken();
 
-
     try {
-      await widget.service
-          .putNotificationSettings(
-            token: fcmToken,
-            isoCountryCode: _selectedCountry.alpha2Code);
+      await widget.service.putNotificationSettings(
+          token: fcmToken, isoCountryCode: _selectedCountry.alpha2Code);
     } catch (error) {
       print('Error sending location to API: $error');
     }

--- a/client/lib/proto/api/who/who.pb.dart
+++ b/client/lib/proto/api/who/who.pb.dart
@@ -16,51 +16,69 @@ import 'who.pbenum.dart';
 export 'who.pbenum.dart';
 
 class Void extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('Void', package: const $pb.PackageName('who'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('Void',
+      package: const $pb.PackageName('who'), createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
   Void._() : super();
   factory Void() => create();
-  factory Void.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory Void.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory Void.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory Void.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
   Void clone() => Void()..mergeFromMessage(this);
-  Void copyWith(void Function(Void) updates) => super.copyWith((message) => updates(message as Void));
+  Void copyWith(void Function(Void) updates) =>
+      super.copyWith((message) => updates(message as Void));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Void create() => Void._();
   Void createEmptyInstance() => create();
   static $pb.PbList<Void> createRepeated() => $pb.PbList<Void>();
   @$core.pragma('dart2js:noInline')
-  static Void getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Void>(create);
+  static Void getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Void>(create);
   static Void _defaultInstance;
 }
 
 class PutDeviceTokenRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('PutDeviceTokenRequest', package: const $pb.PackageName('who'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('PutDeviceTokenRequest',
+      package: const $pb.PackageName('who'), createEmptyInstance: create)
     ..aOS(1, 'token')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   PutDeviceTokenRequest._() : super();
   factory PutDeviceTokenRequest() => create();
-  factory PutDeviceTokenRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory PutDeviceTokenRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  PutDeviceTokenRequest clone() => PutDeviceTokenRequest()..mergeFromMessage(this);
-  PutDeviceTokenRequest copyWith(void Function(PutDeviceTokenRequest) updates) => super.copyWith((message) => updates(message as PutDeviceTokenRequest));
+  factory PutDeviceTokenRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory PutDeviceTokenRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  PutDeviceTokenRequest clone() =>
+      PutDeviceTokenRequest()..mergeFromMessage(this);
+  PutDeviceTokenRequest copyWith(
+          void Function(PutDeviceTokenRequest) updates) =>
+      super.copyWith((message) => updates(message as PutDeviceTokenRequest));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static PutDeviceTokenRequest create() => PutDeviceTokenRequest._();
   PutDeviceTokenRequest createEmptyInstance() => create();
-  static $pb.PbList<PutDeviceTokenRequest> createRepeated() => $pb.PbList<PutDeviceTokenRequest>();
+  static $pb.PbList<PutDeviceTokenRequest> createRepeated() =>
+      $pb.PbList<PutDeviceTokenRequest>();
   @$core.pragma('dart2js:noInline')
-  static PutDeviceTokenRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PutDeviceTokenRequest>(create);
+  static PutDeviceTokenRequest getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<PutDeviceTokenRequest>(create);
   static PutDeviceTokenRequest _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get token => $_getSZ(0);
   @$pb.TagNumber(1)
-  set token($core.String v) { $_setString(0, v); }
+  set token($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasToken() => $_has(0);
   @$pb.TagNumber(1)
@@ -68,62 +86,84 @@ class PutDeviceTokenRequest extends $pb.GeneratedMessage {
 }
 
 class PutLocationRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('PutLocationRequest', package: const $pb.PackageName('who'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('PutLocationRequest',
+      package: const $pb.PackageName('who'), createEmptyInstance: create)
     ..aOS(12, 'isoCountryCode', protoName: 'isoCountryCode')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   PutLocationRequest._() : super();
   factory PutLocationRequest() => create();
-  factory PutLocationRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory PutLocationRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory PutLocationRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory PutLocationRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
   PutLocationRequest clone() => PutLocationRequest()..mergeFromMessage(this);
-  PutLocationRequest copyWith(void Function(PutLocationRequest) updates) => super.copyWith((message) => updates(message as PutLocationRequest));
+  PutLocationRequest copyWith(void Function(PutLocationRequest) updates) =>
+      super.copyWith((message) => updates(message as PutLocationRequest));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static PutLocationRequest create() => PutLocationRequest._();
   PutLocationRequest createEmptyInstance() => create();
-  static $pb.PbList<PutLocationRequest> createRepeated() => $pb.PbList<PutLocationRequest>();
+  static $pb.PbList<PutLocationRequest> createRepeated() =>
+      $pb.PbList<PutLocationRequest>();
   @$core.pragma('dart2js:noInline')
-  static PutLocationRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PutLocationRequest>(create);
+  static PutLocationRequest getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<PutLocationRequest>(create);
   static PutLocationRequest _defaultInstance;
 
   @$pb.TagNumber(12)
   $core.String get isoCountryCode => $_getSZ(0);
   @$pb.TagNumber(12)
-  set isoCountryCode($core.String v) { $_setString(0, v); }
+  set isoCountryCode($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(12)
   $core.bool hasIsoCountryCode() => $_has(0);
   @$pb.TagNumber(12)
   void clearIsoCountryCode() => clearField(12);
 }
 
-class PutNotificationSettingsRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('PutNotificationSettingsRequest', package: const $pb.PackageName('who'), createEmptyInstance: create)
+class PutClientSettingsRequest extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('PutClientSettingsRequest',
+      package: const $pb.PackageName('who'), createEmptyInstance: create)
     ..aOS(1, 'token')
     ..aOS(12, 'isoCountryCode', protoName: 'isoCountryCode')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  PutNotificationSettingsRequest._() : super();
-  factory PutNotificationSettingsRequest() => create();
-  factory PutNotificationSettingsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory PutNotificationSettingsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  PutNotificationSettingsRequest clone() => PutNotificationSettingsRequest()..mergeFromMessage(this);
-  PutNotificationSettingsRequest copyWith(void Function(PutNotificationSettingsRequest) updates) => super.copyWith((message) => updates(message as PutNotificationSettingsRequest));
+  PutClientSettingsRequest._() : super();
+  factory PutClientSettingsRequest() => create();
+  factory PutClientSettingsRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory PutClientSettingsRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  PutClientSettingsRequest clone() =>
+      PutClientSettingsRequest()..mergeFromMessage(this);
+  PutClientSettingsRequest copyWith(
+          void Function(PutClientSettingsRequest) updates) =>
+      super.copyWith((message) => updates(message as PutClientSettingsRequest));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
-  static PutNotificationSettingsRequest create() => PutNotificationSettingsRequest._();
-  PutNotificationSettingsRequest createEmptyInstance() => create();
-  static $pb.PbList<PutNotificationSettingsRequest> createRepeated() => $pb.PbList<PutNotificationSettingsRequest>();
+  static PutClientSettingsRequest create() => PutClientSettingsRequest._();
+  PutClientSettingsRequest createEmptyInstance() => create();
+  static $pb.PbList<PutClientSettingsRequest> createRepeated() =>
+      $pb.PbList<PutClientSettingsRequest>();
   @$core.pragma('dart2js:noInline')
-  static PutNotificationSettingsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PutNotificationSettingsRequest>(create);
-  static PutNotificationSettingsRequest _defaultInstance;
+  static PutClientSettingsRequest getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<PutClientSettingsRequest>(create);
+  static PutClientSettingsRequest _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get token => $_getSZ(0);
   @$pb.TagNumber(1)
-  set token($core.String v) { $_setString(0, v); }
+  set token($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasToken() => $_has(0);
   @$pb.TagNumber(1)
@@ -132,7 +172,10 @@ class PutNotificationSettingsRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(12)
   $core.String get isoCountryCode => $_getSZ(1);
   @$pb.TagNumber(12)
-  set isoCountryCode($core.String v) { $_setString(1, v); }
+  set isoCountryCode($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(12)
   $core.bool hasIsoCountryCode() => $_has(1);
   @$pb.TagNumber(12)
@@ -140,31 +183,45 @@ class PutNotificationSettingsRequest extends $pb.GeneratedMessage {
 }
 
 class JurisdictionId extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('JurisdictionId', package: const $pb.PackageName('who'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('JurisdictionId',
+      package: const $pb.PackageName('who'), createEmptyInstance: create)
     ..aOS(1, 'code')
-    ..e<JurisdictionType>(2, 'jurisdictionType', $pb.PbFieldType.OE, protoName: 'jurisdictionType', defaultOrMaker: JurisdictionType.GLOBAL, valueOf: JurisdictionType.valueOf, enumValues: JurisdictionType.values)
-    ..hasRequiredFields = false
-  ;
+    ..e<JurisdictionType>(2, 'jurisdictionType', $pb.PbFieldType.OE,
+        protoName: 'jurisdictionType',
+        defaultOrMaker: JurisdictionType.GLOBAL,
+        valueOf: JurisdictionType.valueOf,
+        enumValues: JurisdictionType.values)
+    ..hasRequiredFields = false;
 
   JurisdictionId._() : super();
   factory JurisdictionId() => create();
-  factory JurisdictionId.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory JurisdictionId.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory JurisdictionId.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory JurisdictionId.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
   JurisdictionId clone() => JurisdictionId()..mergeFromMessage(this);
-  JurisdictionId copyWith(void Function(JurisdictionId) updates) => super.copyWith((message) => updates(message as JurisdictionId));
+  JurisdictionId copyWith(void Function(JurisdictionId) updates) =>
+      super.copyWith((message) => updates(message as JurisdictionId));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static JurisdictionId create() => JurisdictionId._();
   JurisdictionId createEmptyInstance() => create();
-  static $pb.PbList<JurisdictionId> createRepeated() => $pb.PbList<JurisdictionId>();
+  static $pb.PbList<JurisdictionId> createRepeated() =>
+      $pb.PbList<JurisdictionId>();
   @$core.pragma('dart2js:noInline')
-  static JurisdictionId getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<JurisdictionId>(create);
+  static JurisdictionId getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<JurisdictionId>(create);
   static JurisdictionId _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get code => $_getSZ(0);
   @$pb.TagNumber(1)
-  set code($core.String v) { $_setString(0, v); }
+  set code($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasCode() => $_has(0);
   @$pb.TagNumber(1)
@@ -173,7 +230,10 @@ class JurisdictionId extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   JurisdictionType get jurisdictionType => $_getN(1);
   @$pb.TagNumber(2)
-  set jurisdictionType(JurisdictionType v) { setField(2, v); }
+  set jurisdictionType(JurisdictionType v) {
+    setField(2, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasJurisdictionType() => $_has(1);
   @$pb.TagNumber(2)
@@ -181,24 +241,32 @@ class JurisdictionId extends $pb.GeneratedMessage {
 }
 
 class GetCaseStatsRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('GetCaseStatsRequest', package: const $pb.PackageName('who'), createEmptyInstance: create)
-    ..pc<JurisdictionId>(1, 'jurisdictions', $pb.PbFieldType.PM, subBuilder: JurisdictionId.create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('GetCaseStatsRequest',
+      package: const $pb.PackageName('who'), createEmptyInstance: create)
+    ..pc<JurisdictionId>(1, 'jurisdictions', $pb.PbFieldType.PM,
+        subBuilder: JurisdictionId.create)
+    ..hasRequiredFields = false;
 
   GetCaseStatsRequest._() : super();
   factory GetCaseStatsRequest() => create();
-  factory GetCaseStatsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory GetCaseStatsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory GetCaseStatsRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GetCaseStatsRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
   GetCaseStatsRequest clone() => GetCaseStatsRequest()..mergeFromMessage(this);
-  GetCaseStatsRequest copyWith(void Function(GetCaseStatsRequest) updates) => super.copyWith((message) => updates(message as GetCaseStatsRequest));
+  GetCaseStatsRequest copyWith(void Function(GetCaseStatsRequest) updates) =>
+      super.copyWith((message) => updates(message as GetCaseStatsRequest));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static GetCaseStatsRequest create() => GetCaseStatsRequest._();
   GetCaseStatsRequest createEmptyInstance() => create();
-  static $pb.PbList<GetCaseStatsRequest> createRepeated() => $pb.PbList<GetCaseStatsRequest>();
+  static $pb.PbList<GetCaseStatsRequest> createRepeated() =>
+      $pb.PbList<GetCaseStatsRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetCaseStatsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetCaseStatsRequest>(create);
+  static GetCaseStatsRequest getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GetCaseStatsRequest>(create);
   static GetCaseStatsRequest _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -206,26 +274,37 @@ class GetCaseStatsRequest extends $pb.GeneratedMessage {
 }
 
 class GetCaseStatsResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('GetCaseStatsResponse', package: const $pb.PackageName('who'), createEmptyInstance: create)
-    ..aOM<CaseStats>(1, 'globalStats', protoName: 'globalStats', subBuilder: CaseStats.create)
-    ..a<$fixnum.Int64>(2, 'ttl', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
-    ..pc<CaseStats>(3, 'jurisdictionStats', $pb.PbFieldType.PM, protoName: 'jurisdictionStats', subBuilder: CaseStats.create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('GetCaseStatsResponse',
+      package: const $pb.PackageName('who'), createEmptyInstance: create)
+    ..aOM<CaseStats>(1, 'globalStats',
+        protoName: 'globalStats', subBuilder: CaseStats.create)
+    ..a<$fixnum.Int64>(2, 'ttl', $pb.PbFieldType.OU6,
+        defaultOrMaker: $fixnum.Int64.ZERO)
+    ..pc<CaseStats>(3, 'jurisdictionStats', $pb.PbFieldType.PM,
+        protoName: 'jurisdictionStats', subBuilder: CaseStats.create)
+    ..hasRequiredFields = false;
 
   GetCaseStatsResponse._() : super();
   factory GetCaseStatsResponse() => create();
-  factory GetCaseStatsResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory GetCaseStatsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  GetCaseStatsResponse clone() => GetCaseStatsResponse()..mergeFromMessage(this);
-  GetCaseStatsResponse copyWith(void Function(GetCaseStatsResponse) updates) => super.copyWith((message) => updates(message as GetCaseStatsResponse));
+  factory GetCaseStatsResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GetCaseStatsResponse.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  GetCaseStatsResponse clone() =>
+      GetCaseStatsResponse()..mergeFromMessage(this);
+  GetCaseStatsResponse copyWith(void Function(GetCaseStatsResponse) updates) =>
+      super.copyWith((message) => updates(message as GetCaseStatsResponse));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static GetCaseStatsResponse create() => GetCaseStatsResponse._();
   GetCaseStatsResponse createEmptyInstance() => create();
-  static $pb.PbList<GetCaseStatsResponse> createRepeated() => $pb.PbList<GetCaseStatsResponse>();
+  static $pb.PbList<GetCaseStatsResponse> createRepeated() =>
+      $pb.PbList<GetCaseStatsResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetCaseStatsResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetCaseStatsResponse>(create);
+  static GetCaseStatsResponse getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GetCaseStatsResponse>(create);
   static GetCaseStatsResponse _defaultInstance;
 
   @$core.Deprecated('This field is deprecated.')
@@ -233,7 +312,10 @@ class GetCaseStatsResponse extends $pb.GeneratedMessage {
   CaseStats get globalStats => $_getN(0);
   @$core.Deprecated('This field is deprecated.')
   @$pb.TagNumber(1)
-  set globalStats(CaseStats v) { setField(1, v); }
+  set globalStats(CaseStats v) {
+    setField(1, v);
+  }
+
   @$core.Deprecated('This field is deprecated.')
   @$pb.TagNumber(1)
   $core.bool hasGlobalStats() => $_has(0);
@@ -247,7 +329,10 @@ class GetCaseStatsResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get ttl => $_getI64(1);
   @$pb.TagNumber(2)
-  set ttl($fixnum.Int64 v) { $_setInt64(1, v); }
+  set ttl($fixnum.Int64 v) {
+    $_setInt64(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasTtl() => $_has(1);
   @$pb.TagNumber(2)
@@ -258,36 +343,47 @@ class GetCaseStatsResponse extends $pb.GeneratedMessage {
 }
 
 class StatSnapshot extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('StatSnapshot', package: const $pb.PackageName('who'), createEmptyInstance: create)
-    ..a<$fixnum.Int64>(1, 'epochMsec', $pb.PbFieldType.OU6, protoName: 'epochMsec', defaultOrMaker: $fixnum.Int64.ZERO)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('StatSnapshot',
+      package: const $pb.PackageName('who'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(1, 'epochMsec', $pb.PbFieldType.OU6,
+        protoName: 'epochMsec', defaultOrMaker: $fixnum.Int64.ZERO)
     ..aInt64(2, 'dailyCases', protoName: 'dailyCases')
     ..aInt64(3, 'dailyDeaths', protoName: 'dailyDeaths')
     ..aInt64(4, 'dailyRecoveries', protoName: 'dailyRecoveries')
     ..aInt64(5, 'totalCases', protoName: 'totalCases')
     ..aInt64(6, 'totalDeaths', protoName: 'totalDeaths')
     ..aInt64(7, 'totalRecoveries', protoName: 'totalRecoveries')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   StatSnapshot._() : super();
   factory StatSnapshot() => create();
-  factory StatSnapshot.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory StatSnapshot.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory StatSnapshot.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory StatSnapshot.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
   StatSnapshot clone() => StatSnapshot()..mergeFromMessage(this);
-  StatSnapshot copyWith(void Function(StatSnapshot) updates) => super.copyWith((message) => updates(message as StatSnapshot));
+  StatSnapshot copyWith(void Function(StatSnapshot) updates) =>
+      super.copyWith((message) => updates(message as StatSnapshot));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static StatSnapshot create() => StatSnapshot._();
   StatSnapshot createEmptyInstance() => create();
-  static $pb.PbList<StatSnapshot> createRepeated() => $pb.PbList<StatSnapshot>();
+  static $pb.PbList<StatSnapshot> createRepeated() =>
+      $pb.PbList<StatSnapshot>();
   @$core.pragma('dart2js:noInline')
-  static StatSnapshot getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StatSnapshot>(create);
+  static StatSnapshot getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<StatSnapshot>(create);
   static StatSnapshot _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get epochMsec => $_getI64(0);
   @$pb.TagNumber(1)
-  set epochMsec($fixnum.Int64 v) { $_setInt64(0, v); }
+  set epochMsec($fixnum.Int64 v) {
+    $_setInt64(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasEpochMsec() => $_has(0);
   @$pb.TagNumber(1)
@@ -296,7 +392,10 @@ class StatSnapshot extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get dailyCases => $_getI64(1);
   @$pb.TagNumber(2)
-  set dailyCases($fixnum.Int64 v) { $_setInt64(1, v); }
+  set dailyCases($fixnum.Int64 v) {
+    $_setInt64(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasDailyCases() => $_has(1);
   @$pb.TagNumber(2)
@@ -305,7 +404,10 @@ class StatSnapshot extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get dailyDeaths => $_getI64(2);
   @$pb.TagNumber(3)
-  set dailyDeaths($fixnum.Int64 v) { $_setInt64(2, v); }
+  set dailyDeaths($fixnum.Int64 v) {
+    $_setInt64(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasDailyDeaths() => $_has(2);
   @$pb.TagNumber(3)
@@ -314,7 +416,10 @@ class StatSnapshot extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $fixnum.Int64 get dailyRecoveries => $_getI64(3);
   @$pb.TagNumber(4)
-  set dailyRecoveries($fixnum.Int64 v) { $_setInt64(3, v); }
+  set dailyRecoveries($fixnum.Int64 v) {
+    $_setInt64(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasDailyRecoveries() => $_has(3);
   @$pb.TagNumber(4)
@@ -323,7 +428,10 @@ class StatSnapshot extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $fixnum.Int64 get totalCases => $_getI64(4);
   @$pb.TagNumber(5)
-  set totalCases($fixnum.Int64 v) { $_setInt64(4, v); }
+  set totalCases($fixnum.Int64 v) {
+    $_setInt64(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasTotalCases() => $_has(4);
   @$pb.TagNumber(5)
@@ -332,7 +440,10 @@ class StatSnapshot extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $fixnum.Int64 get totalDeaths => $_getI64(5);
   @$pb.TagNumber(6)
-  set totalDeaths($fixnum.Int64 v) { $_setInt64(5, v); }
+  set totalDeaths($fixnum.Int64 v) {
+    $_setInt64(5, v);
+  }
+
   @$pb.TagNumber(6)
   $core.bool hasTotalDeaths() => $_has(5);
   @$pb.TagNumber(6)
@@ -341,7 +452,10 @@ class StatSnapshot extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $fixnum.Int64 get totalRecoveries => $_getI64(6);
   @$pb.TagNumber(7)
-  set totalRecoveries($fixnum.Int64 v) { $_setInt64(6, v); }
+  set totalRecoveries($fixnum.Int64 v) {
+    $_setInt64(6, v);
+  }
+
   @$pb.TagNumber(7)
   $core.bool hasTotalRecoveries() => $_has(6);
   @$pb.TagNumber(7)
@@ -349,37 +463,52 @@ class StatSnapshot extends $pb.GeneratedMessage {
 }
 
 class CaseStats extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('CaseStats', package: const $pb.PackageName('who'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('CaseStats',
+      package: const $pb.PackageName('who'), createEmptyInstance: create)
     ..aOS(1, 'jurisdiction')
-    ..a<$fixnum.Int64>(2, 'lastUpdated', $pb.PbFieldType.OU6, protoName: 'lastUpdated', defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(2, 'lastUpdated', $pb.PbFieldType.OU6,
+        protoName: 'lastUpdated', defaultOrMaker: $fixnum.Int64.ZERO)
     ..aInt64(3, 'cases')
     ..aInt64(4, 'deaths')
     ..aInt64(5, 'recoveries')
     ..aOS(6, 'attribution')
-    ..e<JurisdictionType>(7, 'jurisdictionType', $pb.PbFieldType.OE, protoName: 'jurisdictionType', defaultOrMaker: JurisdictionType.GLOBAL, valueOf: JurisdictionType.valueOf, enumValues: JurisdictionType.values)
-    ..pc<StatSnapshot>(8, 'timeseries', $pb.PbFieldType.PM, subBuilder: StatSnapshot.create)
-    ..hasRequiredFields = false
-  ;
+    ..e<JurisdictionType>(7, 'jurisdictionType', $pb.PbFieldType.OE,
+        protoName: 'jurisdictionType',
+        defaultOrMaker: JurisdictionType.GLOBAL,
+        valueOf: JurisdictionType.valueOf,
+        enumValues: JurisdictionType.values)
+    ..pc<StatSnapshot>(8, 'timeseries', $pb.PbFieldType.PM,
+        subBuilder: StatSnapshot.create)
+    ..hasRequiredFields = false;
 
   CaseStats._() : super();
   factory CaseStats() => create();
-  factory CaseStats.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory CaseStats.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory CaseStats.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory CaseStats.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
   CaseStats clone() => CaseStats()..mergeFromMessage(this);
-  CaseStats copyWith(void Function(CaseStats) updates) => super.copyWith((message) => updates(message as CaseStats));
+  CaseStats copyWith(void Function(CaseStats) updates) =>
+      super.copyWith((message) => updates(message as CaseStats));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static CaseStats create() => CaseStats._();
   CaseStats createEmptyInstance() => create();
   static $pb.PbList<CaseStats> createRepeated() => $pb.PbList<CaseStats>();
   @$core.pragma('dart2js:noInline')
-  static CaseStats getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CaseStats>(create);
+  static CaseStats getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CaseStats>(create);
   static CaseStats _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get jurisdiction => $_getSZ(0);
   @$pb.TagNumber(1)
-  set jurisdiction($core.String v) { $_setString(0, v); }
+  set jurisdiction($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasJurisdiction() => $_has(0);
   @$pb.TagNumber(1)
@@ -388,7 +517,10 @@ class CaseStats extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get lastUpdated => $_getI64(1);
   @$pb.TagNumber(2)
-  set lastUpdated($fixnum.Int64 v) { $_setInt64(1, v); }
+  set lastUpdated($fixnum.Int64 v) {
+    $_setInt64(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasLastUpdated() => $_has(1);
   @$pb.TagNumber(2)
@@ -397,7 +529,10 @@ class CaseStats extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get cases => $_getI64(2);
   @$pb.TagNumber(3)
-  set cases($fixnum.Int64 v) { $_setInt64(2, v); }
+  set cases($fixnum.Int64 v) {
+    $_setInt64(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasCases() => $_has(2);
   @$pb.TagNumber(3)
@@ -406,7 +541,10 @@ class CaseStats extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $fixnum.Int64 get deaths => $_getI64(3);
   @$pb.TagNumber(4)
-  set deaths($fixnum.Int64 v) { $_setInt64(3, v); }
+  set deaths($fixnum.Int64 v) {
+    $_setInt64(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasDeaths() => $_has(3);
   @$pb.TagNumber(4)
@@ -415,7 +553,10 @@ class CaseStats extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $fixnum.Int64 get recoveries => $_getI64(4);
   @$pb.TagNumber(5)
-  set recoveries($fixnum.Int64 v) { $_setInt64(4, v); }
+  set recoveries($fixnum.Int64 v) {
+    $_setInt64(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasRecoveries() => $_has(4);
   @$pb.TagNumber(5)
@@ -424,7 +565,10 @@ class CaseStats extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.String get attribution => $_getSZ(5);
   @$pb.TagNumber(6)
-  set attribution($core.String v) { $_setString(5, v); }
+  set attribution($core.String v) {
+    $_setString(5, v);
+  }
+
   @$pb.TagNumber(6)
   $core.bool hasAttribution() => $_has(5);
   @$pb.TagNumber(6)
@@ -433,7 +577,10 @@ class CaseStats extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   JurisdictionType get jurisdictionType => $_getN(6);
   @$pb.TagNumber(7)
-  set jurisdictionType(JurisdictionType v) { setField(7, v); }
+  set jurisdictionType(JurisdictionType v) {
+    setField(7, v);
+  }
+
   @$pb.TagNumber(7)
   $core.bool hasJurisdictionType() => $_has(6);
   @$pb.TagNumber(7)
@@ -447,21 +594,31 @@ class WhoServiceApi {
   $pb.RpcClient _client;
   WhoServiceApi(this._client);
 
-  $async.Future<Void> putDeviceToken($pb.ClientContext ctx, PutDeviceTokenRequest request) {
+  $async.Future<Void> putDeviceToken(
+      $pb.ClientContext ctx, PutDeviceTokenRequest request) {
     var emptyResponse = Void();
-    return _client.invoke<Void>(ctx, 'WhoService', 'putDeviceToken', request, emptyResponse);
+    return _client.invoke<Void>(
+        ctx, 'WhoService', 'putDeviceToken', request, emptyResponse);
   }
-  $async.Future<Void> putLocation($pb.ClientContext ctx, PutLocationRequest request) {
+
+  $async.Future<Void> putLocation(
+      $pb.ClientContext ctx, PutLocationRequest request) {
     var emptyResponse = Void();
-    return _client.invoke<Void>(ctx, 'WhoService', 'putLocation', request, emptyResponse);
+    return _client.invoke<Void>(
+        ctx, 'WhoService', 'putLocation', request, emptyResponse);
   }
-  $async.Future<Void> putNotificationSettings($pb.ClientContext ctx, PutNotificationSettingsRequest request) {
+
+  $async.Future<Void> putClientSettings(
+      $pb.ClientContext ctx, PutClientSettingsRequest request) {
     var emptyResponse = Void();
-    return _client.invoke<Void>(ctx, 'WhoService', 'putNotificationSettings', request, emptyResponse);
+    return _client.invoke<Void>(
+        ctx, 'WhoService', 'putClientSettings', request, emptyResponse);
   }
-  $async.Future<GetCaseStatsResponse> getCaseStats($pb.ClientContext ctx, GetCaseStatsRequest request) {
+
+  $async.Future<GetCaseStatsResponse> getCaseStats(
+      $pb.ClientContext ctx, GetCaseStatsRequest request) {
     var emptyResponse = GetCaseStatsResponse();
-    return _client.invoke<GetCaseStatsResponse>(ctx, 'WhoService', 'getCaseStats', request, emptyResponse);
+    return _client.invoke<GetCaseStatsResponse>(
+        ctx, 'WhoService', 'getCaseStats', request, emptyResponse);
   }
 }
-

--- a/client/lib/proto/api/who/who.pb.dart
+++ b/client/lib/proto/api/who/who.pb.dart
@@ -3,7 +3,7 @@
 //  source: api/who/who.proto
 //
 // @dart = 2.3
-// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type
+// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:async' as $async;
 import 'dart:core' as $core;
@@ -16,8 +16,15 @@ import 'who.pbenum.dart';
 export 'who.pbenum.dart';
 
 class Void extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('Void',
-      package: const $pb.PackageName('who'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'Void',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'who'),
+      createEmptyInstance: create)
     ..hasRequiredFields = false;
 
   Void._() : super();
@@ -28,9 +35,15 @@ class Void extends $pb.GeneratedMessage {
   factory Void.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   Void clone() => Void()..mergeFromMessage(this);
-  Void copyWith(void Function(Void) updates) =>
-      super.copyWith((message) => updates(message as Void));
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  Void copyWith(void Function(Void) updates) => super.copyWith(
+      (message) => updates(message as Void)); // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Void create() => Void._();
@@ -43,9 +56,20 @@ class Void extends $pb.GeneratedMessage {
 }
 
 class PutDeviceTokenRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('PutDeviceTokenRequest',
-      package: const $pb.PackageName('who'), createEmptyInstance: create)
-    ..aOS(1, 'token')
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'PutDeviceTokenRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'who'),
+      createEmptyInstance: create)
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'token')
     ..hasRequiredFields = false;
 
   PutDeviceTokenRequest._() : super();
@@ -56,11 +80,18 @@ class PutDeviceTokenRequest extends $pb.GeneratedMessage {
   factory PutDeviceTokenRequest.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   PutDeviceTokenRequest clone() =>
       PutDeviceTokenRequest()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
   PutDeviceTokenRequest copyWith(
           void Function(PutDeviceTokenRequest) updates) =>
-      super.copyWith((message) => updates(message as PutDeviceTokenRequest));
+      super.copyWith((message) => updates(
+          message as PutDeviceTokenRequest)); // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static PutDeviceTokenRequest create() => PutDeviceTokenRequest._();
@@ -86,9 +117,21 @@ class PutDeviceTokenRequest extends $pb.GeneratedMessage {
 }
 
 class PutLocationRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('PutLocationRequest',
-      package: const $pb.PackageName('who'), createEmptyInstance: create)
-    ..aOS(12, 'isoCountryCode', protoName: 'isoCountryCode')
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'PutLocationRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'who'),
+      createEmptyInstance: create)
+    ..aOS(
+        12,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'isoCountryCode',
+        protoName: 'isoCountryCode')
     ..hasRequiredFields = false;
 
   PutLocationRequest._() : super();
@@ -99,9 +142,16 @@ class PutLocationRequest extends $pb.GeneratedMessage {
   factory PutLocationRequest.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   PutLocationRequest clone() => PutLocationRequest()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
   PutLocationRequest copyWith(void Function(PutLocationRequest) updates) =>
-      super.copyWith((message) => updates(message as PutLocationRequest));
+      super.copyWith((message) => updates(
+          message as PutLocationRequest)); // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static PutLocationRequest create() => PutLocationRequest._();
@@ -127,10 +177,26 @@ class PutLocationRequest extends $pb.GeneratedMessage {
 }
 
 class PutClientSettingsRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('PutClientSettingsRequest',
-      package: const $pb.PackageName('who'), createEmptyInstance: create)
-    ..aOS(1, 'token')
-    ..aOS(12, 'isoCountryCode', protoName: 'isoCountryCode')
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'PutClientSettingsRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'who'),
+      createEmptyInstance: create)
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'token')
+    ..aOS(
+        12,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'isoCountryCode',
+        protoName: 'isoCountryCode')
     ..hasRequiredFields = false;
 
   PutClientSettingsRequest._() : super();
@@ -141,11 +207,18 @@ class PutClientSettingsRequest extends $pb.GeneratedMessage {
   factory PutClientSettingsRequest.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   PutClientSettingsRequest clone() =>
       PutClientSettingsRequest()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
   PutClientSettingsRequest copyWith(
           void Function(PutClientSettingsRequest) updates) =>
-      super.copyWith((message) => updates(message as PutClientSettingsRequest));
+      super.copyWith((message) => updates(message
+          as PutClientSettingsRequest)); // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static PutClientSettingsRequest create() => PutClientSettingsRequest._();
@@ -183,10 +256,26 @@ class PutClientSettingsRequest extends $pb.GeneratedMessage {
 }
 
 class JurisdictionId extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('JurisdictionId',
-      package: const $pb.PackageName('who'), createEmptyInstance: create)
-    ..aOS(1, 'code')
-    ..e<JurisdictionType>(2, 'jurisdictionType', $pb.PbFieldType.OE,
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'JurisdictionId',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'who'),
+      createEmptyInstance: create)
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'code')
+    ..e<JurisdictionType>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'jurisdictionType',
+        $pb.PbFieldType.OE,
         protoName: 'jurisdictionType',
         defaultOrMaker: JurisdictionType.GLOBAL,
         valueOf: JurisdictionType.valueOf,
@@ -201,9 +290,16 @@ class JurisdictionId extends $pb.GeneratedMessage {
   factory JurisdictionId.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   JurisdictionId clone() => JurisdictionId()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
   JurisdictionId copyWith(void Function(JurisdictionId) updates) =>
-      super.copyWith((message) => updates(message as JurisdictionId));
+      super.copyWith((message) =>
+          updates(message as JurisdictionId)); // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static JurisdictionId create() => JurisdictionId._();
@@ -241,9 +337,21 @@ class JurisdictionId extends $pb.GeneratedMessage {
 }
 
 class GetCaseStatsRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('GetCaseStatsRequest',
-      package: const $pb.PackageName('who'), createEmptyInstance: create)
-    ..pc<JurisdictionId>(1, 'jurisdictions', $pb.PbFieldType.PM,
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GetCaseStatsRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'who'),
+      createEmptyInstance: create)
+    ..pc<JurisdictionId>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'jurisdictions',
+        $pb.PbFieldType.PM,
         subBuilder: JurisdictionId.create)
     ..hasRequiredFields = false;
 
@@ -255,9 +363,16 @@ class GetCaseStatsRequest extends $pb.GeneratedMessage {
   factory GetCaseStatsRequest.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   GetCaseStatsRequest clone() => GetCaseStatsRequest()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
   GetCaseStatsRequest copyWith(void Function(GetCaseStatsRequest) updates) =>
-      super.copyWith((message) => updates(message as GetCaseStatsRequest));
+      super.copyWith((message) => updates(
+          message as GetCaseStatsRequest)); // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static GetCaseStatsRequest create() => GetCaseStatsRequest._();
@@ -274,13 +389,22 @@ class GetCaseStatsRequest extends $pb.GeneratedMessage {
 }
 
 class GetCaseStatsResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('GetCaseStatsResponse',
-      package: const $pb.PackageName('who'), createEmptyInstance: create)
-    ..aOM<CaseStats>(1, 'globalStats',
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GetCaseStatsResponse',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'who'),
+      createEmptyInstance: create)
+    ..aOM<CaseStats>(
+        1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'globalStats',
         protoName: 'globalStats', subBuilder: CaseStats.create)
-    ..a<$fixnum.Int64>(2, 'ttl', $pb.PbFieldType.OU6,
+    ..a<$fixnum.Int64>(
+        2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'ttl', $pb.PbFieldType.OU6,
         defaultOrMaker: $fixnum.Int64.ZERO)
-    ..pc<CaseStats>(3, 'jurisdictionStats', $pb.PbFieldType.PM,
+    ..pc<CaseStats>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'jurisdictionStats', $pb.PbFieldType.PM,
         protoName: 'jurisdictionStats', subBuilder: CaseStats.create)
     ..hasRequiredFields = false;
 
@@ -292,10 +416,17 @@ class GetCaseStatsResponse extends $pb.GeneratedMessage {
   factory GetCaseStatsResponse.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   GetCaseStatsResponse clone() =>
       GetCaseStatsResponse()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
   GetCaseStatsResponse copyWith(void Function(GetCaseStatsResponse) updates) =>
-      super.copyWith((message) => updates(message as GetCaseStatsResponse));
+      super.copyWith((message) => updates(
+          message as GetCaseStatsResponse)); // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static GetCaseStatsResponse create() => GetCaseStatsResponse._();
@@ -343,16 +474,30 @@ class GetCaseStatsResponse extends $pb.GeneratedMessage {
 }
 
 class StatSnapshot extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('StatSnapshot',
-      package: const $pb.PackageName('who'), createEmptyInstance: create)
-    ..a<$fixnum.Int64>(1, 'epochMsec', $pb.PbFieldType.OU6,
-        protoName: 'epochMsec', defaultOrMaker: $fixnum.Int64.ZERO)
-    ..aInt64(2, 'dailyCases', protoName: 'dailyCases')
-    ..aInt64(3, 'dailyDeaths', protoName: 'dailyDeaths')
-    ..aInt64(4, 'dailyRecoveries', protoName: 'dailyRecoveries')
-    ..aInt64(5, 'totalCases', protoName: 'totalCases')
-    ..aInt64(6, 'totalDeaths', protoName: 'totalDeaths')
-    ..aInt64(7, 'totalRecoveries', protoName: 'totalRecoveries')
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'StatSnapshot',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'who'),
+      createEmptyInstance: create)
+    ..a<$fixnum.Int64>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'epochMsec',
+        $pb.PbFieldType.OU6,
+        protoName: 'epochMsec',
+        defaultOrMaker: $fixnum.Int64.ZERO)
+    ..aInt64(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'dailyCases',
+        protoName: 'dailyCases')
+    ..aInt64(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'dailyDeaths', protoName: 'dailyDeaths')
+    ..aInt64(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'dailyRecoveries', protoName: 'dailyRecoveries')
+    ..aInt64(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'totalCases', protoName: 'totalCases')
+    ..aInt64(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'totalDeaths', protoName: 'totalDeaths')
+    ..aInt64(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'totalRecoveries', protoName: 'totalRecoveries')
     ..hasRequiredFields = false;
 
   StatSnapshot._() : super();
@@ -363,9 +508,16 @@ class StatSnapshot extends $pb.GeneratedMessage {
   factory StatSnapshot.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   StatSnapshot clone() => StatSnapshot()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
   StatSnapshot copyWith(void Function(StatSnapshot) updates) =>
-      super.copyWith((message) => updates(message as StatSnapshot));
+      super.copyWith((message) =>
+          updates(message as StatSnapshot)); // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static StatSnapshot create() => StatSnapshot._();
@@ -463,22 +615,35 @@ class StatSnapshot extends $pb.GeneratedMessage {
 }
 
 class CaseStats extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('CaseStats',
-      package: const $pb.PackageName('who'), createEmptyInstance: create)
-    ..aOS(1, 'jurisdiction')
-    ..a<$fixnum.Int64>(2, 'lastUpdated', $pb.PbFieldType.OU6,
-        protoName: 'lastUpdated', defaultOrMaker: $fixnum.Int64.ZERO)
-    ..aInt64(3, 'cases')
-    ..aInt64(4, 'deaths')
-    ..aInt64(5, 'recoveries')
-    ..aOS(6, 'attribution')
-    ..e<JurisdictionType>(7, 'jurisdictionType', $pb.PbFieldType.OE,
-        protoName: 'jurisdictionType',
-        defaultOrMaker: JurisdictionType.GLOBAL,
-        valueOf: JurisdictionType.valueOf,
-        enumValues: JurisdictionType.values)
-    ..pc<StatSnapshot>(8, 'timeseries', $pb.PbFieldType.PM,
-        subBuilder: StatSnapshot.create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'CaseStats',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'who'),
+      createEmptyInstance: create)
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'jurisdiction')
+    ..a<$fixnum.Int64>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'lastUpdated',
+        $pb.PbFieldType.OU6,
+        protoName: 'lastUpdated',
+        defaultOrMaker: $fixnum.Int64.ZERO)
+    ..aInt64(
+        3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'cases')
+    ..aInt64(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'deaths')
+    ..aInt64(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'recoveries')
+    ..aOS(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'attribution')
+    ..e<JurisdictionType>(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'jurisdictionType', $pb.PbFieldType.OE, protoName: 'jurisdictionType', defaultOrMaker: JurisdictionType.GLOBAL, valueOf: JurisdictionType.valueOf, enumValues: JurisdictionType.values)
+    ..pc<StatSnapshot>(8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'timeseries', $pb.PbFieldType.PM, subBuilder: StatSnapshot.create)
     ..hasRequiredFields = false;
 
   CaseStats._() : super();
@@ -489,9 +654,16 @@ class CaseStats extends $pb.GeneratedMessage {
   factory CaseStats.fromJson($core.String i,
           [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
       create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   CaseStats clone() => CaseStats()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
   CaseStats copyWith(void Function(CaseStats) updates) =>
-      super.copyWith((message) => updates(message as CaseStats));
+      super.copyWith((message) =>
+          updates(message as CaseStats)); // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static CaseStats create() => CaseStats._();

--- a/client/lib/proto/api/who/who.pb.dart
+++ b/client/lib/proto/api/who/who.pb.dart
@@ -3,7 +3,7 @@
 //  source: api/who/who.proto
 //
 // @dart = 2.3
-// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
+// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type
 
 import 'dart:async' as $async;
 import 'dart:core' as $core;
@@ -16,100 +16,51 @@ import 'who.pbenum.dart';
 export 'who.pbenum.dart';
 
 class Void extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'Void',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'who'),
-      createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('Void', package: const $pb.PackageName('who'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
   Void._() : super();
   factory Void() => create();
-  factory Void.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Void.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  factory Void.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Void.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   Void clone() => Void()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  Void copyWith(void Function(Void) updates) => super.copyWith(
-      (message) => updates(message as Void)); // ignore: deprecated_member_use
+  Void copyWith(void Function(Void) updates) => super.copyWith((message) => updates(message as Void));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Void create() => Void._();
   Void createEmptyInstance() => create();
   static $pb.PbList<Void> createRepeated() => $pb.PbList<Void>();
   @$core.pragma('dart2js:noInline')
-  static Void getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Void>(create);
+  static Void getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Void>(create);
   static Void _defaultInstance;
 }
 
 class PutDeviceTokenRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'PutDeviceTokenRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'who'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'token')
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('PutDeviceTokenRequest', package: const $pb.PackageName('who'), createEmptyInstance: create)
+    ..aOS(1, 'token')
+    ..hasRequiredFields = false
+  ;
 
   PutDeviceTokenRequest._() : super();
   factory PutDeviceTokenRequest() => create();
-  factory PutDeviceTokenRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory PutDeviceTokenRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  PutDeviceTokenRequest clone() =>
-      PutDeviceTokenRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  PutDeviceTokenRequest copyWith(
-          void Function(PutDeviceTokenRequest) updates) =>
-      super.copyWith((message) => updates(
-          message as PutDeviceTokenRequest)); // ignore: deprecated_member_use
+  factory PutDeviceTokenRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory PutDeviceTokenRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  PutDeviceTokenRequest clone() => PutDeviceTokenRequest()..mergeFromMessage(this);
+  PutDeviceTokenRequest copyWith(void Function(PutDeviceTokenRequest) updates) => super.copyWith((message) => updates(message as PutDeviceTokenRequest));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static PutDeviceTokenRequest create() => PutDeviceTokenRequest._();
   PutDeviceTokenRequest createEmptyInstance() => create();
-  static $pb.PbList<PutDeviceTokenRequest> createRepeated() =>
-      $pb.PbList<PutDeviceTokenRequest>();
+  static $pb.PbList<PutDeviceTokenRequest> createRepeated() => $pb.PbList<PutDeviceTokenRequest>();
   @$core.pragma('dart2js:noInline')
-  static PutDeviceTokenRequest getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<PutDeviceTokenRequest>(create);
+  static PutDeviceTokenRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PutDeviceTokenRequest>(create);
   static PutDeviceTokenRequest _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get token => $_getSZ(0);
   @$pb.TagNumber(1)
-  set token($core.String v) {
-    $_setString(0, v);
-  }
-
+  set token($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasToken() => $_has(0);
   @$pb.TagNumber(1)
@@ -117,128 +68,103 @@ class PutDeviceTokenRequest extends $pb.GeneratedMessage {
 }
 
 class PutLocationRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'PutLocationRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'who'),
-      createEmptyInstance: create)
-    ..aOS(
-        12,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'isoCountryCode',
-        protoName: 'isoCountryCode')
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('PutLocationRequest', package: const $pb.PackageName('who'), createEmptyInstance: create)
+    ..aOS(12, 'isoCountryCode', protoName: 'isoCountryCode')
+    ..hasRequiredFields = false
+  ;
 
   PutLocationRequest._() : super();
   factory PutLocationRequest() => create();
-  factory PutLocationRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory PutLocationRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  factory PutLocationRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory PutLocationRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   PutLocationRequest clone() => PutLocationRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  PutLocationRequest copyWith(void Function(PutLocationRequest) updates) =>
-      super.copyWith((message) => updates(
-          message as PutLocationRequest)); // ignore: deprecated_member_use
+  PutLocationRequest copyWith(void Function(PutLocationRequest) updates) => super.copyWith((message) => updates(message as PutLocationRequest));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static PutLocationRequest create() => PutLocationRequest._();
   PutLocationRequest createEmptyInstance() => create();
-  static $pb.PbList<PutLocationRequest> createRepeated() =>
-      $pb.PbList<PutLocationRequest>();
+  static $pb.PbList<PutLocationRequest> createRepeated() => $pb.PbList<PutLocationRequest>();
   @$core.pragma('dart2js:noInline')
-  static PutLocationRequest getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<PutLocationRequest>(create);
+  static PutLocationRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PutLocationRequest>(create);
   static PutLocationRequest _defaultInstance;
 
   @$pb.TagNumber(12)
   $core.String get isoCountryCode => $_getSZ(0);
   @$pb.TagNumber(12)
-  set isoCountryCode($core.String v) {
-    $_setString(0, v);
-  }
-
+  set isoCountryCode($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(12)
   $core.bool hasIsoCountryCode() => $_has(0);
   @$pb.TagNumber(12)
   void clearIsoCountryCode() => clearField(12);
 }
 
+class PutNotificationSettingsRequest extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('PutNotificationSettingsRequest', package: const $pb.PackageName('who'), createEmptyInstance: create)
+    ..aOS(1, 'token')
+    ..aOS(12, 'isoCountryCode', protoName: 'isoCountryCode')
+    ..hasRequiredFields = false
+  ;
+
+  PutNotificationSettingsRequest._() : super();
+  factory PutNotificationSettingsRequest() => create();
+  factory PutNotificationSettingsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory PutNotificationSettingsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  PutNotificationSettingsRequest clone() => PutNotificationSettingsRequest()..mergeFromMessage(this);
+  PutNotificationSettingsRequest copyWith(void Function(PutNotificationSettingsRequest) updates) => super.copyWith((message) => updates(message as PutNotificationSettingsRequest));
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static PutNotificationSettingsRequest create() => PutNotificationSettingsRequest._();
+  PutNotificationSettingsRequest createEmptyInstance() => create();
+  static $pb.PbList<PutNotificationSettingsRequest> createRepeated() => $pb.PbList<PutNotificationSettingsRequest>();
+  @$core.pragma('dart2js:noInline')
+  static PutNotificationSettingsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PutNotificationSettingsRequest>(create);
+  static PutNotificationSettingsRequest _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get token => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set token($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasToken() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearToken() => clearField(1);
+
+  @$pb.TagNumber(12)
+  $core.String get isoCountryCode => $_getSZ(1);
+  @$pb.TagNumber(12)
+  set isoCountryCode($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(12)
+  $core.bool hasIsoCountryCode() => $_has(1);
+  @$pb.TagNumber(12)
+  void clearIsoCountryCode() => clearField(12);
+}
+
 class JurisdictionId extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'JurisdictionId',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'who'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'code')
-    ..e<JurisdictionType>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'jurisdictionType',
-        $pb.PbFieldType.OE,
-        protoName: 'jurisdictionType',
-        defaultOrMaker: JurisdictionType.GLOBAL,
-        valueOf: JurisdictionType.valueOf,
-        enumValues: JurisdictionType.values)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('JurisdictionId', package: const $pb.PackageName('who'), createEmptyInstance: create)
+    ..aOS(1, 'code')
+    ..e<JurisdictionType>(2, 'jurisdictionType', $pb.PbFieldType.OE, protoName: 'jurisdictionType', defaultOrMaker: JurisdictionType.GLOBAL, valueOf: JurisdictionType.valueOf, enumValues: JurisdictionType.values)
+    ..hasRequiredFields = false
+  ;
 
   JurisdictionId._() : super();
   factory JurisdictionId() => create();
-  factory JurisdictionId.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory JurisdictionId.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  factory JurisdictionId.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory JurisdictionId.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   JurisdictionId clone() => JurisdictionId()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  JurisdictionId copyWith(void Function(JurisdictionId) updates) =>
-      super.copyWith((message) =>
-          updates(message as JurisdictionId)); // ignore: deprecated_member_use
+  JurisdictionId copyWith(void Function(JurisdictionId) updates) => super.copyWith((message) => updates(message as JurisdictionId));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static JurisdictionId create() => JurisdictionId._();
   JurisdictionId createEmptyInstance() => create();
-  static $pb.PbList<JurisdictionId> createRepeated() =>
-      $pb.PbList<JurisdictionId>();
+  static $pb.PbList<JurisdictionId> createRepeated() => $pb.PbList<JurisdictionId>();
   @$core.pragma('dart2js:noInline')
-  static JurisdictionId getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<JurisdictionId>(create);
+  static JurisdictionId getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<JurisdictionId>(create);
   static JurisdictionId _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get code => $_getSZ(0);
   @$pb.TagNumber(1)
-  set code($core.String v) {
-    $_setString(0, v);
-  }
-
+  set code($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasCode() => $_has(0);
   @$pb.TagNumber(1)
@@ -247,10 +173,7 @@ class JurisdictionId extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   JurisdictionType get jurisdictionType => $_getN(1);
   @$pb.TagNumber(2)
-  set jurisdictionType(JurisdictionType v) {
-    setField(2, v);
-  }
-
+  set jurisdictionType(JurisdictionType v) { setField(2, v); }
   @$pb.TagNumber(2)
   $core.bool hasJurisdictionType() => $_has(1);
   @$pb.TagNumber(2)
@@ -258,51 +181,24 @@ class JurisdictionId extends $pb.GeneratedMessage {
 }
 
 class GetCaseStatsRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'GetCaseStatsRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'who'),
-      createEmptyInstance: create)
-    ..pc<JurisdictionId>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'jurisdictions',
-        $pb.PbFieldType.PM,
-        subBuilder: JurisdictionId.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('GetCaseStatsRequest', package: const $pb.PackageName('who'), createEmptyInstance: create)
+    ..pc<JurisdictionId>(1, 'jurisdictions', $pb.PbFieldType.PM, subBuilder: JurisdictionId.create)
+    ..hasRequiredFields = false
+  ;
 
   GetCaseStatsRequest._() : super();
   factory GetCaseStatsRequest() => create();
-  factory GetCaseStatsRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetCaseStatsRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  factory GetCaseStatsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetCaseStatsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   GetCaseStatsRequest clone() => GetCaseStatsRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetCaseStatsRequest copyWith(void Function(GetCaseStatsRequest) updates) =>
-      super.copyWith((message) => updates(
-          message as GetCaseStatsRequest)); // ignore: deprecated_member_use
+  GetCaseStatsRequest copyWith(void Function(GetCaseStatsRequest) updates) => super.copyWith((message) => updates(message as GetCaseStatsRequest));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static GetCaseStatsRequest create() => GetCaseStatsRequest._();
   GetCaseStatsRequest createEmptyInstance() => create();
-  static $pb.PbList<GetCaseStatsRequest> createRepeated() =>
-      $pb.PbList<GetCaseStatsRequest>();
+  static $pb.PbList<GetCaseStatsRequest> createRepeated() => $pb.PbList<GetCaseStatsRequest>();
   @$core.pragma('dart2js:noInline')
-  static GetCaseStatsRequest getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<GetCaseStatsRequest>(create);
+  static GetCaseStatsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetCaseStatsRequest>(create);
   static GetCaseStatsRequest _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -310,53 +206,26 @@ class GetCaseStatsRequest extends $pb.GeneratedMessage {
 }
 
 class GetCaseStatsResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'GetCaseStatsResponse',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'who'),
-      createEmptyInstance: create)
-    ..aOM<CaseStats>(
-        1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'globalStats',
-        protoName: 'globalStats', subBuilder: CaseStats.create)
-    ..a<$fixnum.Int64>(
-        2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'ttl', $pb.PbFieldType.OU6,
-        defaultOrMaker: $fixnum.Int64.ZERO)
-    ..pc<CaseStats>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'jurisdictionStats', $pb.PbFieldType.PM,
-        protoName: 'jurisdictionStats', subBuilder: CaseStats.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('GetCaseStatsResponse', package: const $pb.PackageName('who'), createEmptyInstance: create)
+    ..aOM<CaseStats>(1, 'globalStats', protoName: 'globalStats', subBuilder: CaseStats.create)
+    ..a<$fixnum.Int64>(2, 'ttl', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..pc<CaseStats>(3, 'jurisdictionStats', $pb.PbFieldType.PM, protoName: 'jurisdictionStats', subBuilder: CaseStats.create)
+    ..hasRequiredFields = false
+  ;
 
   GetCaseStatsResponse._() : super();
   factory GetCaseStatsResponse() => create();
-  factory GetCaseStatsResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GetCaseStatsResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  GetCaseStatsResponse clone() =>
-      GetCaseStatsResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GetCaseStatsResponse copyWith(void Function(GetCaseStatsResponse) updates) =>
-      super.copyWith((message) => updates(
-          message as GetCaseStatsResponse)); // ignore: deprecated_member_use
+  factory GetCaseStatsResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetCaseStatsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  GetCaseStatsResponse clone() => GetCaseStatsResponse()..mergeFromMessage(this);
+  GetCaseStatsResponse copyWith(void Function(GetCaseStatsResponse) updates) => super.copyWith((message) => updates(message as GetCaseStatsResponse));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static GetCaseStatsResponse create() => GetCaseStatsResponse._();
   GetCaseStatsResponse createEmptyInstance() => create();
-  static $pb.PbList<GetCaseStatsResponse> createRepeated() =>
-      $pb.PbList<GetCaseStatsResponse>();
+  static $pb.PbList<GetCaseStatsResponse> createRepeated() => $pb.PbList<GetCaseStatsResponse>();
   @$core.pragma('dart2js:noInline')
-  static GetCaseStatsResponse getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<GetCaseStatsResponse>(create);
+  static GetCaseStatsResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetCaseStatsResponse>(create);
   static GetCaseStatsResponse _defaultInstance;
 
   @$core.Deprecated('This field is deprecated.')
@@ -364,10 +233,7 @@ class GetCaseStatsResponse extends $pb.GeneratedMessage {
   CaseStats get globalStats => $_getN(0);
   @$core.Deprecated('This field is deprecated.')
   @$pb.TagNumber(1)
-  set globalStats(CaseStats v) {
-    setField(1, v);
-  }
-
+  set globalStats(CaseStats v) { setField(1, v); }
   @$core.Deprecated('This field is deprecated.')
   @$pb.TagNumber(1)
   $core.bool hasGlobalStats() => $_has(0);
@@ -381,10 +247,7 @@ class GetCaseStatsResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get ttl => $_getI64(1);
   @$pb.TagNumber(2)
-  set ttl($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set ttl($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasTtl() => $_has(1);
   @$pb.TagNumber(2)
@@ -395,68 +258,36 @@ class GetCaseStatsResponse extends $pb.GeneratedMessage {
 }
 
 class StatSnapshot extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'StatSnapshot',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'who'),
-      createEmptyInstance: create)
-    ..a<$fixnum.Int64>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'epochMsec',
-        $pb.PbFieldType.OU6,
-        protoName: 'epochMsec',
-        defaultOrMaker: $fixnum.Int64.ZERO)
-    ..aInt64(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'dailyCases',
-        protoName: 'dailyCases')
-    ..aInt64(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'dailyDeaths', protoName: 'dailyDeaths')
-    ..aInt64(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'dailyRecoveries', protoName: 'dailyRecoveries')
-    ..aInt64(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'totalCases', protoName: 'totalCases')
-    ..aInt64(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'totalDeaths', protoName: 'totalDeaths')
-    ..aInt64(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'totalRecoveries', protoName: 'totalRecoveries')
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('StatSnapshot', package: const $pb.PackageName('who'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(1, 'epochMsec', $pb.PbFieldType.OU6, protoName: 'epochMsec', defaultOrMaker: $fixnum.Int64.ZERO)
+    ..aInt64(2, 'dailyCases', protoName: 'dailyCases')
+    ..aInt64(3, 'dailyDeaths', protoName: 'dailyDeaths')
+    ..aInt64(4, 'dailyRecoveries', protoName: 'dailyRecoveries')
+    ..aInt64(5, 'totalCases', protoName: 'totalCases')
+    ..aInt64(6, 'totalDeaths', protoName: 'totalDeaths')
+    ..aInt64(7, 'totalRecoveries', protoName: 'totalRecoveries')
+    ..hasRequiredFields = false
+  ;
 
   StatSnapshot._() : super();
   factory StatSnapshot() => create();
-  factory StatSnapshot.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory StatSnapshot.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  factory StatSnapshot.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StatSnapshot.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   StatSnapshot clone() => StatSnapshot()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  StatSnapshot copyWith(void Function(StatSnapshot) updates) =>
-      super.copyWith((message) =>
-          updates(message as StatSnapshot)); // ignore: deprecated_member_use
+  StatSnapshot copyWith(void Function(StatSnapshot) updates) => super.copyWith((message) => updates(message as StatSnapshot));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static StatSnapshot create() => StatSnapshot._();
   StatSnapshot createEmptyInstance() => create();
-  static $pb.PbList<StatSnapshot> createRepeated() =>
-      $pb.PbList<StatSnapshot>();
+  static $pb.PbList<StatSnapshot> createRepeated() => $pb.PbList<StatSnapshot>();
   @$core.pragma('dart2js:noInline')
-  static StatSnapshot getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<StatSnapshot>(create);
+  static StatSnapshot getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StatSnapshot>(create);
   static StatSnapshot _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get epochMsec => $_getI64(0);
   @$pb.TagNumber(1)
-  set epochMsec($fixnum.Int64 v) {
-    $_setInt64(0, v);
-  }
-
+  set epochMsec($fixnum.Int64 v) { $_setInt64(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasEpochMsec() => $_has(0);
   @$pb.TagNumber(1)
@@ -465,10 +296,7 @@ class StatSnapshot extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get dailyCases => $_getI64(1);
   @$pb.TagNumber(2)
-  set dailyCases($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set dailyCases($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasDailyCases() => $_has(1);
   @$pb.TagNumber(2)
@@ -477,10 +305,7 @@ class StatSnapshot extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get dailyDeaths => $_getI64(2);
   @$pb.TagNumber(3)
-  set dailyDeaths($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set dailyDeaths($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasDailyDeaths() => $_has(2);
   @$pb.TagNumber(3)
@@ -489,10 +314,7 @@ class StatSnapshot extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $fixnum.Int64 get dailyRecoveries => $_getI64(3);
   @$pb.TagNumber(4)
-  set dailyRecoveries($fixnum.Int64 v) {
-    $_setInt64(3, v);
-  }
-
+  set dailyRecoveries($fixnum.Int64 v) { $_setInt64(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasDailyRecoveries() => $_has(3);
   @$pb.TagNumber(4)
@@ -501,10 +323,7 @@ class StatSnapshot extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $fixnum.Int64 get totalCases => $_getI64(4);
   @$pb.TagNumber(5)
-  set totalCases($fixnum.Int64 v) {
-    $_setInt64(4, v);
-  }
-
+  set totalCases($fixnum.Int64 v) { $_setInt64(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasTotalCases() => $_has(4);
   @$pb.TagNumber(5)
@@ -513,10 +332,7 @@ class StatSnapshot extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $fixnum.Int64 get totalDeaths => $_getI64(5);
   @$pb.TagNumber(6)
-  set totalDeaths($fixnum.Int64 v) {
-    $_setInt64(5, v);
-  }
-
+  set totalDeaths($fixnum.Int64 v) { $_setInt64(5, v); }
   @$pb.TagNumber(6)
   $core.bool hasTotalDeaths() => $_has(5);
   @$pb.TagNumber(6)
@@ -525,10 +341,7 @@ class StatSnapshot extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $fixnum.Int64 get totalRecoveries => $_getI64(6);
   @$pb.TagNumber(7)
-  set totalRecoveries($fixnum.Int64 v) {
-    $_setInt64(6, v);
-  }
-
+  set totalRecoveries($fixnum.Int64 v) { $_setInt64(6, v); }
   @$pb.TagNumber(7)
   $core.bool hasTotalRecoveries() => $_has(6);
   @$pb.TagNumber(7)
@@ -536,72 +349,37 @@ class StatSnapshot extends $pb.GeneratedMessage {
 }
 
 class CaseStats extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'CaseStats',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'who'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'jurisdiction')
-    ..a<$fixnum.Int64>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'lastUpdated',
-        $pb.PbFieldType.OU6,
-        protoName: 'lastUpdated',
-        defaultOrMaker: $fixnum.Int64.ZERO)
-    ..aInt64(
-        3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'cases')
-    ..aInt64(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'deaths')
-    ..aInt64(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'recoveries')
-    ..aOS(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'attribution')
-    ..e<JurisdictionType>(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'jurisdictionType', $pb.PbFieldType.OE, protoName: 'jurisdictionType', defaultOrMaker: JurisdictionType.GLOBAL, valueOf: JurisdictionType.valueOf, enumValues: JurisdictionType.values)
-    ..pc<StatSnapshot>(8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'timeseries', $pb.PbFieldType.PM, subBuilder: StatSnapshot.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('CaseStats', package: const $pb.PackageName('who'), createEmptyInstance: create)
+    ..aOS(1, 'jurisdiction')
+    ..a<$fixnum.Int64>(2, 'lastUpdated', $pb.PbFieldType.OU6, protoName: 'lastUpdated', defaultOrMaker: $fixnum.Int64.ZERO)
+    ..aInt64(3, 'cases')
+    ..aInt64(4, 'deaths')
+    ..aInt64(5, 'recoveries')
+    ..aOS(6, 'attribution')
+    ..e<JurisdictionType>(7, 'jurisdictionType', $pb.PbFieldType.OE, protoName: 'jurisdictionType', defaultOrMaker: JurisdictionType.GLOBAL, valueOf: JurisdictionType.valueOf, enumValues: JurisdictionType.values)
+    ..pc<StatSnapshot>(8, 'timeseries', $pb.PbFieldType.PM, subBuilder: StatSnapshot.create)
+    ..hasRequiredFields = false
+  ;
 
   CaseStats._() : super();
   factory CaseStats() => create();
-  factory CaseStats.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CaseStats.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  factory CaseStats.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CaseStats.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   CaseStats clone() => CaseStats()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CaseStats copyWith(void Function(CaseStats) updates) =>
-      super.copyWith((message) =>
-          updates(message as CaseStats)); // ignore: deprecated_member_use
+  CaseStats copyWith(void Function(CaseStats) updates) => super.copyWith((message) => updates(message as CaseStats));
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static CaseStats create() => CaseStats._();
   CaseStats createEmptyInstance() => create();
   static $pb.PbList<CaseStats> createRepeated() => $pb.PbList<CaseStats>();
   @$core.pragma('dart2js:noInline')
-  static CaseStats getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CaseStats>(create);
+  static CaseStats getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CaseStats>(create);
   static CaseStats _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get jurisdiction => $_getSZ(0);
   @$pb.TagNumber(1)
-  set jurisdiction($core.String v) {
-    $_setString(0, v);
-  }
-
+  set jurisdiction($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasJurisdiction() => $_has(0);
   @$pb.TagNumber(1)
@@ -610,10 +388,7 @@ class CaseStats extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get lastUpdated => $_getI64(1);
   @$pb.TagNumber(2)
-  set lastUpdated($fixnum.Int64 v) {
-    $_setInt64(1, v);
-  }
-
+  set lastUpdated($fixnum.Int64 v) { $_setInt64(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasLastUpdated() => $_has(1);
   @$pb.TagNumber(2)
@@ -622,10 +397,7 @@ class CaseStats extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get cases => $_getI64(2);
   @$pb.TagNumber(3)
-  set cases($fixnum.Int64 v) {
-    $_setInt64(2, v);
-  }
-
+  set cases($fixnum.Int64 v) { $_setInt64(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasCases() => $_has(2);
   @$pb.TagNumber(3)
@@ -634,10 +406,7 @@ class CaseStats extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $fixnum.Int64 get deaths => $_getI64(3);
   @$pb.TagNumber(4)
-  set deaths($fixnum.Int64 v) {
-    $_setInt64(3, v);
-  }
-
+  set deaths($fixnum.Int64 v) { $_setInt64(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasDeaths() => $_has(3);
   @$pb.TagNumber(4)
@@ -646,10 +415,7 @@ class CaseStats extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $fixnum.Int64 get recoveries => $_getI64(4);
   @$pb.TagNumber(5)
-  set recoveries($fixnum.Int64 v) {
-    $_setInt64(4, v);
-  }
-
+  set recoveries($fixnum.Int64 v) { $_setInt64(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasRecoveries() => $_has(4);
   @$pb.TagNumber(5)
@@ -658,10 +424,7 @@ class CaseStats extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.String get attribution => $_getSZ(5);
   @$pb.TagNumber(6)
-  set attribution($core.String v) {
-    $_setString(5, v);
-  }
-
+  set attribution($core.String v) { $_setString(5, v); }
   @$pb.TagNumber(6)
   $core.bool hasAttribution() => $_has(5);
   @$pb.TagNumber(6)
@@ -670,10 +433,7 @@ class CaseStats extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   JurisdictionType get jurisdictionType => $_getN(6);
   @$pb.TagNumber(7)
-  set jurisdictionType(JurisdictionType v) {
-    setField(7, v);
-  }
-
+  set jurisdictionType(JurisdictionType v) { setField(7, v); }
   @$pb.TagNumber(7)
   $core.bool hasJurisdictionType() => $_has(6);
   @$pb.TagNumber(7)
@@ -687,24 +447,21 @@ class WhoServiceApi {
   $pb.RpcClient _client;
   WhoServiceApi(this._client);
 
-  $async.Future<Void> putDeviceToken(
-      $pb.ClientContext ctx, PutDeviceTokenRequest request) {
+  $async.Future<Void> putDeviceToken($pb.ClientContext ctx, PutDeviceTokenRequest request) {
     var emptyResponse = Void();
-    return _client.invoke<Void>(
-        ctx, 'WhoService', 'putDeviceToken', request, emptyResponse);
+    return _client.invoke<Void>(ctx, 'WhoService', 'putDeviceToken', request, emptyResponse);
   }
-
-  $async.Future<Void> putLocation(
-      $pb.ClientContext ctx, PutLocationRequest request) {
+  $async.Future<Void> putLocation($pb.ClientContext ctx, PutLocationRequest request) {
     var emptyResponse = Void();
-    return _client.invoke<Void>(
-        ctx, 'WhoService', 'putLocation', request, emptyResponse);
+    return _client.invoke<Void>(ctx, 'WhoService', 'putLocation', request, emptyResponse);
   }
-
-  $async.Future<GetCaseStatsResponse> getCaseStats(
-      $pb.ClientContext ctx, GetCaseStatsRequest request) {
+  $async.Future<Void> putNotificationSettings($pb.ClientContext ctx, PutNotificationSettingsRequest request) {
+    var emptyResponse = Void();
+    return _client.invoke<Void>(ctx, 'WhoService', 'putNotificationSettings', request, emptyResponse);
+  }
+  $async.Future<GetCaseStatsResponse> getCaseStats($pb.ClientContext ctx, GetCaseStatsRequest request) {
     var emptyResponse = GetCaseStatsResponse();
-    return _client.invoke<GetCaseStatsResponse>(
-        ctx, 'WhoService', 'getCaseStats', request, emptyResponse);
+    return _client.invoke<GetCaseStatsResponse>(ctx, 'WhoService', 'getCaseStats', request, emptyResponse);
   }
 }
+

--- a/client/lib/proto/api/who/who.pbenum.dart
+++ b/client/lib/proto/api/who/who.pbenum.dart
@@ -3,17 +3,28 @@
 //  source: api/who/who.proto
 //
 // @dart = 2.3
-// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type
+// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
-// ignore_for_file: UNDEFINED_SHOWN_NAME,UNUSED_SHOWN_NAME
+// ignore_for_file: UNDEFINED_SHOWN_NAME
 import 'dart:core' as $core;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class JurisdictionType extends $pb.ProtobufEnum {
-  static const JurisdictionType GLOBAL = JurisdictionType._(0, 'GLOBAL');
-  static const JurisdictionType WHO_REGION =
-      JurisdictionType._(1, 'WHO_REGION');
-  static const JurisdictionType COUNTRY = JurisdictionType._(2, 'COUNTRY');
+  static const JurisdictionType GLOBAL = JurisdictionType._(
+      0,
+      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
+          ? ''
+          : 'GLOBAL');
+  static const JurisdictionType WHO_REGION = JurisdictionType._(
+      1,
+      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
+          ? ''
+          : 'WHO_REGION');
+  static const JurisdictionType COUNTRY = JurisdictionType._(
+      2,
+      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
+          ? ''
+          : 'COUNTRY');
 
   static const $core.List<JurisdictionType> values = <JurisdictionType>[
     GLOBAL,
@@ -29,9 +40,21 @@ class JurisdictionType extends $pb.ProtobufEnum {
 }
 
 class Platform extends $pb.ProtobufEnum {
-  static const Platform IOS = Platform._(0, 'IOS');
-  static const Platform ANDROID = Platform._(1, 'ANDROID');
-  static const Platform WEB = Platform._(2, 'WEB');
+  static const Platform IOS = Platform._(
+      0,
+      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
+          ? ''
+          : 'IOS');
+  static const Platform ANDROID = Platform._(
+      1,
+      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
+          ? ''
+          : 'ANDROID');
+  static const Platform WEB = Platform._(
+      2,
+      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
+          ? ''
+          : 'WEB');
 
   static const $core.List<Platform> values = <Platform>[
     IOS,

--- a/client/lib/proto/api/who/who.pbenum.dart
+++ b/client/lib/proto/api/who/who.pbenum.dart
@@ -3,68 +3,43 @@
 //  source: api/who/who.proto
 //
 // @dart = 2.3
-// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
+// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type
 
-// ignore_for_file: UNDEFINED_SHOWN_NAME
+// ignore_for_file: UNDEFINED_SHOWN_NAME,UNUSED_SHOWN_NAME
 import 'dart:core' as $core;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class JurisdictionType extends $pb.ProtobufEnum {
-  static const JurisdictionType GLOBAL = JurisdictionType._(
-      0,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'GLOBAL');
-  static const JurisdictionType WHO_REGION = JurisdictionType._(
-      1,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'WHO_REGION');
-  static const JurisdictionType COUNTRY = JurisdictionType._(
-      2,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'COUNTRY');
+  static const JurisdictionType GLOBAL = JurisdictionType._(0, 'GLOBAL');
+  static const JurisdictionType WHO_REGION = JurisdictionType._(1, 'WHO_REGION');
+  static const JurisdictionType COUNTRY = JurisdictionType._(2, 'COUNTRY');
 
-  static const $core.List<JurisdictionType> values = <JurisdictionType>[
+  static const $core.List<JurisdictionType> values = <JurisdictionType> [
     GLOBAL,
     WHO_REGION,
     COUNTRY,
   ];
 
-  static final $core.Map<$core.int, JurisdictionType> _byValue =
-      $pb.ProtobufEnum.initByValue(values);
+  static final $core.Map<$core.int, JurisdictionType> _byValue = $pb.ProtobufEnum.initByValue(values);
   static JurisdictionType valueOf($core.int value) => _byValue[value];
 
   const JurisdictionType._($core.int v, $core.String n) : super(v, n);
 }
 
 class Platform extends $pb.ProtobufEnum {
-  static const Platform IOS = Platform._(
-      0,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'IOS');
-  static const Platform ANDROID = Platform._(
-      1,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'ANDROID');
-  static const Platform WEB = Platform._(
-      2,
-      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
-          ? ''
-          : 'WEB');
+  static const Platform IOS = Platform._(0, 'IOS');
+  static const Platform ANDROID = Platform._(1, 'ANDROID');
+  static const Platform WEB = Platform._(2, 'WEB');
 
-  static const $core.List<Platform> values = <Platform>[
+  static const $core.List<Platform> values = <Platform> [
     IOS,
     ANDROID,
     WEB,
   ];
 
-  static final $core.Map<$core.int, Platform> _byValue =
-      $pb.ProtobufEnum.initByValue(values);
+  static final $core.Map<$core.int, Platform> _byValue = $pb.ProtobufEnum.initByValue(values);
   static Platform valueOf($core.int value) => _byValue[value];
 
   const Platform._($core.int v, $core.String n) : super(v, n);
 }
+

--- a/client/lib/proto/api/who/who.pbenum.dart
+++ b/client/lib/proto/api/who/who.pbenum.dart
@@ -11,16 +11,18 @@ import 'package:protobuf/protobuf.dart' as $pb;
 
 class JurisdictionType extends $pb.ProtobufEnum {
   static const JurisdictionType GLOBAL = JurisdictionType._(0, 'GLOBAL');
-  static const JurisdictionType WHO_REGION = JurisdictionType._(1, 'WHO_REGION');
+  static const JurisdictionType WHO_REGION =
+      JurisdictionType._(1, 'WHO_REGION');
   static const JurisdictionType COUNTRY = JurisdictionType._(2, 'COUNTRY');
 
-  static const $core.List<JurisdictionType> values = <JurisdictionType> [
+  static const $core.List<JurisdictionType> values = <JurisdictionType>[
     GLOBAL,
     WHO_REGION,
     COUNTRY,
   ];
 
-  static final $core.Map<$core.int, JurisdictionType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static final $core.Map<$core.int, JurisdictionType> _byValue =
+      $pb.ProtobufEnum.initByValue(values);
   static JurisdictionType valueOf($core.int value) => _byValue[value];
 
   const JurisdictionType._($core.int v, $core.String n) : super(v, n);
@@ -31,15 +33,15 @@ class Platform extends $pb.ProtobufEnum {
   static const Platform ANDROID = Platform._(1, 'ANDROID');
   static const Platform WEB = Platform._(2, 'WEB');
 
-  static const $core.List<Platform> values = <Platform> [
+  static const $core.List<Platform> values = <Platform>[
     IOS,
     ANDROID,
     WEB,
   ];
 
-  static final $core.Map<$core.int, Platform> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static final $core.Map<$core.int, Platform> _byValue =
+      $pb.ProtobufEnum.initByValue(values);
   static Platform valueOf($core.int value) => _byValue[value];
 
   const Platform._($core.int v, $core.String n) : super(v, n);
 }
-

--- a/client/lib/proto/api/who/who.pbjson.dart
+++ b/client/lib/proto/api/who/who.pbjson.dart
@@ -3,7 +3,7 @@
 //  source: api/who/who.proto
 //
 // @dart = 2.3
-// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type
+// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 const JurisdictionType$json = const {
   '1': 'JurisdictionType',

--- a/client/lib/proto/api/who/who.pbjson.dart
+++ b/client/lib/proto/api/who/who.pbjson.dart
@@ -37,22 +37,41 @@ const PutDeviceTokenRequest$json = const {
 const PutLocationRequest$json = const {
   '1': 'PutLocationRequest',
   '2': const [
-    const {'1': 'isoCountryCode', '3': 12, '4': 1, '5': 9, '10': 'isoCountryCode'},
+    const {
+      '1': 'isoCountryCode',
+      '3': 12,
+      '4': 1,
+      '5': 9,
+      '10': 'isoCountryCode'
+    },
   ],
 };
 
-const PutNotificationSettingsRequest$json = const {
-  '1': 'PutNotificationSettingsRequest',
+const PutClientSettingsRequest$json = const {
+  '1': 'PutClientSettingsRequest',
   '2': const [
     const {'1': 'token', '3': 1, '4': 1, '5': 9, '10': 'token'},
-    const {'1': 'isoCountryCode', '3': 12, '4': 1, '5': 9, '10': 'isoCountryCode'},
+    const {
+      '1': 'isoCountryCode',
+      '3': 12,
+      '4': 1,
+      '5': 9,
+      '10': 'isoCountryCode'
+    },
   ],
 };
 
 const JurisdictionId$json = const {
   '1': 'JurisdictionId',
   '2': const [
-    const {'1': 'jurisdictionType', '3': 2, '4': 1, '5': 14, '6': '.who.JurisdictionType', '10': 'jurisdictionType'},
+    const {
+      '1': 'jurisdictionType',
+      '3': 2,
+      '4': 1,
+      '5': 14,
+      '6': '.who.JurisdictionType',
+      '10': 'jurisdictionType'
+    },
     const {'1': 'code', '3': 1, '4': 1, '5': 9, '10': 'code'},
   ],
 };
@@ -60,7 +79,14 @@ const JurisdictionId$json = const {
 const GetCaseStatsRequest$json = const {
   '1': 'GetCaseStatsRequest',
   '2': const [
-    const {'1': 'jurisdictions', '3': 1, '4': 3, '5': 11, '6': '.who.JurisdictionId', '10': 'jurisdictions'},
+    const {
+      '1': 'jurisdictions',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.who.JurisdictionId',
+      '10': 'jurisdictions'
+    },
   ],
 };
 
@@ -76,7 +102,14 @@ const GetCaseStatsResponse$json = const {
       '8': const {'3': true},
       '10': 'globalStats',
     },
-    const {'1': 'jurisdictionStats', '3': 3, '4': 3, '5': 11, '6': '.who.CaseStats', '10': 'jurisdictionStats'},
+    const {
+      '1': 'jurisdictionStats',
+      '3': 3,
+      '4': 3,
+      '5': 11,
+      '6': '.who.CaseStats',
+      '10': 'jurisdictionStats'
+    },
     const {'1': 'ttl', '3': 2, '4': 1, '5': 4, '10': 'ttl'},
   ],
 };
@@ -87,34 +120,76 @@ const StatSnapshot$json = const {
     const {'1': 'epochMsec', '3': 1, '4': 1, '5': 4, '10': 'epochMsec'},
     const {'1': 'dailyCases', '3': 2, '4': 1, '5': 3, '10': 'dailyCases'},
     const {'1': 'dailyDeaths', '3': 3, '4': 1, '5': 3, '10': 'dailyDeaths'},
-    const {'1': 'dailyRecoveries', '3': 4, '4': 1, '5': 3, '10': 'dailyRecoveries'},
+    const {
+      '1': 'dailyRecoveries',
+      '3': 4,
+      '4': 1,
+      '5': 3,
+      '10': 'dailyRecoveries'
+    },
     const {'1': 'totalCases', '3': 5, '4': 1, '5': 3, '10': 'totalCases'},
     const {'1': 'totalDeaths', '3': 6, '4': 1, '5': 3, '10': 'totalDeaths'},
-    const {'1': 'totalRecoveries', '3': 7, '4': 1, '5': 3, '10': 'totalRecoveries'},
+    const {
+      '1': 'totalRecoveries',
+      '3': 7,
+      '4': 1,
+      '5': 3,
+      '10': 'totalRecoveries'
+    },
   ],
 };
 
 const CaseStats$json = const {
   '1': 'CaseStats',
   '2': const [
-    const {'1': 'jurisdictionType', '3': 7, '4': 1, '5': 14, '6': '.who.JurisdictionType', '10': 'jurisdictionType'},
+    const {
+      '1': 'jurisdictionType',
+      '3': 7,
+      '4': 1,
+      '5': 14,
+      '6': '.who.JurisdictionType',
+      '10': 'jurisdictionType'
+    },
     const {'1': 'jurisdiction', '3': 1, '4': 1, '5': 9, '10': 'jurisdiction'},
     const {'1': 'lastUpdated', '3': 2, '4': 1, '5': 4, '10': 'lastUpdated'},
     const {'1': 'cases', '3': 3, '4': 1, '5': 3, '10': 'cases'},
     const {'1': 'deaths', '3': 4, '4': 1, '5': 3, '10': 'deaths'},
     const {'1': 'recoveries', '3': 5, '4': 1, '5': 3, '10': 'recoveries'},
     const {'1': 'attribution', '3': 6, '4': 1, '5': 9, '10': 'attribution'},
-    const {'1': 'timeseries', '3': 8, '4': 3, '5': 11, '6': '.who.StatSnapshot', '10': 'timeseries'},
+    const {
+      '1': 'timeseries',
+      '3': 8,
+      '4': 3,
+      '5': 11,
+      '6': '.who.StatSnapshot',
+      '10': 'timeseries'
+    },
   ],
 };
 
 const WhoServiceBase$json = const {
   '1': 'WhoService',
   '2': const [
-    const {'1': 'putDeviceToken', '2': '.who.PutDeviceTokenRequest', '3': '.who.Void'},
-    const {'1': 'putLocation', '2': '.who.PutLocationRequest', '3': '.who.Void'},
-    const {'1': 'putNotificationSettings', '2': '.who.PutNotificationSettingsRequest', '3': '.who.Void'},
-    const {'1': 'getCaseStats', '2': '.who.GetCaseStatsRequest', '3': '.who.GetCaseStatsResponse'},
+    const {
+      '1': 'putDeviceToken',
+      '2': '.who.PutDeviceTokenRequest',
+      '3': '.who.Void'
+    },
+    const {
+      '1': 'putLocation',
+      '2': '.who.PutLocationRequest',
+      '3': '.who.Void'
+    },
+    const {
+      '1': 'putClientSettings',
+      '2': '.who.PutClientSettingsRequest',
+      '3': '.who.Void'
+    },
+    const {
+      '1': 'getCaseStats',
+      '2': '.who.GetCaseStatsRequest',
+      '3': '.who.GetCaseStatsResponse'
+    },
   ],
 };
 
@@ -122,11 +197,10 @@ const WhoServiceBase$messageJson = const {
   '.who.PutDeviceTokenRequest': PutDeviceTokenRequest$json,
   '.who.Void': Void$json,
   '.who.PutLocationRequest': PutLocationRequest$json,
-  '.who.PutNotificationSettingsRequest': PutNotificationSettingsRequest$json,
+  '.who.PutClientSettingsRequest': PutClientSettingsRequest$json,
   '.who.GetCaseStatsRequest': GetCaseStatsRequest$json,
   '.who.JurisdictionId': JurisdictionId$json,
   '.who.GetCaseStatsResponse': GetCaseStatsResponse$json,
   '.who.CaseStats': CaseStats$json,
   '.who.StatSnapshot': StatSnapshot$json,
 };
-

--- a/client/lib/proto/api/who/who.pbjson.dart
+++ b/client/lib/proto/api/who/who.pbjson.dart
@@ -3,7 +3,7 @@
 //  source: api/who/who.proto
 //
 // @dart = 2.3
-// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
+// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type
 
 const JurisdictionType$json = const {
   '1': 'JurisdictionType',
@@ -37,27 +37,22 @@ const PutDeviceTokenRequest$json = const {
 const PutLocationRequest$json = const {
   '1': 'PutLocationRequest',
   '2': const [
-    const {
-      '1': 'isoCountryCode',
-      '3': 12,
-      '4': 1,
-      '5': 9,
-      '10': 'isoCountryCode'
-    },
+    const {'1': 'isoCountryCode', '3': 12, '4': 1, '5': 9, '10': 'isoCountryCode'},
+  ],
+};
+
+const PutNotificationSettingsRequest$json = const {
+  '1': 'PutNotificationSettingsRequest',
+  '2': const [
+    const {'1': 'token', '3': 1, '4': 1, '5': 9, '10': 'token'},
+    const {'1': 'isoCountryCode', '3': 12, '4': 1, '5': 9, '10': 'isoCountryCode'},
   ],
 };
 
 const JurisdictionId$json = const {
   '1': 'JurisdictionId',
   '2': const [
-    const {
-      '1': 'jurisdictionType',
-      '3': 2,
-      '4': 1,
-      '5': 14,
-      '6': '.who.JurisdictionType',
-      '10': 'jurisdictionType'
-    },
+    const {'1': 'jurisdictionType', '3': 2, '4': 1, '5': 14, '6': '.who.JurisdictionType', '10': 'jurisdictionType'},
     const {'1': 'code', '3': 1, '4': 1, '5': 9, '10': 'code'},
   ],
 };
@@ -65,14 +60,7 @@ const JurisdictionId$json = const {
 const GetCaseStatsRequest$json = const {
   '1': 'GetCaseStatsRequest',
   '2': const [
-    const {
-      '1': 'jurisdictions',
-      '3': 1,
-      '4': 3,
-      '5': 11,
-      '6': '.who.JurisdictionId',
-      '10': 'jurisdictions'
-    },
+    const {'1': 'jurisdictions', '3': 1, '4': 3, '5': 11, '6': '.who.JurisdictionId', '10': 'jurisdictions'},
   ],
 };
 
@@ -88,14 +76,7 @@ const GetCaseStatsResponse$json = const {
       '8': const {'3': true},
       '10': 'globalStats',
     },
-    const {
-      '1': 'jurisdictionStats',
-      '3': 3,
-      '4': 3,
-      '5': 11,
-      '6': '.who.CaseStats',
-      '10': 'jurisdictionStats'
-    },
+    const {'1': 'jurisdictionStats', '3': 3, '4': 3, '5': 11, '6': '.who.CaseStats', '10': 'jurisdictionStats'},
     const {'1': 'ttl', '3': 2, '4': 1, '5': 4, '10': 'ttl'},
   ],
 };
@@ -106,71 +87,34 @@ const StatSnapshot$json = const {
     const {'1': 'epochMsec', '3': 1, '4': 1, '5': 4, '10': 'epochMsec'},
     const {'1': 'dailyCases', '3': 2, '4': 1, '5': 3, '10': 'dailyCases'},
     const {'1': 'dailyDeaths', '3': 3, '4': 1, '5': 3, '10': 'dailyDeaths'},
-    const {
-      '1': 'dailyRecoveries',
-      '3': 4,
-      '4': 1,
-      '5': 3,
-      '10': 'dailyRecoveries'
-    },
+    const {'1': 'dailyRecoveries', '3': 4, '4': 1, '5': 3, '10': 'dailyRecoveries'},
     const {'1': 'totalCases', '3': 5, '4': 1, '5': 3, '10': 'totalCases'},
     const {'1': 'totalDeaths', '3': 6, '4': 1, '5': 3, '10': 'totalDeaths'},
-    const {
-      '1': 'totalRecoveries',
-      '3': 7,
-      '4': 1,
-      '5': 3,
-      '10': 'totalRecoveries'
-    },
+    const {'1': 'totalRecoveries', '3': 7, '4': 1, '5': 3, '10': 'totalRecoveries'},
   ],
 };
 
 const CaseStats$json = const {
   '1': 'CaseStats',
   '2': const [
-    const {
-      '1': 'jurisdictionType',
-      '3': 7,
-      '4': 1,
-      '5': 14,
-      '6': '.who.JurisdictionType',
-      '10': 'jurisdictionType'
-    },
+    const {'1': 'jurisdictionType', '3': 7, '4': 1, '5': 14, '6': '.who.JurisdictionType', '10': 'jurisdictionType'},
     const {'1': 'jurisdiction', '3': 1, '4': 1, '5': 9, '10': 'jurisdiction'},
     const {'1': 'lastUpdated', '3': 2, '4': 1, '5': 4, '10': 'lastUpdated'},
     const {'1': 'cases', '3': 3, '4': 1, '5': 3, '10': 'cases'},
     const {'1': 'deaths', '3': 4, '4': 1, '5': 3, '10': 'deaths'},
     const {'1': 'recoveries', '3': 5, '4': 1, '5': 3, '10': 'recoveries'},
     const {'1': 'attribution', '3': 6, '4': 1, '5': 9, '10': 'attribution'},
-    const {
-      '1': 'timeseries',
-      '3': 8,
-      '4': 3,
-      '5': 11,
-      '6': '.who.StatSnapshot',
-      '10': 'timeseries'
-    },
+    const {'1': 'timeseries', '3': 8, '4': 3, '5': 11, '6': '.who.StatSnapshot', '10': 'timeseries'},
   ],
 };
 
 const WhoServiceBase$json = const {
   '1': 'WhoService',
   '2': const [
-    const {
-      '1': 'putDeviceToken',
-      '2': '.who.PutDeviceTokenRequest',
-      '3': '.who.Void'
-    },
-    const {
-      '1': 'putLocation',
-      '2': '.who.PutLocationRequest',
-      '3': '.who.Void'
-    },
-    const {
-      '1': 'getCaseStats',
-      '2': '.who.GetCaseStatsRequest',
-      '3': '.who.GetCaseStatsResponse'
-    },
+    const {'1': 'putDeviceToken', '2': '.who.PutDeviceTokenRequest', '3': '.who.Void'},
+    const {'1': 'putLocation', '2': '.who.PutLocationRequest', '3': '.who.Void'},
+    const {'1': 'putNotificationSettings', '2': '.who.PutNotificationSettingsRequest', '3': '.who.Void'},
+    const {'1': 'getCaseStats', '2': '.who.GetCaseStatsRequest', '3': '.who.GetCaseStatsResponse'},
   ],
 };
 
@@ -178,9 +122,11 @@ const WhoServiceBase$messageJson = const {
   '.who.PutDeviceTokenRequest': PutDeviceTokenRequest$json,
   '.who.Void': Void$json,
   '.who.PutLocationRequest': PutLocationRequest$json,
+  '.who.PutNotificationSettingsRequest': PutNotificationSettingsRequest$json,
   '.who.GetCaseStatsRequest': GetCaseStatsRequest$json,
   '.who.JurisdictionId': JurisdictionId$json,
   '.who.GetCaseStatsResponse': GetCaseStatsResponse$json,
   '.who.CaseStats': CaseStats$json,
   '.who.StatSnapshot': StatSnapshot$json,
 };
+

--- a/client/lib/proto/api/who/who.pbserver.dart
+++ b/client/lib/proto/api/who/who.pbserver.dart
@@ -3,7 +3,7 @@
 //  source: api/who/who.proto
 //
 // @dart = 2.3
-// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type
+// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:async' as $async;
 

--- a/client/lib/proto/api/who/who.pbserver.dart
+++ b/client/lib/proto/api/who/who.pbserver.dart
@@ -3,7 +3,7 @@
 //  source: api/who/who.proto
 //
 // @dart = 2.3
-// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
+// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type
 
 import 'dart:async' as $async;
 
@@ -16,41 +16,32 @@ import 'who.pbjson.dart';
 export 'who.pb.dart';
 
 abstract class WhoServiceBase extends $pb.GeneratedService {
-  $async.Future<$0.Void> putDeviceToken(
-      $pb.ServerContext ctx, $0.PutDeviceTokenRequest request);
-  $async.Future<$0.Void> putLocation(
-      $pb.ServerContext ctx, $0.PutLocationRequest request);
-  $async.Future<$0.GetCaseStatsResponse> getCaseStats(
-      $pb.ServerContext ctx, $0.GetCaseStatsRequest request);
+  $async.Future<$0.Void> putDeviceToken($pb.ServerContext ctx, $0.PutDeviceTokenRequest request);
+  $async.Future<$0.Void> putLocation($pb.ServerContext ctx, $0.PutLocationRequest request);
+  $async.Future<$0.Void> putNotificationSettings($pb.ServerContext ctx, $0.PutNotificationSettingsRequest request);
+  $async.Future<$0.GetCaseStatsResponse> getCaseStats($pb.ServerContext ctx, $0.GetCaseStatsRequest request);
 
   $pb.GeneratedMessage createRequest($core.String method) {
     switch (method) {
-      case 'putDeviceToken':
-        return $0.PutDeviceTokenRequest();
-      case 'putLocation':
-        return $0.PutLocationRequest();
-      case 'getCaseStats':
-        return $0.GetCaseStatsRequest();
-      default:
-        throw $core.ArgumentError('Unknown method: $method');
+      case 'putDeviceToken': return $0.PutDeviceTokenRequest();
+      case 'putLocation': return $0.PutLocationRequest();
+      case 'putNotificationSettings': return $0.PutNotificationSettingsRequest();
+      case 'getCaseStats': return $0.GetCaseStatsRequest();
+      default: throw $core.ArgumentError('Unknown method: $method');
     }
   }
 
-  $async.Future<$pb.GeneratedMessage> handleCall($pb.ServerContext ctx,
-      $core.String method, $pb.GeneratedMessage request) {
+  $async.Future<$pb.GeneratedMessage> handleCall($pb.ServerContext ctx, $core.String method, $pb.GeneratedMessage request) {
     switch (method) {
-      case 'putDeviceToken':
-        return this.putDeviceToken(ctx, request);
-      case 'putLocation':
-        return this.putLocation(ctx, request);
-      case 'getCaseStats':
-        return this.getCaseStats(ctx, request);
-      default:
-        throw $core.ArgumentError('Unknown method: $method');
+      case 'putDeviceToken': return this.putDeviceToken(ctx, request);
+      case 'putLocation': return this.putLocation(ctx, request);
+      case 'putNotificationSettings': return this.putNotificationSettings(ctx, request);
+      case 'getCaseStats': return this.getCaseStats(ctx, request);
+      default: throw $core.ArgumentError('Unknown method: $method');
     }
   }
 
   $core.Map<$core.String, $core.dynamic> get $json => WhoServiceBase$json;
-  $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>>
-      get $messageJson => WhoServiceBase$messageJson;
+  $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> get $messageJson => WhoServiceBase$messageJson;
 }
+

--- a/client/lib/proto/api/who/who.pbserver.dart
+++ b/client/lib/proto/api/who/who.pbserver.dart
@@ -16,32 +16,47 @@ import 'who.pbjson.dart';
 export 'who.pb.dart';
 
 abstract class WhoServiceBase extends $pb.GeneratedService {
-  $async.Future<$0.Void> putDeviceToken($pb.ServerContext ctx, $0.PutDeviceTokenRequest request);
-  $async.Future<$0.Void> putLocation($pb.ServerContext ctx, $0.PutLocationRequest request);
-  $async.Future<$0.Void> putNotificationSettings($pb.ServerContext ctx, $0.PutNotificationSettingsRequest request);
-  $async.Future<$0.GetCaseStatsResponse> getCaseStats($pb.ServerContext ctx, $0.GetCaseStatsRequest request);
+  $async.Future<$0.Void> putDeviceToken(
+      $pb.ServerContext ctx, $0.PutDeviceTokenRequest request);
+  $async.Future<$0.Void> putLocation(
+      $pb.ServerContext ctx, $0.PutLocationRequest request);
+  $async.Future<$0.Void> putClientSettings(
+      $pb.ServerContext ctx, $0.PutClientSettingsRequest request);
+  $async.Future<$0.GetCaseStatsResponse> getCaseStats(
+      $pb.ServerContext ctx, $0.GetCaseStatsRequest request);
 
   $pb.GeneratedMessage createRequest($core.String method) {
     switch (method) {
-      case 'putDeviceToken': return $0.PutDeviceTokenRequest();
-      case 'putLocation': return $0.PutLocationRequest();
-      case 'putNotificationSettings': return $0.PutNotificationSettingsRequest();
-      case 'getCaseStats': return $0.GetCaseStatsRequest();
-      default: throw $core.ArgumentError('Unknown method: $method');
+      case 'putDeviceToken':
+        return $0.PutDeviceTokenRequest();
+      case 'putLocation':
+        return $0.PutLocationRequest();
+      case 'putClientSettings':
+        return $0.PutClientSettingsRequest();
+      case 'getCaseStats':
+        return $0.GetCaseStatsRequest();
+      default:
+        throw $core.ArgumentError('Unknown method: $method');
     }
   }
 
-  $async.Future<$pb.GeneratedMessage> handleCall($pb.ServerContext ctx, $core.String method, $pb.GeneratedMessage request) {
+  $async.Future<$pb.GeneratedMessage> handleCall($pb.ServerContext ctx,
+      $core.String method, $pb.GeneratedMessage request) {
     switch (method) {
-      case 'putDeviceToken': return this.putDeviceToken(ctx, request);
-      case 'putLocation': return this.putLocation(ctx, request);
-      case 'putNotificationSettings': return this.putNotificationSettings(ctx, request);
-      case 'getCaseStats': return this.getCaseStats(ctx, request);
-      default: throw $core.ArgumentError('Unknown method: $method');
+      case 'putDeviceToken':
+        return this.putDeviceToken(ctx, request);
+      case 'putLocation':
+        return this.putLocation(ctx, request);
+      case 'putClientSettings':
+        return this.putClientSettings(ctx, request);
+      case 'getCaseStats':
+        return this.getCaseStats(ctx, request);
+      default:
+        throw $core.ArgumentError('Unknown method: $method');
     }
   }
 
   $core.Map<$core.String, $core.dynamic> get $json => WhoServiceBase$json;
-  $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> get $messageJson => WhoServiceBase$messageJson;
+  $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>>
+      get $messageJson => WhoServiceBase$messageJson;
 }
-

--- a/server/appengine/src/main/java/who/NotificationsManager.java
+++ b/server/appengine/src/main/java/who/NotificationsManager.java
@@ -61,9 +61,15 @@ public class NotificationsManager {
           // If something goes wrong we'll still save the partial update.
           ofy().defer().save().entity(client);
         } else {
-          if (!Environment.isProduction()) logger.info(
-            "FAILED - Subscribed " + client.token + " to topic " + topic
-          );
+          if (!Environment.isProduction()) {
+            logger.info(
+                "FAILED - Subscribed " + client.token + " to topic " + topic
+              );
+            List<TopicManagementResponse.Error> errors = resp.getErrors();
+            for (TopicManagementResponse.Error error : errors) {
+                logger.info("FAILED - Reason - "     + error);
+            }
+          }
         }
       }
 

--- a/server/appengine/src/main/java/who/NotificationsManager.java
+++ b/server/appengine/src/main/java/who/NotificationsManager.java
@@ -63,11 +63,11 @@ public class NotificationsManager {
         } else {
           if (!Environment.isProduction()) {
             logger.info(
-                "FAILED - Subscribed " + client.token + " to topic " + topic
-              );
+              "FAILED - Subscribed " + client.token + " to topic " + topic
+            );
             List<TopicManagementResponse.Error> errors = resp.getErrors();
             for (TopicManagementResponse.Error error : errors) {
-                logger.info("FAILED - Reason - "     + error);
+              logger.info("FAILED - Reason - " + error);
             }
           }
         }

--- a/server/appengine/src/main/java/who/WhoServiceImpl.java
+++ b/server/appengine/src/main/java/who/WhoServiceImpl.java
@@ -25,7 +25,7 @@ public class WhoServiceImpl implements WhoService {
     this.nm = nm;
   }
 
-  // TODO: Delete this method once all clients are moved to putNotificationSettings.
+  // TODO: Delete this method once all clients are moved to putClientSettings.
   @Override
   public Void putDeviceToken(PutDeviceTokenRequest request) throws IOException {
     Client client = Client.current();
@@ -44,7 +44,7 @@ public class WhoServiceImpl implements WhoService {
 
   private static final Pattern COUNTRY_CODE = Pattern.compile("^[A-Z][A-Z]$");
 
-  // TODO: Delete this method once all clients are moved to putNotificationSettings.
+  // TODO: Delete this method once all clients are moved to putClientSettings.
   @Override
   public Void putLocation(PutLocationRequest request) throws IOException {
     Client client = Client.current();
@@ -63,7 +63,7 @@ public class WhoServiceImpl implements WhoService {
   }
 
   @Override
-  public Void putNotificationSettings(PutNotificationSettingsRequest request)
+  public Void putClientSettings(PutClientSettingsRequest request)
     throws IOException {
     // TODO: Consider doing this in some form of datastore transaction. THe trick being that the firebase and datastore may get out of sync...
     Client client = Client.current();

--- a/server/appengine/src/main/java/who/WhoServiceImpl.java
+++ b/server/appengine/src/main/java/who/WhoServiceImpl.java
@@ -61,12 +61,13 @@ public class WhoServiceImpl implements WhoService {
     nm.updateSubscriptions(client);
     return new Void();
   }
-  
+
   @Override
-  public Void putNotificationSettings(PutNotificationSettingsRequest request) throws IOException {
+  public Void putNotificationSettings(PutNotificationSettingsRequest request)
+    throws IOException {
     // TODO: Consider doing this in some form of datastore transaction. THe trick being that the firebase and datastore may get out of sync...
     Client client = Client.current();
-    
+
     // The underlying "Topics" system allows for a null country code; would that be OK to allow here too? ?????????????????????????????????????????????
     if (
       request.isoCountryCode == null ||
@@ -77,12 +78,11 @@ public class WhoServiceImpl implements WhoService {
     }
     client.isoCountryCode = request.isoCountryCode;
     client.token = Strings.emptyToNull(request.token);
-    
+
     ofy().save().entities(client);
     nm.updateSubscriptions(client);
     return new Void();
-    
-  }  
+  }
 
   // 10 mins
   private static final long STATS_TTL_SECONDS = 60 * 10;

--- a/server/appengine/src/main/java/who/WhoServiceImpl.java
+++ b/server/appengine/src/main/java/who/WhoServiceImpl.java
@@ -25,6 +25,7 @@ public class WhoServiceImpl implements WhoService {
     this.nm = nm;
   }
 
+  // TODO: Delete this method once all clients are moved to putNotificationSettings.
   @Override
   public Void putDeviceToken(PutDeviceTokenRequest request) throws IOException {
     Client client = Client.current();
@@ -43,6 +44,7 @@ public class WhoServiceImpl implements WhoService {
 
   private static final Pattern COUNTRY_CODE = Pattern.compile("^[A-Z][A-Z]$");
 
+  // TODO: Delete this method once all clients are moved to putNotificationSettings.
   @Override
   public Void putLocation(PutLocationRequest request) throws IOException {
     Client client = Client.current();
@@ -59,6 +61,28 @@ public class WhoServiceImpl implements WhoService {
     nm.updateSubscriptions(client);
     return new Void();
   }
+  
+  @Override
+  public Void putNotificationSettings(PutNotificationSettingsRequest request) throws IOException {
+    // TODO: Consider doing this in some form of datastore transaction. THe trick being that the firebase and datastore may get out of sync...
+    Client client = Client.current();
+    
+    // The underlying "Topics" system allows for a null country code; would that be OK to allow here too? ?????????????????????????????????????????????
+    if (
+      request.isoCountryCode == null ||
+      request.isoCountryCode.length() != 2 ||
+      !COUNTRY_CODE.matcher(request.isoCountryCode).matches()
+    ) {
+      throw new ClientException("Invalid isoCountryCode");
+    }
+    client.isoCountryCode = request.isoCountryCode;
+    client.token = Strings.emptyToNull(request.token);
+    
+    ofy().save().entities(client);
+    nm.updateSubscriptions(client);
+    return new Void();
+    
+  }  
 
   // 10 mins
   private static final long STATS_TTL_SECONDS = 60 * 10;


### PR DESCRIPTION
This change set includes Client and Server changes to obsolete putDeviceToken and putLocation in favor of new putNotificationSettings.

It also adds a tiny bit of debug logging on the server.

The behavior should be mostly the same as before in terms of when RPCs are fired. One  RPC is skipped: if the user has not selected a country, they will not be subscribed to notifications.

No true locking is present either client or server side at this time: it is possible for up to three (or more) requests to come in 'simulteanously', where the last one will win: getstats for a new user, and a putNotificationSettings if the response is taking some period of time. However, now that the initial 'firebase token plus no country' RPC is gone, it is highly unlikley for this to happen, as it would mean that the user would be taking multiple UI actions faster than the server is responding.

A future change could include server-side transactions.

Addresses issue #1524 

## Screenshots

<details>
<summary>Screenshots</summary>
Add any relevant before/after screenshots here
</details>

## How did you test the change?

- [ ] iOS Simulator
- [ ] iOS Device
- [ ] Android Simulator
- [x] Android Device
- [ ] `curl` to a dev App Engine server
- [x] other, please describe

Watching requests and checking datastore manually on my own instance of the server.

## Checklist:

- [ ] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
