### PR TITLE
`isProduction` replaced by `isDevLocal`

### DIFF
--- a/server/appengine/src/main/java/who/ClientInterceptor.java
+++ b/server/appengine/src/main/java/who/ClientInterceptor.java
@@ -53,9 +53,7 @@ public class ClientInterceptor implements RpcInterceptor {
 
     Client client = Client.getOrCreate(clientId, platform);
     Client.currentClient.set(client);
-    if (!Environment.isProduction()) logger.info(
-      CLIENT_ID + ": " + client.uuid
-    );
+    if (Environment.isDevLocal()) logger.info(CLIENT_ID + ": " + client.uuid);
     try {
       return invocation.proceed();
     } finally {

--- a/server/appengine/src/main/java/who/Environment.java
+++ b/server/appengine/src/main/java/who/Environment.java
@@ -9,54 +9,11 @@ import present.engine.AppEngine;
 /**
  * Exposes information specific to the current server environment.
  */
-public enum Environment {
-  TEST("http://localhost:3000"),
-  DEV_LOCAL("http://localhost:3000"),
-  DEV_SERVER("https://%s.appspot.com"),
-  STAGING("https://staging.whocoronavirus.org"),
-  HACKER("https://hacker.whocoronavirus.org"),
-  PRODUCTION("https://myhealth.who.int");
+public final class Environment {
 
-  private final String url;
+  private Environment() {}
 
-  Environment(String url) {
-    this.url = url;
-  }
-
-  /** Returns the URL for our server. */
-  public String url() {
-    if (this == DEV_SERVER) {
-      return this.url.format(getApplicationId());
-    }
-    return this.url;
-  }
-
-  /** Returns the current environment. */
-  public static Environment current() {
-    String applicationId = getApplicationId();
-
-    if (applicationId == null) return TEST;
-
-    if (
-      SystemProperty.environment.value() ==
-      SystemProperty.Environment.Value.Development
-    ) {
-      return DEV_LOCAL;
-    }
-
-    switch (applicationId) {
-      case "who-myhealth-staging":
-        return STAGING;
-      case "who-myhealth-hacker":
-        return HACKER;
-      case "myhealthapp-291008":
-        return PRODUCTION;
-      case "test":
-        return TEST;
-      default:
-        return DEV_SERVER;
-    }
-  }
+  private static final String STAGING_PROJECT_ID = "who-mh-staging";
 
   private static String getApplicationId() {
     String applicationId = AppEngine.applicationId();
@@ -70,24 +27,18 @@ public enum Environment {
     return id.getId();
   }
 
-  public String firebaseApplicationId() {
-    switch (this) {
-      case TEST:
-      case DEV_LOCAL:
-        return "who-myhealth-staging";
-      case DEV_SERVER:
-      case STAGING:
-      case HACKER:
-      case PRODUCTION:
-      default:
-        // Firebase and App Engine names should match
-        return getApplicationId();
+  public static String firebaseApplicationId() {
+    if (isDevLocal()) {
+      return STAGING_PROJECT_ID;
     }
+    return getApplicationId();
   }
 
-  /** True if this is the production server. */
-  public static boolean isProduction() {
-    Environment current = current();
-    return current == PRODUCTION || current == HACKER;
+  /** True if this is a development server. */
+  public static boolean isDevLocal() {
+    return (
+      SystemProperty.environment.value() ==
+      SystemProperty.Environment.Value.Development
+    );
   }
 }

--- a/server/appengine/src/main/java/who/NotificationsManager.java
+++ b/server/appengine/src/main/java/who/NotificationsManager.java
@@ -52,14 +52,14 @@ public class NotificationsManager {
       for (String topic : topicsToAdd) {
         TopicManagementResponse resp = fcm.subscribeToTopic(theToken, topic);
         if (resp.getSuccessCount() == 1) {
-          if (!Environment.isProduction()) logger.info(
+          if (Environment.isDevLocal()) logger.info(
             "SUCCESS - Subscribed " + client.token + " to topic " + topic
           );
           client.subscribedTopics.add(topic);
           // If something goes wrong we'll still save the partial update.
           ofy().defer().save().entity(client);
         } else {
-          if (!Environment.isProduction()) {
+          if (Environment.isDevLocal()) {
             logger.info(
               "FAILED - Subscribed " + client.token + " to topic " + topic
             );
@@ -77,14 +77,14 @@ public class NotificationsManager {
           topic
         );
         if (resp.getSuccessCount() == 1) {
-          if (!Environment.isProduction()) logger.info(
+          if (Environment.isDevLocal()) logger.info(
             "SUCCESS - Unsubscribed " + client.token + " from topic " + topic
           );
           client.subscribedTopics.remove(topic);
           // If something goes wrong we'll still save the partial update.
           ofy().defer().save().entity(client);
         } else {
-          if (!Environment.isProduction()) logger.info(
+          if (Environment.isDevLocal()) logger.info(
             "FAILED - Unsubscribed " + client.token + " from topic " + topic
           );
         }

--- a/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
+++ b/server/appengine/src/main/java/who/RefreshCaseStatsServlet.java
@@ -290,10 +290,8 @@ public class RefreshCaseStatsServlet extends HttpServlet {
     // App Engine strips all external X-* request headers, so we can trust this is set by App Engine.
     // https://cloud.google.com/appengine/docs/flexible/java/scheduling-jobs-with-cron-yaml#validating_cron_requests
     if (
-      !(
-        Environment.current() == Environment.DEV_LOCAL ||
-        "true".equals(request.getHeader("X-Appengine-Cron"))
-      )
+      !Environment.isDevLocal() &&
+      !"true".equals(request.getHeader("X-Appengine-Cron"))
     ) {
       response.sendError(
         HttpServletResponse.SC_UNAUTHORIZED,

--- a/server/appengine/src/main/java/who/WhoRpcFilter.java
+++ b/server/appengine/src/main/java/who/WhoRpcFilter.java
@@ -19,13 +19,13 @@ public class WhoRpcFilter extends RpcFilter {
     RpcInterceptorChain chain = new RpcInterceptorChain()
     .add(new ClientInterceptor());
 
-    if (!Environment.isProduction()) {
+    if (Environment.isDevLocal()) {
       chain = chain.add(new LoggingInterceptor());
     }
 
     service(WhoService.class, service, chain);
 
-    if (!Environment.isProduction()) {
+    if (Environment.isDevLocal()) {
       allowHost("localhost");
       allowAll();
     }

--- a/server/appengine/src/main/java/who/WhoServletModule.java
+++ b/server/appengine/src/main/java/who/WhoServletModule.java
@@ -20,11 +20,6 @@ public class WhoServletModule extends ServletModule {
     WhoServletModule.class
   );
 
-  @Provides
-  Environment provideEnvironment() {
-    return Environment.current();
-  }
-
   @Override
   protected void configureServlets() {
     install(new FirebaseModule());


### PR DESCRIPTION
- Removed app server type enums and urls

## How did you test the change?

TBD: Staging server

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
