### PR TITLE
Cron job: Only allow direct requests on dev_appserver.

### DIFF
--- a/server/appengine/src/main/java/who/Environment.java
+++ b/server/appengine/src/main/java/who/Environment.java
@@ -1,5 +1,9 @@
 package who;
 
+import static com.google.appengine.api.appidentity.AppIdentityServiceFactory.getAppIdentityService;
+
+import com.google.appengine.api.appidentity.AppIdentityService;
+import com.google.appengine.api.utils.SystemProperty;
 import present.engine.AppEngine;
 
 /**
@@ -33,6 +37,13 @@ public enum Environment {
 
     if (applicationId == null) return TEST;
 
+    if (
+      SystemProperty.environment.value() ==
+      SystemProperty.Environment.Value.Development
+    ) {
+      return DEV_LOCAL;
+    }
+
     switch (applicationId) {
       case "who-myhealth-staging":
         return STAGING;
@@ -42,8 +53,6 @@ public enum Environment {
         return PRODUCTION;
       case "test":
         return TEST;
-      case AppEngine.DEVELOPMENT_ID:
-        return DEV_LOCAL;
       default:
         return DEV_SERVER;
     }
@@ -54,12 +63,11 @@ public enum Environment {
     if (applicationId == null) {
       return null;
     }
-    // Strip shard.
-    int tilde = applicationId.indexOf('~');
-    if (tilde >= 0) {
-      applicationId = applicationId.substring(tilde + 1);
-    }
-    return applicationId;
+
+    // Work around https://github.com/presentco/present-engine/issues/1
+    AppIdentityService.ParsedAppId id = getAppIdentityService()
+      .parseFullAppId(applicationId);
+    return id.getId();
   }
 
   public String firebaseApplicationId() {

--- a/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
+++ b/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
@@ -290,8 +290,10 @@ public class RefreshCaseStatsServlet extends HttpServlet {
     // App Engine strips all external X-* request headers, so we can trust this is set by App Engine.
     // https://cloud.google.com/appengine/docs/flexible/java/scheduling-jobs-with-cron-yaml#validating_cron_requests
     if (
-      !(Environment.current() == Environment.DEV_LOCAL ||
-      "true".equals(request.getHeader("X-Appengine-Cron")))
+      !(
+        Environment.current() == Environment.DEV_LOCAL ||
+        "true".equals(request.getHeader("X-Appengine-Cron"))
+      )
     ) {
       response.sendError(
         HttpServletResponse.SC_UNAUTHORIZED,

--- a/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
+++ b/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
@@ -290,8 +290,8 @@ public class RefreshCaseStatsServlet extends HttpServlet {
     // App Engine strips all external X-* request headers, so we can trust this is set by App Engine.
     // https://cloud.google.com/appengine/docs/flexible/java/scheduling-jobs-with-cron-yaml#validating_cron_requests
     if (
-      Environment.current() != Environment.DEV_LOCAL &&
-      !"true".equals(request.getHeader("X-Appengine-Cron"))
+      !(Environment.current() == Environment.DEV_LOCAL ||
+      "true".equals(request.getHeader("X-Appengine-Cron")))
     ) {
       response.sendError(
         HttpServletResponse.SC_UNAUTHORIZED,

--- a/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
+++ b/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
@@ -290,7 +290,7 @@ public class RefreshCaseStatsServlet extends HttpServlet {
     // App Engine strips all external X-* request headers, so we can trust this is set by App Engine.
     // https://cloud.google.com/appengine/docs/flexible/java/scheduling-jobs-with-cron-yaml#validating_cron_requests
     if (
-      Environment.isProduction() &&
+      Environment.current() != Environment.DEV_LOCAL &&
       !"true".equals(request.getHeader("X-Appengine-Cron"))
     ) {
       response.sendError(

--- a/server/appengine/src/test/java/who/RefreshCaseStatsServletTest.java
+++ b/server/appengine/src/test/java/who/RefreshCaseStatsServletTest.java
@@ -22,7 +22,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
-public class RefreshCaseStatsServletTest extends WhoTestSupport {
+public class RefreshCaseStatsServletTest {
 
   private JsonArray getRowsFromTestResource(String filename)
     throws UnsupportedEncodingException {
@@ -41,7 +41,6 @@ public class RefreshCaseStatsServletTest extends WhoTestSupport {
 
     new RefreshCaseStatsServlet().doGet(request, response);
 
-    ArgumentCaptor<String> stringCaptor = ArgumentCaptor.forClass(String.class);
     verify(response)
       .sendError(HttpServletResponse.SC_UNAUTHORIZED, "Cron access only");
   }

--- a/server/appengine/src/test/java/who/RefreshCaseStatsServletTest.java
+++ b/server/appengine/src/test/java/who/RefreshCaseStatsServletTest.java
@@ -3,6 +3,9 @@ package who;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -14,9 +17,34 @@ import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 public class RefreshCaseStatsServletTest extends WhoTestSupport {
+
+  private JsonArray getRowsFromTestResource(String filename)
+    throws UnsupportedEncodingException {
+    InputStream in =
+      this.getClass().getClassLoader().getResourceAsStream(filename);
+    JsonObject root = JsonParser
+      .parseReader(new InputStreamReader(in, "UTF-8"))
+      .getAsJsonObject();
+    return root.getAsJsonArray("features");
+  }
+
+  @Test
+  public void testCronFailsOutsideDevAppserver() throws Exception {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+
+    new RefreshCaseStatsServlet().doGet(request, response);
+
+    ArgumentCaptor<String> stringCaptor = ArgumentCaptor.forClass(String.class);
+    verify(response)
+      .sendError(HttpServletResponse.SC_UNAUTHORIZED, "Cron access only");
+  }
 
   @Test
   public void testParse() throws UnsupportedEncodingException {
@@ -174,16 +202,6 @@ public class RefreshCaseStatsServletTest extends WhoTestSupport {
     assertEquals(2, bbCountry.snapshots.size());
     // CC: zero numbers for last 2 days (kept as likely "valid zero following prior zero")
     assertEquals(3, ccCountry.snapshots.size());
-  }
-
-  private JsonArray getRowsFromTestResource(String filename)
-    throws UnsupportedEncodingException {
-    InputStream in =
-      this.getClass().getClassLoader().getResourceAsStream(filename);
-    JsonObject root = JsonParser
-      .parseReader(new InputStreamReader(in, "UTF-8"))
-      .getAsJsonObject();
-    return root.getAsJsonArray("features");
   }
 
   @Test


### PR DESCRIPTION
Allow direct request to the cron job only if the instance is running on dev_appserver.

Note that before it could be done on non - 'prod' instances of the app; this is better done in the Cloud Console Cron Job page by clicking 'run'. 
Before it could 'doGet' also simply be called e.g. in the test environment; if this is desirable, the method could probably be extracted out from doGet so doGet does a bit of authorization then the other code becomes testable.

## Screenshots

<details>
<summary>Screenshots</summary>
Add any relevant before/after screenshots here
</details>

## How did you test the change?

- [ ] iOS Simulator
- [ ] iOS Device
- [ ] Android Simulator
- [ ] Android Device
- [ ] `curl` to a dev App Engine server
- [x] other, please describe

Ran in dev_appserver and tested with a GET to the app.
Added unit test to verify it has been blocked.
Uploaded to my instance, tested with 'run cron' button and direct url fetch.

## Checklist:

- [ ] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
