### PR TITLE
Fix Static Content CI Push

### DIFF
--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -194,6 +194,6 @@ jobs:
               deployment_id: '${{steps.newDeployment.outputs.result}}',
               state: '${{job.status}}' === 'success' ? 'success' : 'failure',
               log_url: process.env.LOG_URL,
-              environment_url: '${{job.status}}' === 'success' ? 'https://console.firebase.google.com/project/who-myhealth-staging/appdistribution/app/android:org.who.WHOMyHealth/releases' : '',
+              environment_url: '${{job.status}}' === 'success' ? 'https://console.firebase.google.com/project/who-mh-staging/appdistribution/app/android:org.who.WHOMyHealth/releases' : '',
               auto_inactive: '${{job.status}}' === 'success'
             });

--- a/.github/workflows/server.yaml
+++ b/.github/workflows/server.yaml
@@ -91,7 +91,7 @@ jobs:
             });
             return deployment.id;
       - shell: bash
-        run: ./bin/deploy-server.sh who-myhealth-staging
+        run: ./bin/deploy-server.sh who-mh-staging
         working-directory: server
       - name: Destroy GCP Credentials File
         run: rm $APPLICATION_CREDENTIALS
@@ -114,6 +114,6 @@ jobs:
               deployment_id: '${{steps.newDeployment.outputs.result}}',
               state: '${{job.status}}' === 'success' ? 'success' : 'failure',
               log_url: process.env.LOG_URL,
-              environment_url: '${{job.status}}' === 'success' ? 'https://console.cloud.google.com/appengine?project=who-myhealth-staging&serviceId=default' : '',
+              environment_url: '${{job.status}}' === 'success' ? 'https://console.cloud.google.com/appengine?project=who-mh-staging&serviceId=default' : '',
               auto_inactive: '${{job.status}}' === 'success'
             });

--- a/.github/workflows/static-content.yaml
+++ b/.github/workflows/static-content.yaml
@@ -104,7 +104,7 @@ jobs:
               log_url: process.env.LOG_URL,
             });
             return deployment.id;
-      - run: DONT_BUILD=true ./tools/build-and-push-static-serving.sh who-myhealth-staging-static-content-01
+      - run: DONT_BUILD=true ./tools/build-and-push-static-serving.sh who-mh-staging
       - name: Destroy GCP Credentials File
         run: rm $APPLICATION_CREDENTIALS
         if: ${{ always() }}
@@ -126,6 +126,6 @@ jobs:
               deployment_id: '${{steps.newDeployment.outputs.result}}',
               state: '${{job.status}}' === 'success' ? 'success' : 'failure',
               log_url: process.env.LOG_URL,
-              environment_url: '${{job.status}}' === 'success' ? 'https://console.cloud.google.com/storage/browser/who-myhealth-staging-static-content-01;tab=objects?project=who-myhealth-staging&prefix=' : '',
+              environment_url: '${{job.status}}' === 'success' ? 'https://console.cloud.google.com/storage/browser/who-mh-staging-static-content;tab=objects?project=who-mh-staging&prefix=' : '',
               auto_inactive: '${{job.status}}' === 'success'
             });

--- a/docs/devdesign/ci.md
+++ b/docs/devdesign/ci.md
@@ -8,7 +8,7 @@ On every push to `master` that affects the client, an Android APK will be pushed
 
 ### Setup
 
-1.  (First time) Create [a service account](https://console.cloud.google.com/iam-admin/serviceaccounts/details/104111540645440452578?project=who-myhealth-staging) on `who-myhealth-staging` GCP with `Firebase App Distribution Admin` role.
+1.  (First time) Create [a service account](https://console.cloud.google.com/iam-admin/serviceaccounts/details/104111540645440452578?project=who-mh-staging) on `who-mh-staging` GCP with `Firebase App Distribution Admin` role.
 2.  Create a Key for that service account: Add Key -> Create New Key -> JSON. Save the JSON file locally as `key.json`.
 3.  Generate a random passphrase. Store that passphrase as GitHub secret `FIREBASE_APPDEPLOY_STAGING_SVCACCT_PASSPHRASE`.
 4.  Encrypt and encode the key using the generated passphrase:
@@ -26,7 +26,7 @@ On every push to `master` that affects the server, the server will be pushed to 
 
 ### Setup
 
-1.  (First time) Create [a service account](https://console.cloud.google.com/iam-admin/serviceaccounts/details/104111540645440452578?project=who-myhealth-staging) on `who-myhealth-staging` GCP with the following role:
+1.  (First time) Create [a service account](https://console.cloud.google.com/iam-admin/serviceaccounts/details/104111540645440452578?project=who-mh-staging) on `who-mh-staging` GCP with the following role:
     `App Engine Deployer`,
     `App Engine Service Admin`,
     `Cloud Build Editor`,

--- a/tools/build-and-push-static-serving.sh
+++ b/tools/build-and-push-static-serving.sh
@@ -18,7 +18,7 @@ if [ "$DONT_PUSH" != "true" ]; then
     exit 1
   fi
 
-  PROJECT_ID=$PROJECT_ID-static-content
+  BUCKET=$PROJECT_ID-static-content
   set -euv
   gsutil -m -h "Cache-Control:public, max-age=600" -h "x-goog-meta-git-sha:$(git rev-parse HEAD)" -h "Content-Type:application/x-yaml;charset=utf-8" rsync -r ./staticContentBuild/ gs://$BUCKET/content/bundles/
 fi

--- a/tools/build-and-push-static-serving.sh
+++ b/tools/build-and-push-static-serving.sh
@@ -3,7 +3,7 @@
 set -ev
 cd $(dirname "$0")
 
-# Only argument is ProjectId or Bucket Name (deprecated)
+# Usage: ./tools/build-and-push-static-serving.sh <ProjectID>
 # When running as a GitHub action, building and pushing are separated.
 
 if [ "$DONT_BUILD" != "true" ]; then
@@ -12,17 +12,13 @@ if [ "$DONT_BUILD" != "true" ]; then
 fi
 
 if [ "$DONT_PUSH" != "true" ]; then
-  BUCKET=$1
-  if ! [[ $BUCKET == who-* ]]; then
+  PROJECT_ID=$1
+  if ! [[ $PROJECT_ID == who-* ]]; then
     echo "Required argument: project id starting with 'who-' : $PROJECT"
     exit 1
   fi
-  # TODO: remove once .github/workflows/static-content.yaml is updated
-  if [[ $BUCKET == *static-content* ]]; then
-    echo "Deprecated argument for bucket name: $BUCKET"
-  else
-    BUCKET=$BUCKET-static-content
-  fi
+
+  PROJECT_ID=$PROJECT_ID-static-content
   set -euv
   gsutil -m -h "Cache-Control:public, max-age=600" -h "x-goog-meta-git-sha:$(git rev-parse HEAD)" -h "Content-Type:application/x-yaml;charset=utf-8" rsync -r ./staticContentBuild/ gs://$BUCKET/content/bundles/
 fi


### PR DESCRIPTION
- Standardize on projectID usage
- Correct project id
- Remove deprecated code in push script

## How did you test the change?

CI Push Static Content after merge

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
