### PR TITLE
Remove PolicyCheck

### DIFF
--- a/.github/workflows/policy-check.yaml
+++ b/.github/workflows/policy-check.yaml
@@ -7,24 +7,6 @@ on:
     branches: [master]
 
 jobs:
-  policy_check:
-    name: Check source code for policy violations
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.8
-      - name: Install dependencies
-        run: |
-          pip install scikit-learn==0.22.2 profanity-check==1.0.3
-      - name: Lint with profanity-check
-        run: |
-          # Every file in the repo that is treated as text
-          FILES2CHECK=$(git ls-files | xargs git grep --name-only -I -e . --)
-
-          python3.8 -W ignore ./tools/policycheck.py 0.5 ./.github/policy-ignored-lines.txt $FILES2CHECK
   formatting:
     # Dart is handled in the client CI
     name: Prettier Formatting


### PR DESCRIPTION
This linter has not had added value, however, it is blocking PRs with too many false positives for something that isn't profane.

## Checklist:

- [x] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
