### PR TITLE
Remove remote_api

### DIFF
--- a/server/appengine/build.gradle
+++ b/server/appengine/build.gradle
@@ -63,9 +63,6 @@ dependencies {
     // Linked from https://github.com/google/s2-geometry-library-java/issues/7.
     implementation "io.sgr:s2-geometry-library-java:1.0.1";
 
-    // Not sure why this didn't come in with present-engine...
-    implementation 'com.google.appengine:appengine-remote-api:+'
-
     implementation 'com.google.firebase:firebase-admin:7.0.1'
     // 4.1.34.Final included in Firebase, which has vulnerabilities.
     implementation 'io.netty:netty-codec-http:4.1.53.Final'

--- a/server/appengine/src/main/java/who/WhoServletModule.java
+++ b/server/appengine/src/main/java/who/WhoServletModule.java
@@ -29,9 +29,6 @@ public class WhoServletModule extends ServletModule {
   protected void configureServlets() {
     install(new FirebaseModule());
 
-    // App Engine Remote API
-    serve("/remote_api").with(new RemoteApiServlet());
-
     serve("/app").with(new AppStoreServlet());
 
     // Set up Objectify


### PR DESCRIPTION
## Screenshots

Remove remote_api from server configuration. This should not be needed.

<details>
<summary>Screenshots</summary>
Add any relevant before/after screenshots here
</details>

## How did you test the change?

- [ ] iOS Simulator
- [ ] iOS Device
- [ ] Android Simulator
- [ ] Android Device
- [ ] `curl` to a dev App Engine server
- [x] other, please describe

Opened in browser. Error message changed from "This request did not contain a necessary header" to a generic "Error: Not Found".

## Checklist:

- [ ] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
