### PR TITLE
Fix Static Content and App Engine deploys scripts

### DIFF
--- a/.github/workflows/server.yaml
+++ b/.github/workflows/server.yaml
@@ -52,7 +52,7 @@ jobs:
         with:
           java-version: "12.0.2"
           architecture: x86
-      - uses: google-github-actions/setup-gcloud@0.2.0
+      - uses: google-github-actions/setup-gcloud@v0.2.0
       - run: gcloud components install beta app-engine-java && gcloud components update
       - name: Setup GCP Credentials
         shell: bash

--- a/.github/workflows/static-content.yaml
+++ b/.github/workflows/static-content.yaml
@@ -57,7 +57,7 @@ jobs:
         with:
           java-version: "12.0.2"
           architecture: x86
-      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@0.1.2
+      - uses: google-github-actions/setup-gcloud@v0.2.0
       - name: Download Artifact
         uses: actions/download-artifact@v2
         with:


### PR DESCRIPTION
- `setup-gcloud` corrected from `@0.2.0` => `@v0.2.0`
- Based off this documentation:
https://cloud.google.com/blog/topics/developers-practitioners/deploying-serverless-platforms-github-actions

## How did you test the change?

CI after merge

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
