### PR TITLE
Log URLs requested of ArcGIS

### DIFF
--- a/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
+++ b/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
@@ -79,7 +79,8 @@ public class RefreshCaseStatsServlet extends HttpServlet {
   protected void doGet(
     HttpServletRequest request,
     HttpServletResponse response
-  ) throws IOException {
+  )
+    throws IOException {
     // App Engine strips all external X-* request headers, so we can trust this is set by App Engine.
     // https://cloud.google.com/appengine/docs/flexible/java/scheduling-jobs-with-cron-yaml#validating_cron_requests
     if (

--- a/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
+++ b/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
@@ -40,6 +40,7 @@ public class RefreshCaseStatsServlet extends HttpServlet {
       // Safe because the value is an integer and does not need to be escaped
       .url(WHO_CASE_STATS_URL + "&resultOffset=" + offset)
       .build();
+    logger.info(request.url().toString());
     try (Response response = HTTP_CLIENT.newCall(request).execute()) {
       return response.body().string();
     }


### PR DESCRIPTION
Log URLs requested of ArcGIS when refreshing case stats.

This will help us debug issue #1876 . 

In the common scenario, we should see two requests to the server: one at offset zero, one at offset number-of-records (today that is resultOffset=84846). The second request will return no records.

In the scenario where the data on the arcgis server is in flux, it may return multiple requests. This log record will let us validate that. 

In some other scenarios, e.g. large amounts of data but stable, it might send multiple requests, but we are probably not yet seeing that.


## Screenshots


<details>
<summary>Screenshots</summary>
Add any relevant before/after screenshots here
</details>

## How did you test the change?

- [ ] iOS Simulator
- [ ] iOS Device
- [ ] Android Simulator
- [ ] Android Device
- [ ] `curl` to a dev App Engine server
- [x] other, please describe

Redeployed to my App Engine instance. Went to https://console.cloud.google.com/appengine/cronjobs and triggered a cron job. Clicked on 'logs' from there and reviewed logs.


## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
