### PR TITLE
Fail RefreshCaseStats on duplicate data

### DIFF
--- a/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
+++ b/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
@@ -26,9 +26,16 @@ public class RefreshCaseStatsServlet extends HttpServlet {
   @VisibleForTesting
   static final class JurisdictionData {
 
+    JurisdictionType jurisdictionType;
+    String jurisdiction = "";
     long totalCases = 0L, totalDeaths = 0L;
     long lastUpdated = 0L;
     Map<Long, StoredCaseStats.StoredStatSnapshot> snapshots = new HashMap<>();
+
+    JurisdictionData(JurisdictionType jurisdictionType, String jurisdiction) {
+      this.jurisdictionType = jurisdictionType;
+      this.jurisdiction = jurisdiction;
+    }
   }
 
   private static final String WHO_CASE_STATS_URL =
@@ -75,6 +82,21 @@ public class RefreshCaseStatsServlet extends HttpServlet {
       snapshot.totalCases = 0L;
       snapshot.totalDeaths = 0L;
       data.snapshots.put(timestamp, snapshot);
+    } else if (data.jurisdictionType != JurisdictionType.GLOBAL) {
+      // For individual jurisdictions, we should NOT see the same timestamp more than once.
+      // Raise an error, and hope that the next run of the cron job picks up good results.
+      // Note that when the bad results are doubled/trebled/etc, they have also been missing
+      // some data, suggesting failure is a better choice than silently ignoring duplicates.
+      logger.error(
+        "Duplicate country data found at {} for {} {}",
+        timestamp,
+        data.jurisdictionType,
+        data.jurisdiction
+      );
+      /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+      // (Should we create a proper exception?)
+
+      throw new RuntimeException("This is wrong.");
     }
 
     snapshot.dailyCases += dailyCases;
@@ -124,7 +146,7 @@ public class RefreshCaseStatsServlet extends HttpServlet {
         String isoCode = attributes.get("ISO_2_CODE").getAsString();
         JurisdictionData country = countryData.get(isoCode);
         if (country == null) {
-          country = new JurisdictionData();
+          country = new JurisdictionData(JurisdictionType.COUNTRY, isoCode);
           countryData.put(isoCode, country);
         }
         updateData(
@@ -143,14 +165,10 @@ public class RefreshCaseStatsServlet extends HttpServlet {
    * Generate a CaseStats record suitable for saving to the datastore from JurisdictionData.
    */
   @NotNull
-  private CaseStats buildCaseStats(
-    JurisdictionType jurisdictionType,
-    String jurisdiction,
-    JurisdictionData data
-  ) {
+  private CaseStats buildCaseStats(JurisdictionData data) {
     CaseStats.Builder countryStats = new CaseStats.Builder()
-      .jurisdictionType(jurisdictionType)
-      .jurisdiction(jurisdiction)
+      .jurisdictionType(data.jurisdictionType)
+      .jurisdiction(data.jurisdiction)
       .cases(data.totalCases)
       .deaths(data.totalDeaths)
       .lastUpdated(data.lastUpdated)
@@ -186,7 +204,10 @@ public class RefreshCaseStatsServlet extends HttpServlet {
       return;
     }
 
-    JurisdictionData globalData = new JurisdictionData();
+    JurisdictionData globalData = new JurisdictionData(
+      JurisdictionType.GLOBAL,
+      ""
+    );
     Map<String, JurisdictionData> countryData = new HashMap<>();
 
     int numItems = 0;
@@ -200,24 +221,15 @@ public class RefreshCaseStatsServlet extends HttpServlet {
       if (rows == null || rows.size() == 0) {
         break;
       }
+      logger.info("Retreived {} features.", rows.size());
       numItems += rows.size();
       processWhoStats(rows, countryData, globalData);
     }
 
-    CaseStats globalStats = buildCaseStats(
-      JurisdictionType.GLOBAL,
-      "",
-      globalData
-    );
-    StoredCaseStats.save(globalStats);
+    StoredCaseStats.save(buildCaseStats(globalData));
 
     for (Map.Entry<String, JurisdictionData> entry : countryData.entrySet()) {
-      CaseStats stats = buildCaseStats(
-        JurisdictionType.COUNTRY,
-        entry.getKey(),
-        entry.getValue()
-      );
-      StoredCaseStats.save(stats);
+      StoredCaseStats.save(buildCaseStats(entry.getValue()));
     }
   }
 }

--- a/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
+++ b/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
@@ -27,7 +27,7 @@ public class RefreshCaseStatsServlet extends HttpServlet {
   static final class JurisdictionData {
 
     JurisdictionType jurisdictionType;
-    String jurisdiction = "";
+    String jurisdiction;
     long totalCases = 0L, totalDeaths = 0L;
     long lastUpdated = 0L;
     Map<Long, StoredCaseStats.StoredStatSnapshot> snapshots = new HashMap<>();
@@ -94,10 +94,9 @@ public class RefreshCaseStatsServlet extends HttpServlet {
         data.jurisdictionType,
         data.jurisdiction
       );
-      /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-      // (Should we create a proper exception?)
 
-      throw new RuntimeException("This is wrong.");
+      // Todo: Create a proper exception.
+      throw new RuntimeException("Saw duplicated country data.");
     }
 
     snapshot.dailyCases += dailyCases;

--- a/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
+++ b/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
@@ -83,10 +83,11 @@ public class RefreshCaseStatsServlet extends HttpServlet {
       snapshot.totalDeaths = 0L;
       data.snapshots.put(timestamp, snapshot);
     } else if (data.jurisdictionType != JurisdictionType.GLOBAL) {
-      // For individual jurisdictions, we should NOT see the same timestamp more than once.
-      // Raise an error, and hope that the next run of the cron job picks up good results.
-      // Note that when the bad results are doubled/trebled/etc, they have also been missing
-      // some data, suggesting failure is a better choice than silently ignoring duplicates.
+      // For individual jurisdictions, we should NOT see the same timestamp
+      // more than once.
+      // Fail and hope that the next run of the cron job succeeds.
+      // Note that when the bad results are doubled/trebled/etc, they have
+      // also been missing data, so ignoring duplicates is not safe.
       logger.error(
         "Duplicate country data found at {} for {} {}",
         timestamp,

--- a/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
+++ b/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
@@ -233,5 +233,6 @@ public class RefreshCaseStatsServlet extends HttpServlet {
     for (Map.Entry<String, JurisdictionData> entry : countryData.entrySet()) {
       StoredCaseStats.save(buildCaseStats(entry.getValue()));
     }
+    logger.info("Results saved.");
   }
 }

--- a/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
+++ b/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
@@ -220,6 +220,7 @@ public class RefreshCaseStatsServlet extends HttpServlet {
 
       JsonArray rows = root.getAsJsonArray("features");
       if (rows == null || rows.size() == 0) {
+        logger.info("Retreived no features.");
         break;
       }
       logger.info("Retreived {} features.", rows.size());

--- a/server/appengine/src/test/java/who/RefreshCaseStatsServletTest.java
+++ b/server/appengine/src/test/java/who/RefreshCaseStatsServletTest.java
@@ -1,6 +1,7 @@
 package who;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -20,16 +21,12 @@ public class RefreshCaseStatsServletTest extends WhoTestSupport {
   public void testParse() throws UnsupportedEncodingException {
     RefreshCaseStatsServlet servlet = new RefreshCaseStatsServlet();
 
-    InputStream in =
-      this.getClass()
-        .getClassLoader()
-        .getResourceAsStream("smaller-who-data.json");
-    JsonObject root = JsonParser
-      .parseReader(new InputStreamReader(in, "UTF-8"))
-      .getAsJsonObject();
-    JsonArray rows = root.getAsJsonArray("features");
+    JsonArray rows = getRowsFromTestResource("smaller-who-data.json");
 
-    RefreshCaseStatsServlet.JurisdictionData globalData = new RefreshCaseStatsServlet.JurisdictionData();
+    RefreshCaseStatsServlet.JurisdictionData globalData = new RefreshCaseStatsServlet.JurisdictionData(
+      JurisdictionType.GLOBAL,
+      ""
+    );
     Map<String, RefreshCaseStatsServlet.JurisdictionData> countryData = new HashMap<>();
 
     servlet.processWhoStats(rows, countryData, globalData);
@@ -51,6 +48,64 @@ public class RefreshCaseStatsServletTest extends WhoTestSupport {
   }
 
   @Test
+  public void testDoubleData() throws UnsupportedEncodingException {
+    RefreshCaseStatsServlet servlet = new RefreshCaseStatsServlet();
+
+    JsonArray rows = getRowsFromTestResource("smaller-who-data.json");
+
+    RefreshCaseStatsServlet.JurisdictionData globalData = new RefreshCaseStatsServlet.JurisdictionData(
+      JurisdictionType.GLOBAL,
+      ""
+    );
+    Map<String, RefreshCaseStatsServlet.JurisdictionData> countryData = new HashMap<>();
+
+    servlet.processWhoStats(rows, countryData, globalData);
+    // Imagine that the server is going haywire: it is called a second time,
+    // and instead of returning new data (or no data), it returns previously
+    // seen data! This may be what is triggering a bug where some countries
+    // were seeing double or triple the correct values.
+    Exception exception = assertThrows(
+      RuntimeException.class,
+      () -> {
+        servlet.processWhoStats(rows, countryData, globalData);
+      }
+    );
+  }
+
+  @Test
+  public void testPaginatedData() throws UnsupportedEncodingException {
+    RefreshCaseStatsServlet servlet = new RefreshCaseStatsServlet();
+
+    JsonArray rows1 = getRowsFromTestResource("smaller-who-data-earlier.json");
+    JsonArray rows2 = getRowsFromTestResource("smaller-who-data.json");
+
+    RefreshCaseStatsServlet.JurisdictionData globalData = new RefreshCaseStatsServlet.JurisdictionData(
+      JurisdictionType.GLOBAL,
+      ""
+    );
+    Map<String, RefreshCaseStatsServlet.JurisdictionData> countryData = new HashMap<>();
+
+    servlet.processWhoStats(rows1, countryData, globalData);
+    assertEquals(1608595200000L, globalData.lastUpdated);
+    servlet.processWhoStats(rows2, countryData, globalData);
+
+    assertEquals(1608768000000L, globalData.lastUpdated);
+    assertEquals(384, globalData.totalCases);
+    assertEquals(12, globalData.totalDeaths);
+    assertEquals(3, globalData.snapshots.size());
+  }
+
+  private JsonArray getRowsFromTestResource(String filename)
+    throws UnsupportedEncodingException {
+    InputStream in =
+      this.getClass().getClassLoader().getResourceAsStream(filename);
+    JsonObject root = JsonParser
+      .parseReader(new InputStreamReader(in, "UTF-8"))
+      .getAsJsonObject();
+    return root.getAsJsonArray("features");
+  }
+
+  @Test
   public void testDec24Data() throws IOException {
     RefreshCaseStatsServlet servlet = new RefreshCaseStatsServlet();
 
@@ -64,7 +119,10 @@ public class RefreshCaseStatsServletTest extends WhoTestSupport {
       .getAsJsonObject();
     JsonArray rows = root.getAsJsonArray("features");
 
-    RefreshCaseStatsServlet.JurisdictionData globalData = new RefreshCaseStatsServlet.JurisdictionData();
+    RefreshCaseStatsServlet.JurisdictionData globalData = new RefreshCaseStatsServlet.JurisdictionData(
+      JurisdictionType.GLOBAL,
+      ""
+    );
     Map<String, RefreshCaseStatsServlet.JurisdictionData> countryData = new HashMap<>();
 
     servlet.processWhoStats(rows, countryData, globalData);

--- a/server/appengine/src/test/resources/smaller-who-data-earlier.json
+++ b/server/appengine/src/test/resources/smaller-who-data-earlier.json
@@ -1,0 +1,99 @@
+{
+  "objectIdFieldName" : "OBJECTID", 
+  "uniqueIdField" : 
+  {
+    "name" : "OBJECTID", 
+    "isSystemMaintained" : true
+  }, 
+  "globalIdFieldName" : "", 
+  "geometryType" : "esriGeometryPoint", 
+  "spatialReference" : {
+    "wkid" : 4326, 
+    "latestWkid" : 4326
+  }, 
+  "fields" : [
+    {
+      "name" : "ISO_2_CODE", 
+      "type" : "esriFieldTypeString", 
+      "alias" : "ISO_2_CODE", 
+      "sqlType" : "sqlTypeOther", 
+      "length" : 2, 
+      "domain" : null, 
+      "defaultValue" : null
+    }, 
+    {
+      "name" : "date_epicrv", 
+      "type" : "esriFieldTypeDate", 
+      "alias" : "date_epicrv", 
+      "sqlType" : "sqlTypeOther", 
+      "length" : 8, 
+      "domain" : null, 
+      "defaultValue" : null
+    }, 
+    {
+      "name" : "NewCase", 
+      "type" : "esriFieldTypeInteger", 
+      "alias" : "NewCase", 
+      "sqlType" : "sqlTypeOther", 
+      "domain" : null, 
+      "defaultValue" : null
+    }, 
+    {
+      "name" : "CumCase", 
+      "type" : "esriFieldTypeInteger", 
+      "alias" : "CumCase", 
+      "sqlType" : "sqlTypeOther", 
+      "domain" : null, 
+      "defaultValue" : null
+    }, 
+    {
+      "name" : "NewDeath", 
+      "type" : "esriFieldTypeInteger", 
+      "alias" : "NewDeath", 
+      "sqlType" : "sqlTypeOther", 
+      "domain" : null, 
+      "defaultValue" : null
+    }, 
+    {
+      "name" : "CumDeath", 
+      "type" : "esriFieldTypeInteger", 
+      "alias" : "CumDeath", 
+      "sqlType" : "sqlTypeOther", 
+      "domain" : null, 
+      "defaultValue" : null
+    }, 
+    {
+      "name" : "ADM0_NAME", 
+      "type" : "esriFieldTypeString", 
+      "alias" : "ADM0_NAME", 
+      "sqlType" : "sqlTypeOther", 
+      "length" : 255, 
+      "domain" : null, 
+      "defaultValue" : null
+    }
+  ], 
+  "features" : [
+    {
+      "attributes" : {
+        "ISO_2_CODE" : "ZM", 
+        "date_epicrv" : 1608595200000, 
+        "NewCase" : 52, 
+        "CumCase" : 18768, 
+        "NewDeath" : 2, 
+        "CumDeath" : 375, 
+        "ADM0_NAME" : "Zambia"
+      }
+    }, 
+    {
+      "attributes" : {
+        "ISO_2_CODE" : "ZW", 
+        "date_epicrv" : 1608595200000, 
+        "NewCase" : 97, 
+        "CumCase" : 12422, 
+        "NewDeath" : 2, 
+        "CumDeath" : 322, 
+        "ADM0_NAME" : "Zimbabwe"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
The RefreshCaseStats cron task will now fail if it sees a second entry for a particular time and place.

This is most likley happening when the arcgis server returns some sort of strange result, perhaps a 'paginated' one which is really overlapping rather than paginated data. We also see missing data when this occurs, suggesting that this process should fail rather than ignore any duplicates.

Likely fix for issue #1876

## Screenshots


## How did you test the change?

- [ ] iOS Simulator
- [ ] iOS Device
- [ ] Android Simulator
- [ ] Android Device
- [ ] `curl` to a dev App Engine server
- [x] other, please describe

Unit tests.
Pushed to my instance also and will watch.

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
