### PR TITLE
GetStats: Persist the country only on success

### DIFF
--- a/client/lib/api/stats_store.dart
+++ b/client/lib/api/stats_store.dart
@@ -74,21 +74,21 @@ abstract class _StatsStore with Store implements Updateable {
 
     var now = DateTime.now().millisecondsSinceEpoch;
     var delta = now - _lastUpdateTimestamp;
-    if (delta < statsUpdateFrequency &&
-        countryIsoCode == prefs.countryIsoCode) {
+    var countryToLoad = prefs.countryIsoCode;
+
+    if (delta < statsUpdateFrequency && countryIsoCode == countryToLoad) {
       print('StatsStore update skipped, cached data used from ${delta}ms ago.');
       return;
     }
 
-    var countryToLoad = prefs.countryIsoCode;
     if (countryToLoad == null) {
       // This happens at startup time (while the prefs are being loaded in?).
       print('StatsStore update skipped, country unknown.');
       return;
     }
 
-    print('StatsStore update with country ${countryIsoCode}, '
-        'refreshing data last seen ${delta}ms ago.');
+    print('StatsStore update with country ${countryToLoad}, '
+        'refreshing data last seen ${delta}ms ago for ${countryIsoCode}.');
 
     caseStatsResponse =
         await service.getCaseStats(isoCountryCode: countryToLoad);
@@ -96,6 +96,5 @@ abstract class _StatsStore with Store implements Updateable {
     // persisted values will not be updated.
     _lastUpdateTimestamp = now;
     countryIsoCode = countryToLoad;
-
   }
 }

--- a/client/lib/api/stats_store.dart
+++ b/client/lib/api/stats_store.dart
@@ -80,8 +80,8 @@ abstract class _StatsStore with Store implements Updateable {
       return;
     }
 
-    countryIsoCode = prefs.countryIsoCode;
-    if (countryIsoCode == null) {
+    var countryToLoad = prefs.countryIsoCode;
+    if (countryToLoad == null) {
       // This happens at startup time (while the prefs are being loaded in?).
       print('StatsStore update skipped, country unknown.');
       return;
@@ -91,7 +91,11 @@ abstract class _StatsStore with Store implements Updateable {
         'refreshing data last seen ${delta}ms ago.');
 
     caseStatsResponse =
-        await service.getCaseStats(isoCountryCode: countryIsoCode);
+        await service.getCaseStats(isoCountryCode: countryToLoad);
+    // On error, getCaseStats will raise an exception and the
+    // persisted values will not be updated.
     _lastUpdateTimestamp = now;
+    countryIsoCode = countryToLoad;
+
   }
 }


### PR DESCRIPTION
GetStats: Persist the country only on success.
Fixes #1858 

## Screenshots

<details>
<summary>Screenshots</summary>
Add any relevant before/after screenshots here
</details>

## How did you test the change?

- [ ] iOS Simulator
- [ ] iOS Device
- [ ] Android Simulator
- [ ] Android Device
- [ ] `curl` to a dev App Engine server
- [ ] other, please describe

I have not yet tested this! Will do so later today.

## Checklist:

- [ ] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
