### PR TITLE
Case Stats update rejected for unexpected change

### DIFF
--- a/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
+++ b/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
@@ -168,7 +168,6 @@ public class RefreshCaseStatsServlet extends HttpServlet {
         );
       }
     }
-    fixPartialLastDayAll(countryData, globalData);
   }
 
   /**
@@ -323,7 +322,9 @@ public class RefreshCaseStatsServlet extends HttpServlet {
       numItems += rows.size();
       processWhoStats(rows, countryData, globalData);
     }
+    fixPartialLastDayAll(countryData, globalData);
 
+    // Reject unexpected changes in case stats, e.g. too large an increase
     CaseStats oldCaseStats = StoredCaseStats.load(JurisdictionType.GLOBAL, "");
     if (oldCaseStats != null) {
       totalCasesDeltaCheck(oldCaseStats.cases, globalData.totalCases);

--- a/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
+++ b/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
@@ -38,8 +38,13 @@ public class RefreshCaseStatsServlet extends HttpServlet {
     }
   }
 
-  private static final double TOTAL_CASES_MAX_DAILY_INCREASE_FACTOR = 1.02;
-  private static final double TOTAL_CASES_MAX_DAILY_INCREASE_ABS = 1000;
+  // Triggers to reject case stats update for unexpectedly large increase
+  // Tuned to only trigger a handful of time in early pandemic and never since April 1st
+  // Largest Cases Stats increase was 15.2% on March 24th
+  // Triggers are cumulative rather than triggered separately
+  private static final double TOTAL_CASES_MAX_DAILY_INCREASE_FACTOR = 1.05;
+  private static final double TOTAL_CASES_MAX_DAILY_INCREASE_ABS = 30_000;
+
   private static final String WHO_CASE_STATS_URL =
     "https://services.arcgis.com/5T5nSi527N4F7luB/ArcGIS/rest/services/COVID_19_Historic_cases_by_country_pt_v7_view/FeatureServer/0/query?where=1%3D1&objectIds=&time=&geometry=&geometryType=esriGeometryEnvelope&inSR=&spatialRel=esriSpatialRelIntersects&resultType=none&distance=0.0&units=esriSRUnit_Meter&returnGeodetic=false&outFields=ISO_2_CODE%2Cdate_epicrv%2CNewCase%2CCumCase%2CNewDeath%2CCumDeath%2C+ADM0_NAME&returnGeometry=false&featureEncoding=esriDefault&multipatchOption=xyFootprint&maxAllowableOffset=&geometryPrecision=&outSR=&datumTransformation=&applyVCSProjection=false&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnExtentOnly=false&returnQueryGeometry=false&returnDistinctValues=false&cacheHint=false&groupByFieldsForStatistics=&outStatistics=&having=&resultRecordCount=&returnZ=false&returnM=false&returnExceededLimitFeatures=true&quantizationParameters=&sqlFormat=none&f=pjson&orderByFields=date_epicrv&token=";
   private static final Logger logger = LoggerFactory.getLogger(

--- a/server/appengine/src/test/java/who/RefreshCaseStatsServletTest.java
+++ b/server/appengine/src/test/java/who/RefreshCaseStatsServletTest.java
@@ -135,6 +135,7 @@ public class RefreshCaseStatsServletTest extends WhoTestSupport {
     Map<String, RefreshCaseStatsServlet.JurisdictionData> countryData = new HashMap<>();
 
     servlet.processWhoStats(rows, countryData, globalData);
+    servlet.fixPartialLastDayAll(countryData, globalData);
 
     // Global Stats
     assertEquals(1608854400000L, globalData.lastUpdated);
@@ -215,9 +216,9 @@ public class RefreshCaseStatsServletTest extends WhoTestSupport {
 
     RefreshCaseStatsServlet.JurisdictionData us = countryData.get("US");
     assertEquals(357, us.snapshots.size());
-    // Rwanda: Zero numbers, so dropped as likely "No data reported yet"
+    // Last entry would be removed by fixPartialLastDayAll
     RefreshCaseStatsServlet.JurisdictionData ng = countryData.get("RW");
-    assertEquals(356, ng.snapshots.size());
+    assertEquals(357, ng.snapshots.size());
   }
 
   @Test
@@ -225,10 +226,20 @@ public class RefreshCaseStatsServletTest extends WhoTestSupport {
     RefreshCaseStatsServlet servlet = new RefreshCaseStatsServlet();
     servlet.totalCasesDeltaCheck(1000, 2000);
     servlet.totalCasesDeltaCheck(77_000_000, 78_000_000);
-    Exception exception = assertThrows(
+
+    // Unexpected increase
+    Exception exception1 = assertThrows(
       RuntimeException.class,
       () -> {
         servlet.totalCasesDeltaCheck(77_000_000, 82_000_000);
+      }
+    );
+
+    // Unexpected decrease
+    Exception exception2 = assertThrows(
+      RuntimeException.class,
+      () -> {
+        servlet.totalCasesDeltaCheck(77_000_000, 76_999_999);
       }
     );
   }

--- a/server/appengine/src/test/java/who/RefreshCaseStatsServletTest.java
+++ b/server/appengine/src/test/java/who/RefreshCaseStatsServletTest.java
@@ -228,7 +228,7 @@ public class RefreshCaseStatsServletTest extends WhoTestSupport {
     Exception exception = assertThrows(
       RuntimeException.class,
       () -> {
-        servlet.totalCasesDeltaCheck(77_000_000, 79_000_000);
+        servlet.totalCasesDeltaCheck(77_000_000, 82_000_000);
       }
     );
   }

--- a/server/appengine/src/test/java/who/RefreshCaseStatsServletTest.java
+++ b/server/appengine/src/test/java/who/RefreshCaseStatsServletTest.java
@@ -219,4 +219,17 @@ public class RefreshCaseStatsServletTest extends WhoTestSupport {
     RefreshCaseStatsServlet.JurisdictionData ng = countryData.get("RW");
     assertEquals(356, ng.snapshots.size());
   }
+
+  @Test
+  public void totalCasesDeltaCheck() {
+    RefreshCaseStatsServlet servlet = new RefreshCaseStatsServlet();
+    servlet.totalCasesDeltaCheck(1000, 2000);
+    servlet.totalCasesDeltaCheck(77_000_000, 78_000_000);
+    Exception exception = assertThrows(
+      RuntimeException.class,
+      () -> {
+        servlet.totalCasesDeltaCheck(77_000_000, 79_000_000);
+      }
+    );
+  }
 }


### PR DESCRIPTION
Case Stats update is rejected if:
- Global cases drop below prior value
- Global stats rise more than 5% + 30,000 since last update
- Skip checks for first case stats entry

## How did you test the change?

Unit tests

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
