### PR TITLE
Make RefreshCaseStats testable

### DIFF
--- a/server/appengine/src/main/java/who/Environment.java
+++ b/server/appengine/src/main/java/who/Environment.java
@@ -51,10 +51,13 @@ public enum Environment {
 
   private static String getApplicationId() {
     String applicationId = AppEngine.applicationId();
-    // "o~" prefix bug in App Engine. Not sure where those 2 chars at the beginning come from.
-    final String PREFIX_BUG = "o~";
-    if (applicationId.startsWith(PREFIX_BUG)) {
-      applicationId = applicationId.substring(PREFIX_BUG.length());
+    if (applicationId == null) {
+      return null;
+    }
+    // Strip shard.
+    int tilde = applicationId.indexOf('~');
+    if (tilde >= 0) {
+      applicationId = applicationId.substring(tilde + 1);
     }
     return applicationId;
   }

--- a/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
+++ b/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
@@ -70,9 +70,7 @@ public class RefreshCaseStatsServlet extends HttpServlet {
       snapshot.totalCases = 0L;
       snapshot.totalDeaths = 0L;
       data.snapshots.put(timestamp, snapshot);
-    } else {
-      // There shouldn't be a snapshot already except for GlobalStats!!!
-    }
+    } 
 
     snapshot.dailyCases += dailyCases;
     snapshot.dailyDeaths += dailyDeaths;

--- a/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
+++ b/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
@@ -1,5 +1,6 @@
 package who;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
@@ -16,12 +17,14 @@ import javax.servlet.http.HttpServletResponse;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class RefreshCaseStatsServlet extends HttpServlet {
 
-  private static final class JurisdictionData {
+  @VisibleForTesting
+  static final class JurisdictionData {
 
     long totalCases = 0L, totalDeaths = 0L;
     long lastUpdated = 0L;
@@ -67,18 +70,106 @@ public class RefreshCaseStatsServlet extends HttpServlet {
       snapshot.totalCases = 0L;
       snapshot.totalDeaths = 0L;
       data.snapshots.put(timestamp, snapshot);
+    } else {
+      // There shouldn't be a snapshot already except for GlobalStats!!!
     }
+
     snapshot.dailyCases += dailyCases;
     snapshot.dailyDeaths += dailyDeaths;
     snapshot.totalCases += totalCases;
     snapshot.totalDeaths += totalDeaths;
   }
 
+  /**
+   * Process the JSON data returned by the ArcGIS server.
+   *
+   * @param rows        JSON Data from ArcGIS server
+   * @param countryData Accumulated data for each country.
+   * @param globalData  Accumulated data, sum of all countries.
+   */
+  @VisibleForTesting
+  void processWhoStats(
+    JsonArray rows,
+    Map<String, JurisdictionData> countryData,
+    JurisdictionData globalData
+  ) {
+    // Given that each row has heterogeneous elements, not sure there is much benefit
+    // to using gson with reflection here.
+    for (JsonElement feature : rows) {
+      JsonObject featureAsJsonObject = feature.getAsJsonObject();
+      JsonElement attributesElement = featureAsJsonObject.get("attributes");
+
+      JsonObject attributes = attributesElement.getAsJsonObject();
+
+      long timestamp = attributes.get("date_epicrv").getAsLong();
+      long dailyDeaths = attributes.get("NewDeath").getAsLong();
+      long totalDeaths = attributes.get("CumDeath").getAsLong();
+      long dailyCases = attributes.get("NewCase").getAsLong();
+      long totalCases = attributes.get("CumCase").getAsLong();
+
+      updateData(
+        globalData,
+        timestamp,
+        dailyDeaths,
+        totalDeaths,
+        dailyCases,
+        totalCases
+      );
+
+      if (!(attributes.get("ISO_2_CODE") instanceof JsonNull)) {
+        String isoCode = attributes.get("ISO_2_CODE").getAsString();
+        JurisdictionData country = countryData.get(isoCode);
+        if (country == null) {
+          country = new JurisdictionData();
+          countryData.put(isoCode, country);
+        }
+        updateData(
+          country,
+          timestamp,
+          dailyDeaths,
+          totalDeaths,
+          dailyCases,
+          totalCases
+        );
+      }
+    }
+  }
+
+  /**
+   * Generate a CaseStats record suitable for saving to the datastore from JurisdictionData.
+   */
+  @NotNull
+  private CaseStats buildCaseStats(
+    JurisdictionType jurisdictionType,
+    String jurisdiction,
+    JurisdictionData data
+  ) {
+    CaseStats.Builder countryStats = new CaseStats.Builder()
+      .jurisdictionType(jurisdictionType)
+      .jurisdiction(jurisdiction)
+      .cases(data.totalCases)
+      .deaths(data.totalDeaths)
+      .lastUpdated(data.lastUpdated)
+      .recoveries(-1L)
+      .timeseries(
+        data.snapshots
+          .entrySet()
+          .stream()
+          .sorted(Comparator.comparing(Map.Entry::getKey))
+          .map(Map.Entry::getValue)
+          .map(StoredCaseStats.StoredStatSnapshot::toStatSnapshot)
+          .collect(Collectors.toList())
+      )
+      .attribution("WHO");
+    return countryStats.build();
+  }
+
   @Override
   protected void doGet(
     HttpServletRequest request,
     HttpServletResponse response
-  ) throws IOException {
+  )
+    throws IOException {
     // App Engine strips all external X-* request headers, so we can trust this is set by App Engine.
     // https://cloud.google.com/appengine/docs/flexible/java/scheduling-jobs-with-cron-yaml#validating_cron_requests
     if (
@@ -100,105 +191,30 @@ public class RefreshCaseStatsServlet extends HttpServlet {
     while (true) {
       String jsonString = getDashboardContents(numItems);
 
-      JsonObject root = new JsonParser().parse(jsonString).getAsJsonObject();
+      JsonObject root = JsonParser.parseString(jsonString).getAsJsonObject();
 
       JsonArray rows = root.getAsJsonArray("features");
       if (rows == null || rows.size() == 0) {
         break;
       }
       numItems += rows.size();
-      if (numItems > 100000) {
-        // We may no longer be able to process this in the 30-seconds allocated to cron requests.
-        logger.error(
-          "Ending processing - Will not update stats - More than 100000 features returned by ArcGIS endpoint."
-        );
-        // Throw a 500.
-        throw new RuntimeException(
-          "Ending processing - Will not update stats - More than 100000 features returned by ArcGIS endpoint."
-        );
-      }
-
-      // Given that each row has heterogeneous elements, not sure there is much benefit
-      // to using gson with reflection here.
-      for (JsonElement feature : rows) {
-        JsonObject featureAsJsonObject = feature.getAsJsonObject();
-        JsonElement attributesElement = featureAsJsonObject.get("attributes");
-
-        JsonObject attributes = attributesElement.getAsJsonObject();
-
-        long timestamp = attributes.get("date_epicrv").getAsLong();
-        long dailyDeaths = attributes.get("NewDeath").getAsLong();
-        long totalDeaths = attributes.get("CumDeath").getAsLong();
-        long dailyCases = attributes.get("NewCase").getAsLong();
-        long totalCases = attributes.get("CumCase").getAsLong();
-
-        updateData(
-          globalData,
-          timestamp,
-          dailyDeaths,
-          totalDeaths,
-          dailyCases,
-          totalCases
-        );
-
-        if (!(attributes.get("ISO_2_CODE") instanceof JsonNull)) {
-          String isoCode = attributes.get("ISO_2_CODE").getAsString();
-          JurisdictionData country = countryData.get(isoCode);
-          if (country == null) {
-            country = new JurisdictionData();
-            countryData.put(isoCode, country);
-          }
-          updateData(
-            country,
-            timestamp,
-            dailyDeaths,
-            totalDeaths,
-            dailyCases,
-            totalCases
-          );
-        }
-      }
+      processWhoStats(rows, countryData, globalData);
     }
 
-    CaseStats.Builder global = new CaseStats.Builder()
-      .jurisdictionType(JurisdictionType.GLOBAL)
-      .jurisdiction("")
-      .cases(globalData.totalCases)
-      .deaths(globalData.totalDeaths)
-      .lastUpdated(globalData.lastUpdated)
-      .recoveries(-1L)
-      .timeseries(
-        globalData.snapshots
-          .entrySet()
-          .stream()
-          .sorted(Comparator.comparing(Map.Entry::getKey))
-          .map(Map.Entry::getValue)
-          .map(StoredCaseStats.StoredStatSnapshot::toStatSnapshot)
-          .collect(Collectors.toList())
-      )
-      .attribution("WHO");
-    StoredCaseStats.save(global.build());
+    CaseStats globalStats = buildCaseStats(
+      JurisdictionType.GLOBAL,
+      "",
+      globalData
+    );
+    StoredCaseStats.save(globalStats);
 
     for (Map.Entry<String, JurisdictionData> entry : countryData.entrySet()) {
-      JurisdictionData data = entry.getValue();
-      CaseStats.Builder countryStats = new CaseStats.Builder()
-        .jurisdictionType(JurisdictionType.COUNTRY)
-        .jurisdiction(entry.getKey())
-        .cases(data.totalCases)
-        .deaths(data.totalDeaths)
-        .lastUpdated(data.lastUpdated)
-        .recoveries(-1L)
-        .timeseries(
-          data.snapshots
-            .entrySet()
-            .stream()
-            .sorted(Comparator.comparing(Map.Entry::getKey))
-            .map(Map.Entry::getValue)
-            .map(StoredCaseStats.StoredStatSnapshot::toStatSnapshot)
-            .collect(Collectors.toList())
-        )
-        .attribution("WHO");
-      StoredCaseStats.save(countryStats.build());
+      CaseStats stats = buildCaseStats(
+        JurisdictionType.COUNTRY,
+        entry.getKey(),
+        entry.getValue()
+      );
+      StoredCaseStats.save(stats);
     }
   }
 }

--- a/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
+++ b/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
@@ -70,7 +70,7 @@ public class RefreshCaseStatsServlet extends HttpServlet {
       snapshot.totalCases = 0L;
       snapshot.totalDeaths = 0L;
       data.snapshots.put(timestamp, snapshot);
-    } 
+    }
 
     snapshot.dailyCases += dailyCases;
     snapshot.dailyDeaths += dailyDeaths;
@@ -94,8 +94,9 @@ public class RefreshCaseStatsServlet extends HttpServlet {
     // Given that each row has heterogeneous elements, not sure there is much benefit
     // to using gson with reflection here.
     for (JsonElement feature : rows) {
-      JsonObject featureAsJsonObject = feature.getAsJsonObject();
-      JsonElement attributesElement = featureAsJsonObject.get("attributes");
+      JsonElement attributesElement = feature
+        .getAsJsonObject()
+        .get("attributes");
 
       JsonObject attributes = attributesElement.getAsJsonObject();
 

--- a/server/appengine/src/test/java/who/RefreshCaseStatsServletTest.java
+++ b/server/appengine/src/test/java/who/RefreshCaseStatsServletTest.java
@@ -1,0 +1,41 @@
+package who;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+public class RefreshCaseStatsServletTest extends WhoTestSupport {
+
+  @Test
+  public void testParse() throws UnsupportedEncodingException {
+    RefreshCaseStatsServlet servlet = new RefreshCaseStatsServlet();
+
+    InputStream in =
+      this.getClass()
+        .getClassLoader()
+        .getResourceAsStream("smaller-who-data.json");
+    JsonObject root = JsonParser
+      .parseReader(new InputStreamReader(in, "UTF-8"))
+      .getAsJsonObject();
+
+    JsonArray rows = root.getAsJsonArray("features");
+
+    RefreshCaseStatsServlet.JurisdictionData globalData = new RefreshCaseStatsServlet.JurisdictionData();
+    Map<String, RefreshCaseStatsServlet.JurisdictionData> countryData = new HashMap<>();
+    servlet.processWhoStats(rows, countryData, globalData);
+
+    assertEquals(2, countryData.size());
+  }
+}

--- a/server/appengine/src/test/java/who/RefreshCaseStatsServletTest.java
+++ b/server/appengine/src/test/java/who/RefreshCaseStatsServletTest.java
@@ -29,13 +29,26 @@ public class RefreshCaseStatsServletTest extends WhoTestSupport {
     JsonObject root = JsonParser
       .parseReader(new InputStreamReader(in, "UTF-8"))
       .getAsJsonObject();
-
     JsonArray rows = root.getAsJsonArray("features");
 
     RefreshCaseStatsServlet.JurisdictionData globalData = new RefreshCaseStatsServlet.JurisdictionData();
     Map<String, RefreshCaseStatsServlet.JurisdictionData> countryData = new HashMap<>();
+
     servlet.processWhoStats(rows, countryData, globalData);
 
+    // Test values in a cumbersome way.
+    // TODO: Test against a snapshot of golden data.
+    assertEquals(1608768000000L, globalData.lastUpdated);
+    assertEquals(235, globalData.totalCases);
+    assertEquals(8, globalData.totalDeaths);
+    assertEquals(2, globalData.snapshots.size());
+
     assertEquals(2, countryData.size());
+    RefreshCaseStatsServlet.JurisdictionData zambia = countryData.get("ZM");
+    assertEquals(2, zambia.snapshots.size());
+    StoredCaseStats.StoredStatSnapshot s1 = zambia.snapshots.get(
+      1608681600000L
+    );
+    assertEquals(113, s1.dailyCases.intValue());
   }
 }

--- a/server/appengine/src/test/java/who/WhoTestSupport.java
+++ b/server/appengine/src/test/java/who/WhoTestSupport.java
@@ -18,6 +18,8 @@ public abstract class WhoTestSupport {
   @Before
   public void setup() {
     helper.setUp();
+    ObjectifyService.register(Client.class);
+    ObjectifyService.register(StoredCaseStats.class);
     objectify = ObjectifyService.begin();
   }
 

--- a/server/appengine/src/test/resources/smaller-who-data.json
+++ b/server/appengine/src/test/resources/smaller-who-data.json
@@ -1,0 +1,121 @@
+{
+  "objectIdFieldName" : "OBJECTID", 
+  "uniqueIdField" : 
+  {
+    "name" : "OBJECTID", 
+    "isSystemMaintained" : true
+  }, 
+  "globalIdFieldName" : "", 
+  "geometryType" : "esriGeometryPoint", 
+  "spatialReference" : {
+    "wkid" : 4326, 
+    "latestWkid" : 4326
+  }, 
+  "fields" : [
+    {
+      "name" : "ISO_2_CODE", 
+      "type" : "esriFieldTypeString", 
+      "alias" : "ISO_2_CODE", 
+      "sqlType" : "sqlTypeOther", 
+      "length" : 2, 
+      "domain" : null, 
+      "defaultValue" : null
+    }, 
+    {
+      "name" : "date_epicrv", 
+      "type" : "esriFieldTypeDate", 
+      "alias" : "date_epicrv", 
+      "sqlType" : "sqlTypeOther", 
+      "length" : 8, 
+      "domain" : null, 
+      "defaultValue" : null
+    }, 
+    {
+      "name" : "NewCase", 
+      "type" : "esriFieldTypeInteger", 
+      "alias" : "NewCase", 
+      "sqlType" : "sqlTypeOther", 
+      "domain" : null, 
+      "defaultValue" : null
+    }, 
+    {
+      "name" : "CumCase", 
+      "type" : "esriFieldTypeInteger", 
+      "alias" : "CumCase", 
+      "sqlType" : "sqlTypeOther", 
+      "domain" : null, 
+      "defaultValue" : null
+    }, 
+    {
+      "name" : "NewDeath", 
+      "type" : "esriFieldTypeInteger", 
+      "alias" : "NewDeath", 
+      "sqlType" : "sqlTypeOther", 
+      "domain" : null, 
+      "defaultValue" : null
+    }, 
+    {
+      "name" : "CumDeath", 
+      "type" : "esriFieldTypeInteger", 
+      "alias" : "CumDeath", 
+      "sqlType" : "sqlTypeOther", 
+      "domain" : null, 
+      "defaultValue" : null
+    }, 
+    {
+      "name" : "ADM0_NAME", 
+      "type" : "esriFieldTypeString", 
+      "alias" : "ADM0_NAME", 
+      "sqlType" : "sqlTypeOther", 
+      "length" : 255, 
+      "domain" : null, 
+      "defaultValue" : null
+    }
+  ], 
+   "features" : [
+    {
+      "attributes" : {
+        "ISO_2_CODE" : "ZW", 
+        "date_epicrv" : 1608681600000, 
+        "NewCase" : 122, 
+        "CumCase" : 12544, 
+        "NewDeath" : 4, 
+        "CumDeath" : 326, 
+        "ADM0_NAME" : "Zimbabwe"
+      }
+    }, 
+    {
+      "attributes" : {
+        "ISO_2_CODE" : "ZM", 
+        "date_epicrv" : 1608681600000, 
+        "NewCase" : 113, 
+        "CumCase" : 18881, 
+        "NewDeath" : 4, 
+        "CumDeath" : 379, 
+        "ADM0_NAME" : "Zambia"
+      }
+    }, 
+    {
+      "attributes" : {
+        "ISO_2_CODE" : "ZM", 
+        "date_epicrv" : 1608768000000, 
+        "NewCase" : 0, 
+        "CumCase" : 18881, 
+        "NewDeath" : 0, 
+        "CumDeath" : 379, 
+        "ADM0_NAME" : "Zambia"
+      }
+    }, 
+    {
+      "attributes" : {
+        "ISO_2_CODE" : "ZW", 
+        "date_epicrv" : 1608768000000, 
+        "NewCase" : 0, 
+        "CumCase" : 12544, 
+        "NewDeath" : 0, 
+        "CumDeath" : 326, 
+        "ADM0_NAME" : "Zimbabwe"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Make RefreshCaseStats testable and add a skeletal test.
* Refactor RefreshCastStatsServlet.
* Add RefreshCaseStatsServletTest
* Switch from deprecated JsonParse.parse to JsonParse.parseString.
* Removed n>100000 limit. (Not sure why it was added.)
* Make WhoTestSupport work w/that test.
* Fix bug in Environment with app engine appid shard.

## Screenshots

 n/a

## How did you test the change?

- [ ] iOS Simulator
- [ ] iOS Device
- [ ] Android Simulator
- [ ] Android Device
- [ ] `curl` to a dev App Engine server
- [x] other, please describe

Ran the new unit test and it passed. Verfiied that making the expected value something other than 2 causes it to fail.

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
