### PR TITLE
Respect Disable Notifications User Setting

### DIFF
--- a/server/appengine/src/main/java/who/Client.java
+++ b/server/appengine/src/main/java/who/Client.java
@@ -22,6 +22,7 @@ public class Client {
 
   /** Device token for notifications. */
   public String token;
+  public boolean disableNotifications;
 
   public Platform platform;
 

--- a/server/appengine/src/main/java/who/NotificationsManager.java
+++ b/server/appengine/src/main/java/who/NotificationsManager.java
@@ -35,9 +35,7 @@ public class NotificationsManager {
 
   public void updateSubscriptions(Client client) throws IOException {
     Preconditions.checkNotNull(client);
-    if (client.token == null) {
-      return;
-    }
+
     SortedSet<String> finalTopics = Topics.getTopicNames(client);
     Set<String> topicsToRemove = Sets
       .difference(client.subscribedTopics, finalTopics)

--- a/server/appengine/src/main/java/who/Topics.java
+++ b/server/appengine/src/main/java/who/Topics.java
@@ -79,17 +79,21 @@ public class Topics {
 
   public static ImmutableSortedSet<String> getTopicNames(Client client) {
     Preconditions.checkNotNull(client);
-    // TODO: Store these user-selected types in the Client and add
-    // an RPC to modify them.  Some day users may want to register
-    // only for news, testing centers, etc. and we must properly
-    // namespace topic names now to support that in the future.
-    NotificationType[] types = { NotificationType.ALL };
 
     ImmutableSortedSet.Builder<String> topics = new ImmutableSortedSet.Builder<>(
       Ordering.natural()
     );
-    for (NotificationType t : types) {
-      topics.addAll(getLocationTopicNames(t, client));
+
+    if (client.token != null) {
+      // TODO: Store these user-selected types in the Client and add
+      // an RPC to modify them.  Some day users may want to register
+      // only for news, testing centers, etc. and we must properly
+      // namespace topic names now to support that in the future.
+      NotificationType[] types = { NotificationType.ALL };
+
+      for (NotificationType t : types) {
+        topics.addAll(getLocationTopicNames(t, client));
+      }
     }
 
     return topics.build();

--- a/server/appengine/src/main/java/who/Topics.java
+++ b/server/appengine/src/main/java/who/Topics.java
@@ -84,7 +84,7 @@ public class Topics {
       Ordering.natural()
     );
 
-    if (client.token != null) {
+    if (!client.disableNotifications) {
       // TODO: Store these user-selected types in the Client and add
       // an RPC to modify them.  Some day users may want to register
       // only for news, testing centers, etc. and we must properly

--- a/server/appengine/src/main/java/who/WhoServiceImpl.java
+++ b/server/appengine/src/main/java/who/WhoServiceImpl.java
@@ -85,9 +85,9 @@ public class WhoServiceImpl implements WhoService {
       client.isoCountryCode = request.isoCountryCode;
     }
 
-    // Null token signifies to disable notifications
     String token = Strings.emptyToNull(request.token);
     if (token == null) {
+      // Null token indicates to disable notifications
       // Leave existing token in place to unsubscribe topics
       client.disableNotifications = true;
     } else {

--- a/server/appengine/src/main/java/who/WhoServiceImpl.java
+++ b/server/appengine/src/main/java/who/WhoServiceImpl.java
@@ -84,7 +84,16 @@ public class WhoServiceImpl implements WhoService {
       }
       client.isoCountryCode = request.isoCountryCode;
     }
-    client.token = Strings.emptyToNull(request.token);
+
+    // Null token signifies to disable notifications
+    String token = Strings.emptyToNull(request.token);
+    if (token == null) {
+      // Leave existing token in place to unsubscribe topics
+      client.disableNotifications = true;
+    } else {
+      client.token = token;
+      client.disableNotifications = false;
+    }
 
     ofy().save().entities(client);
     nm.updateSubscriptions(client);


### PR DESCRIPTION
- Notification disabled implemented by setting token to zero
- `updateSubscriptions` on BE will unsubscribe all topics in that case
- Fixes #1857
- TODO: more testing

## How did you test the change?

- Staging server and Android device
- Toggling on and off notifications
- Sending to both `ALL~LOCATION` and `ALL~LOCATION~US` topics

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
