### PR TITLE
Stats Fix - Partial Last Day

### DIFF
--- a/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
+++ b/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
@@ -199,7 +199,9 @@ public class RefreshCaseStatsServlet extends HttpServlet {
   /**
    * Remove last day if it appears to be "No Data Reported"
    *
-   * ArcGIS data doesn't distinguish between "Zero Cases" and "No Data Reported"
+   * ArcGIS data can distinguish between "Zero Cases" and "No Data Reported"
+   * but appears to often report the former when it means the latter
+   *
    * Heuristic:
    *   if lastDayNumbers > 0 => assume up to date
    *   if lastDayNumbers == 0 && priorDayNumbers > 0 => assume "No Data Reported" and delete

--- a/server/appengine/src/test/java/who/RefreshCaseStatsServletTest.java
+++ b/server/appengine/src/test/java/who/RefreshCaseStatsServletTest.java
@@ -1,6 +1,7 @@
 package who;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 
 import com.google.gson.JsonArray;
@@ -34,17 +35,17 @@ public class RefreshCaseStatsServletTest extends WhoTestSupport {
     // Test values in a cumbersome way.
     // TODO: Test against a snapshot of golden data.
     assertEquals(1608768000000L, globalData.lastUpdated);
-    assertEquals(235, globalData.totalCases);
-    assertEquals(8, globalData.totalDeaths);
+    assertEquals(302, globalData.totalCases);
+    assertEquals(32, globalData.totalDeaths);
     assertEquals(2, globalData.snapshots.size());
 
     assertEquals(2, countryData.size());
-    RefreshCaseStatsServlet.JurisdictionData zambia = countryData.get("ZM");
+    RefreshCaseStatsServlet.JurisdictionData zambia = countryData.get("AA");
     assertEquals(2, zambia.snapshots.size());
     StoredCaseStats.StoredStatSnapshot s1 = zambia.snapshots.get(
       1608681600000L
     );
-    assertEquals(113, s1.dailyCases.intValue());
+    assertEquals(100, s1.dailyCases.intValue());
   }
 
   @Test
@@ -76,8 +77,8 @@ public class RefreshCaseStatsServletTest extends WhoTestSupport {
   public void testPaginatedData() throws UnsupportedEncodingException {
     RefreshCaseStatsServlet servlet = new RefreshCaseStatsServlet();
 
-    JsonArray rows1 = getRowsFromTestResource("smaller-who-data-earlier.json");
-    JsonArray rows2 = getRowsFromTestResource("smaller-who-data.json");
+    JsonArray rows1 = getRowsFromTestResource("smaller-who-data.json");
+    JsonArray rows2 = getRowsFromTestResource("smaller-who-data-page-2.json");
 
     RefreshCaseStatsServlet.JurisdictionData globalData = new RefreshCaseStatsServlet.JurisdictionData(
       JurisdictionType.GLOBAL,
@@ -86,13 +87,52 @@ public class RefreshCaseStatsServletTest extends WhoTestSupport {
     Map<String, RefreshCaseStatsServlet.JurisdictionData> countryData = new HashMap<>();
 
     servlet.processWhoStats(rows1, countryData, globalData);
-    assertEquals(1608595200000L, globalData.lastUpdated);
-    servlet.processWhoStats(rows2, countryData, globalData);
-
     assertEquals(1608768000000L, globalData.lastUpdated);
-    assertEquals(384, globalData.totalCases);
-    assertEquals(12, globalData.totalDeaths);
+    assertEquals(302, globalData.totalCases);
+    assertEquals(32, globalData.totalDeaths);
+    assertEquals(2, globalData.snapshots.size());
+
+    servlet.processWhoStats(rows2, countryData, globalData);
+    assertEquals(1608854400000L, globalData.lastUpdated);
+    assertEquals(403, globalData.totalCases);
+    assertEquals(43, globalData.totalDeaths);
     assertEquals(3, globalData.snapshots.size());
+  }
+
+  @Test
+  public void testPartialDay() throws UnsupportedEncodingException {
+    RefreshCaseStatsServlet servlet = new RefreshCaseStatsServlet();
+
+    JsonArray rows = getRowsFromTestResource(
+      "smaller-who-data-partial-day.json"
+    );
+
+    RefreshCaseStatsServlet.JurisdictionData globalData = new RefreshCaseStatsServlet.JurisdictionData(
+      JurisdictionType.GLOBAL,
+      ""
+    );
+    Map<String, RefreshCaseStatsServlet.JurisdictionData> countryData = new HashMap<>();
+
+    servlet.processWhoStats(rows, countryData, globalData);
+    assertEquals(1608854400000L, globalData.lastUpdated);
+    assertEquals(604, globalData.totalCases);
+    assertEquals(64, globalData.totalDeaths);
+    assertEquals(3, globalData.snapshots.size());
+
+    RefreshCaseStatsServlet.JurisdictionData aaCountry = countryData.get("AA");
+    RefreshCaseStatsServlet.JurisdictionData bbCountry = countryData.get("BB");
+    RefreshCaseStatsServlet.JurisdictionData ccCountry = countryData.get("CC");
+
+    assertNotNull(aaCountry);
+    assertNotNull(bbCountry);
+    assertNotNull(ccCountry);
+
+    // AA: non-zero data for all 3 days
+    assertEquals(3, aaCountry.snapshots.size());
+    // BB: zero numbers for last 1 day (discarded last day as likely "no data reported")
+    assertEquals(2, bbCountry.snapshots.size());
+    // CC: zero numbers for last 2 days (kept as likely "valid zero following prior zero")
+    assertEquals(3, ccCountry.snapshots.size());
   }
 
   private JsonArray getRowsFromTestResource(String filename)
@@ -131,5 +171,12 @@ public class RefreshCaseStatsServletTest extends WhoTestSupport {
     // The TotalCases is a good heuristic that the data loaded correctly: it is a sum
     // of every daily case seen in the system so far.
     assertEquals(77530799L, globalData.totalCases);
+    assertEquals(1724904L, globalData.totalDeaths);
+
+    RefreshCaseStatsServlet.JurisdictionData us = countryData.get("US");
+    assertEquals(357, us.snapshots.size());
+    // Rwanda: Zero numbers, so dropped as likely "No data reported yet"
+    RefreshCaseStatsServlet.JurisdictionData ng = countryData.get("RW");
+    assertEquals(356, ng.snapshots.size());
   }
 }

--- a/server/appengine/src/test/resources/smaller-who-data-page-2.json
+++ b/server/appengine/src/test/resources/smaller-who-data-page-2.json
@@ -75,24 +75,24 @@
   "features" : [
     {
       "attributes" : {
-        "ISO_2_CODE" : "ZM", 
-        "date_epicrv" : 1608595200000, 
-        "NewCase" : 52, 
-        "CumCase" : 18768, 
-        "NewDeath" : 2, 
-        "CumDeath" : 375, 
-        "ADM0_NAME" : "Zambia"
+        "ISO_2_CODE" : "AA",
+        "date_epicrv" : 1608854400000,
+        "NewCase" : 50,
+        "CumCase" : 200,
+        "NewDeath" : 5,
+        "CumDeath" : 20,
+        "ADM0_NAME" : "ACountry"
       }
-    }, 
+    },
     {
       "attributes" : {
-        "ISO_2_CODE" : "ZW", 
-        "date_epicrv" : 1608595200000, 
-        "NewCase" : 97, 
-        "CumCase" : 12422, 
-        "NewDeath" : 2, 
-        "CumDeath" : 322, 
-        "ADM0_NAME" : "Zimbabwe"
+        "ISO_2_CODE" : "BB",
+        "date_epicrv" : 1608854400000,
+        "NewCase" : 51,
+        "CumCase" : 203,
+        "NewDeath" : 6,
+        "CumDeath" : 23,
+        "ADM0_NAME" : "BCountry"
       }
     }
   ]

--- a/server/appengine/src/test/resources/smaller-who-data-partial-day.json
+++ b/server/appengine/src/test/resources/smaller-who-data-partial-day.json
@@ -1,0 +1,176 @@
+{
+  "objectIdFieldName" : "OBJECTID",
+  "uniqueIdField" :
+  {
+    "name" : "OBJECTID",
+    "isSystemMaintained" : true
+  },
+  "globalIdFieldName" : "",
+  "geometryType" : "esriGeometryPoint",
+  "spatialReference" : {
+    "wkid" : 4326,
+    "latestWkid" : 4326
+  },
+  "fields" : [
+    {
+      "name" : "ISO_2_CODE",
+      "type" : "esriFieldTypeString",
+      "alias" : "ISO_2_CODE",
+      "sqlType" : "sqlTypeOther",
+      "length" : 2,
+      "domain" : null,
+      "defaultValue" : null
+    },
+    {
+      "name" : "date_epicrv",
+      "type" : "esriFieldTypeDate",
+      "alias" : "date_epicrv",
+      "sqlType" : "sqlTypeOther",
+      "length" : 8,
+      "domain" : null,
+      "defaultValue" : null
+    },
+    {
+      "name" : "NewCase",
+      "type" : "esriFieldTypeInteger",
+      "alias" : "NewCase",
+      "sqlType" : "sqlTypeOther",
+      "domain" : null,
+      "defaultValue" : null
+    },
+    {
+      "name" : "CumCase",
+      "type" : "esriFieldTypeInteger",
+      "alias" : "CumCase",
+      "sqlType" : "sqlTypeOther",
+      "domain" : null,
+      "defaultValue" : null
+    },
+    {
+      "name" : "NewDeath",
+      "type" : "esriFieldTypeInteger",
+      "alias" : "NewDeath",
+      "sqlType" : "sqlTypeOther",
+      "domain" : null,
+      "defaultValue" : null
+    },
+    {
+      "name" : "CumDeath",
+      "type" : "esriFieldTypeInteger",
+      "alias" : "CumDeath",
+      "sqlType" : "sqlTypeOther",
+      "domain" : null,
+      "defaultValue" : null
+    },
+    {
+      "name" : "ADM0_NAME",
+      "type" : "esriFieldTypeString",
+      "alias" : "ADM0_NAME",
+      "sqlType" : "sqlTypeOther",
+      "length" : 255,
+      "domain" : null,
+      "defaultValue" : null
+    }
+  ],
+  "features" : [
+    {
+      "attributes" : {
+        "ISO_2_CODE" : "AA",
+        "date_epicrv" : 1608681600000,
+        "NewCase" : 100,
+        "CumCase" : 100,
+        "NewDeath" : 10,
+        "CumDeath" : 10,
+        "ADM0_NAME" : "A"
+      }
+    },
+    {
+      "attributes" : {
+        "ISO_2_CODE" : "BB",
+        "date_epicrv" : 1608681600000,
+        "NewCase" : 101,
+        "CumCase" : 101,
+        "NewDeath" : 11,
+        "CumDeath" : 11,
+        "ADM0_NAME" : "B"
+      }
+    },
+    {
+      "attributes" : {
+        "ISO_2_CODE" : "CC",
+        "date_epicrv" : 1608681600000,
+        "NewCase" : 102,
+        "CumCase" : 102,
+        "NewDeath" : 12,
+        "CumDeath" : 12,
+        "ADM0_NAME" : "C"
+      }
+    },
+    {
+      "attributes" : {
+        "ISO_2_CODE" : "AA",
+        "date_epicrv" : 1608768000000,
+        "NewCase" : 100,
+        "CumCase" : 200,
+        "NewDeath" : 10,
+        "CumDeath" : 20,
+        "ADM0_NAME" : "A"
+      }
+    },
+    {
+      "attributes" : {
+        "ISO_2_CODE" : "BB",
+        "date_epicrv" : 1608768000000,
+        "NewCase" : 101,
+        "CumCase" : 202,
+        "NewDeath" : 11,
+        "CumDeath" : 22,
+        "ADM0_NAME" : "B"
+      }
+    },
+    {
+      "attributes" : {
+        "ISO_2_CODE" : "CC",
+        "date_epicrv" : 1608768000000,
+        "NewCase" : 0,
+        "CumCase" : 102,
+        "NewDeath" : 0,
+        "CumDeath" : 12,
+        "ADM0_NAME" : "C"
+      }
+    },
+    {
+      "attributes" : {
+        "ISO_2_CODE" : "AA",
+        "date_epicrv" : 1608854400000,
+        "NewCase" : 100,
+        "CumCase" : 300,
+        "NewDeath" : 10,
+        "CumDeath" : 30,
+        "ADM0_NAME" : "A"
+      }
+    },
+    {
+      "attributes" : {
+        "ISO_2_CODE" : "BB",
+        "date_epicrv" : 1608854400000,
+        "NewCase" : 0,
+        "CumCase" : 202,
+        "NewDeath" : 0,
+        "CumDeath" : 22,
+        "ADM0_NAME" : "B"
+      }
+    },
+    {
+      "attributes" : {
+        "ISO_2_CODE" : "CC",
+        "date_epicrv" : 1608854400000,
+        "NewCase" : 0,
+        "CumCase" : 102,
+        "NewDeath" : 0,
+        "CumDeath" : 12,
+        "ADM0_NAME" : "C"
+      }
+    }
+  ]
+}

--- a/server/appengine/src/test/resources/smaller-who-data-partial-last-day.json
+++ b/server/appengine/src/test/resources/smaller-who-data-partial-last-day.json
@@ -108,6 +108,17 @@
     },
     {
       "attributes" : {
+        "ISO_2_CODE" : "DD",
+        "date_epicrv" : 1608681600000,
+        "NewCase" : 400,
+        "CumCase" : 400,
+        "NewDeath" : 80,
+        "CumDeath" : 80,
+        "ADM0_NAME" : "D"
+      }
+    },
+    {
+      "attributes" : {
         "ISO_2_CODE" : "AA",
         "date_epicrv" : 1608768000000,
         "NewCase" : 100,

--- a/server/appengine/src/test/resources/smaller-who-data.json
+++ b/server/appengine/src/test/resources/smaller-who-data.json
@@ -75,46 +75,46 @@
    "features" : [
     {
       "attributes" : {
-        "ISO_2_CODE" : "ZW", 
+        "ISO_2_CODE" : "AA",
         "date_epicrv" : 1608681600000, 
-        "NewCase" : 122, 
-        "CumCase" : 12544, 
-        "NewDeath" : 4, 
-        "CumDeath" : 326, 
-        "ADM0_NAME" : "Zimbabwe"
+        "NewCase" : 100,
+        "CumCase" : 100,
+        "NewDeath" : 10,
+        "CumDeath" : 10,
+        "ADM0_NAME" : "ACountry"
       }
     }, 
     {
       "attributes" : {
-        "ISO_2_CODE" : "ZM", 
+        "ISO_2_CODE" : "BB",
         "date_epicrv" : 1608681600000, 
-        "NewCase" : 113, 
-        "CumCase" : 18881, 
-        "NewDeath" : 4, 
-        "CumDeath" : 379, 
-        "ADM0_NAME" : "Zambia"
+        "NewCase" : 101,
+        "CumCase" : 101,
+        "NewDeath" : 11,
+        "CumDeath" : 11,
+        "ADM0_NAME" : "BCountry"
       }
     }, 
     {
       "attributes" : {
-        "ISO_2_CODE" : "ZM", 
+        "ISO_2_CODE" : "AA",
         "date_epicrv" : 1608768000000, 
-        "NewCase" : 0, 
-        "CumCase" : 18881, 
-        "NewDeath" : 0, 
-        "CumDeath" : 379, 
-        "ADM0_NAME" : "Zambia"
+        "NewCase" : 50,
+        "CumCase" : 150,
+        "NewDeath" : 5,
+        "CumDeath" : 15,
+        "ADM0_NAME" : "ACountry"
       }
     }, 
     {
       "attributes" : {
-        "ISO_2_CODE" : "ZW", 
+        "ISO_2_CODE" : "BB",
         "date_epicrv" : 1608768000000, 
-        "NewCase" : 0, 
-        "CumCase" : 12544, 
-        "NewDeath" : 0, 
-        "CumDeath" : 326, 
-        "ADM0_NAME" : "Zimbabwe"
+        "NewCase" : 51,
+        "CumCase" : 152,
+        "NewDeath" : 6,
+        "CumDeath" : 17,
+        "ADM0_NAME" : "BCountry"
       }
     }
   ]


### PR DESCRIPTION
WHO dashboard stats are updated throughout the day. Some countries
may report 0 for daily cases and deaths. The ArcGIS data response can't
distinguish between "zero cases" and "no data reported yet".
So this heuristic deals with that:
- Global Stats: sum all stats, not just partial stats on last day
- Country Stats: drop last day when likely "no data reported yet"

Fixes #1724
Fixes #1876

## How did you test the change?

- [x] `curl` to a dev App Engine server

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
