### PR TITLE
whoapp.org/app => covid19app.who.int/app

### DIFF
--- a/client/lib/generated/intl/messages_en.dart
+++ b/client/lib/generated/intl/messages_en.dart
@@ -59,7 +59,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Skip"),
         "commonWhoAppShareIconButtonDescription":
             MessageLookupByLibrary.simpleMessage(
-                "Check out the official COVID-19 app from the World Health Organization https://whoapp.org/app"),
+                "Check out the official COVID-19 app from the World Health Organization https://covid19app.who.int/app"),
         "commonWorldHealthOrganization":
             MessageLookupByLibrary.simpleMessage("World Health Organization"),
         "commonWorldHealthOrganizationCoronavirusApp":

--- a/client/lib/generated/intl/messages_en_US.dart
+++ b/client/lib/generated/intl/messages_en_US.dart
@@ -59,7 +59,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Skip"),
         "commonWhoAppShareIconButtonDescription":
             MessageLookupByLibrary.simpleMessage(
-                "Check out the official COVID-19 app from the World Health Organization https://whoapp.org/app"),
+                "Check out the official COVID-19 app from the World Health Organization https://covid19app.who.int/app"),
         "commonWorldHealthOrganization":
             MessageLookupByLibrary.simpleMessage("World Health Organization"),
         "commonWorldHealthOrganizationCoronavirusApp":

--- a/client/lib/generated/intl/messages_fr.dart
+++ b/client/lib/generated/intl/messages_fr.dart
@@ -58,7 +58,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Passer à l\'étape suivante"),
         "commonWhoAppShareIconButtonDescription":
             MessageLookupByLibrary.simpleMessage(
-                "Découvrez l\'application officielle COVID-19 de l\'Organisation mondiale de la Santé https://whoapp.org/app"),
+                "Découvrez l\'application officielle COVID-19 de l\'Organisation mondiale de la Santé https://covid19app.who.int/app"),
         "commonWorldHealthOrganization": MessageLookupByLibrary.simpleMessage(
             "Organisation mondiale de la Santé"),
         "commonWorldHealthOrganizationCoronavirusApp":

--- a/client/lib/generated/intl/messages_fr_FR.dart
+++ b/client/lib/generated/intl/messages_fr_FR.dart
@@ -58,7 +58,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Passer à l\'étape suivante"),
         "commonWhoAppShareIconButtonDescription":
             MessageLookupByLibrary.simpleMessage(
-                "Découvrez l\'application officielle COVID-19 de l\'Organisation mondiale de la Santé https://whoapp.org/app"),
+                "Découvrez l\'application officielle COVID-19 de l\'Organisation mondiale de la Santé https://covid19app.who.int/app"),
         "commonWorldHealthOrganization": MessageLookupByLibrary.simpleMessage(
             "Organisation mondiale de la Santé"),
         "commonWorldHealthOrganizationCoronavirusApp":

--- a/client/lib/generated/l10n.dart
+++ b/client/lib/generated/l10n.dart
@@ -48,7 +48,7 @@ class S {
 
   String get commonWhoAppShareIconButtonDescription {
     return Intl.message(
-      'Check out the official COVID-19 app from the World Health Organization https://whoapp.org/app',
+      'Check out the official COVID-19 app from the World Health Organization https://covid19app.who.int/app',
       name: 'commonWhoAppShareIconButtonDescription',
       desc: '',
       args: [],

--- a/client/lib/l10n/intl_en_US.arb
+++ b/client/lib/l10n/intl_en_US.arb
@@ -2,7 +2,7 @@
   "@section": "Common strings",
   "commonWorldHealthOrganization": "World Health Organization",
   "commonWorldHealthOrganizationCoronavirusApp": "COVID-19",
-  "commonWhoAppShareIconButtonDescription": "Check out the official COVID-19 app from the World Health Organization https://whoapp.org/app",
+  "commonWhoAppShareIconButtonDescription": "Check out the official COVID-19 app from the World Health Organization https://covid19app.who.int/app",
   "commonWorldHealthOrganizationCoronavirusAppVersion": "Version {version} ({buildNumber})",
   "commonWorldHealthOrganizationCoronavirusCopyright": "© {year} WHO",
   "commonPermissionRequestPageButtonSkip": "Skip",

--- a/client/lib/l10n/intl_fr_FR.arb
+++ b/client/lib/l10n/intl_fr_FR.arb
@@ -2,7 +2,7 @@
   "@section": "Common strings",
   "commonWorldHealthOrganization": "Organisation mondiale de la Santé",
   "commonWorldHealthOrganizationCoronavirusApp": "COVID-19",
-  "commonWhoAppShareIconButtonDescription": "Découvrez l'application officielle COVID-19 de l'Organisation mondiale de la Santé https://whoapp.org/app",
+  "commonWhoAppShareIconButtonDescription": "Découvrez l'application officielle COVID-19 de l'Organisation mondiale de la Santé https://covid19app.who.int/app",
   "commonWorldHealthOrganizationCoronavirusAppVersion": "Version {version} ({buildNumber})",
   "commonWorldHealthOrganizationCoronavirusCopyright": "© {year} OMS",
   "commonPermissionRequestPageButtonSkip": "Passer à l'étape suivante",


### PR DESCRIPTION
- Possibly should redirect to who.int landing if not identified as iOS or Android user
- In that case, won't know what the appropriate app store link would be if any

## How did you test the change?

- [ ] iOS Simulator
- [ ] iOS Device
- [x] Android Simulator
- [ ] Android Device
- [ ] `curl` to a dev App Engine server
- [ ] other, please describe

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
