### PR TITLE
Added country name to Homepage Stats + Switched to Totals

### DIFF
--- a/client/lib/components/home_page_sections/home_page_recent_numbers.dart
+++ b/client/lib/components/home_page_sections/home_page_recent_numbers.dart
@@ -2,6 +2,8 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+import 'package:who_app/api/iso_country.dart';
 import 'package:who_app/api/linking.dart';
 import 'package:who_app/api/stats_store.dart';
 import 'package:who_app/components/button.dart';
@@ -92,6 +94,10 @@ class __HomeStatsFaderState extends State<_HomeStatsFader>
 
   @override
   Widget build(BuildContext context) {
+    final countryList = Provider.of<IsoCountryList>(context);
+    final currentCountryCode = widget.statsStore.countryIsoCode;
+    final country = countryList.countries[currentCountryCode];
+
     return Button(
         borderRadius: BorderRadius.all(Radius.circular(12.0)),
         onPressed: widget.link != null
@@ -110,7 +116,7 @@ class __HomeStatsFaderState extends State<_HomeStatsFader>
               // TODO: localize
               title: widget.statsStore.countryStats != null &&
                       widget.statsStore.countryDailyCases >= 0
-                  ? 'National Cases'
+                  ? country.name + ' Total Cases'
                   : '',
             ),
           ),

--- a/client/lib/components/home_page_sections/home_page_recent_numbers.dart
+++ b/client/lib/components/home_page_sections/home_page_recent_numbers.dart
@@ -110,12 +110,12 @@ class __HomeStatsFaderState extends State<_HomeStatsFader>
           firstChild: Observer(
             builder: (_) => _HomeStatCard(
               stat: widget.statsStore.countryStats != null &&
-                      widget.statsStore.countryDailyCases >= 0
-                  ? widget.numFmt.format(widget.statsStore.countryDailyCases)
+                      widget.statsStore.countryCases >= 0
+                  ? widget.numFmt.format(widget.statsStore.countryCases)
                   : '',
               // TODO: localize
               title: widget.statsStore.countryStats != null &&
-                      widget.statsStore.countryDailyCases >= 0
+                      widget.statsStore.countryCases >= 0
                   ? country.name + ' Total Cases'
                   : '',
             ),
@@ -123,14 +123,14 @@ class __HomeStatsFaderState extends State<_HomeStatsFader>
           duration: Duration(seconds: 1),
           secondChild: Observer(
             builder: (_) => _HomeStatCard(
-              stat: widget.statsStore.globalDailyCases != null &&
-                      widget.statsStore.globalDailyCases > 0
-                  ? widget.numFmt.format(widget.statsStore.globalDailyCases)
+              stat: widget.statsStore.globalCases != null &&
+                      widget.statsStore.globalCases > 0
+                  ? widget.numFmt.format(widget.statsStore.globalCases)
                   : '',
               // TODO: localize
               title: widget.statsStore.globalCases != null &&
                       widget.statsStore.globalCases > 0
-                  ? 'Global Cases'
+                  ? 'Global Total Cases'
                   : '',
             ),
           ),


### PR DESCRIPTION
Partial fix of #1916

<details>
<summary>Screenshots</summary>

![Simulator Screen Shot - iPhone 12 Pro Max - 2021-01-10 at 22 07 52](https://user-images.githubusercontent.com/38309438/104150931-5fa55980-5390-11eb-8c2c-cc185d08c5d7.png)
![Simulator Screen Shot - iPhone 12 Pro Max - 2021-01-10 at 22 07 48](https://user-images.githubusercontent.com/38309438/104150933-603df000-5390-11eb-8d69-eee83d660653.png)

</details>

## How did you test the change?

- [x] iOS Simulator
- [ ] iOS Device
- [ ] Android Simulator
- [ ] Android Device
- [ ] `curl` to a dev App Engine server
- [ ] other, please describe

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
