### PR TITLE
Bugfix on Home Screen shows a blank animation for countries having 0 daily National  

### DIFF
--- a/client/lib/components/home_page_sections/home_page_recent_numbers.dart
+++ b/client/lib/components/home_page_sections/home_page_recent_numbers.dart
@@ -103,14 +103,15 @@ class __HomeStatsFaderState extends State<_HomeStatsFader>
         child: AnimatedCrossFade(
           firstChild: Observer(
             builder: (_) => _HomeStatCard(
-              stat: widget.statsStore.countryStats != null && widget.statsStore.countryDailyCases >= 0
+              stat: widget.statsStore.countryStats != null &&
+                      widget.statsStore.countryDailyCases >= 0
                   ? widget.numFmt.format(widget.statsStore.countryDailyCases)
                   : '',
               // TODO: localize
               title: widget.statsStore.countryStats != null &&
                       widget.statsStore.countryDailyCases >= 0
                   ? 'National Cases'
-                  : '', 
+                  : '',
             ),
           ),
           duration: Duration(seconds: 1),

--- a/client/lib/components/home_page_sections/home_page_recent_numbers.dart
+++ b/client/lib/components/home_page_sections/home_page_recent_numbers.dart
@@ -103,15 +103,14 @@ class __HomeStatsFaderState extends State<_HomeStatsFader>
         child: AnimatedCrossFade(
           firstChild: Observer(
             builder: (_) => _HomeStatCard(
-              stat: widget.statsStore.countryStats != null &&
-                      widget.statsStore.countryDailyCases > 0
+              stat: widget.statsStore.countryStats != null && widget.statsStore.countryDailyCases >= 0
                   ? widget.numFmt.format(widget.statsStore.countryDailyCases)
                   : '',
               // TODO: localize
               title: widget.statsStore.countryStats != null &&
-                      widget.statsStore.countryDailyCases > 0
+                      widget.statsStore.countryDailyCases >= 0
                   ? 'National Cases'
-                  : '',
+                  : '', 
             ),
           ),
           duration: Duration(seconds: 1),

--- a/docs/credits.yaml
+++ b/docs/credits.yaml
@@ -154,3 +154,4 @@ team:
   - Will Ackerly
   - Yosua Ian Sebastian
   - Yu Zhao
+  - Tushar Ramesh Nikam


### PR DESCRIPTION
Bugfix on Home Screen shows a blank animation for countries having 0 daily National Cases like Anguilla has zero cases.

Issue number #1860 

## Screenshots

![](https://media.giphy.com/media/AglNBRs8omMzGAwjej/giphy.gif)



Modified the condition on home_page_recent_number.dart file
 displayed zero cases for daily National cases instead of a blank animation


## System
  - Device  Redmi 8A
  - OS: Android 9.0


## Checklist:

- [x]  Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
