### PR TITLE
feat(v2 backend): update FCM token directly in Firestore

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -66,6 +66,8 @@ Then, in your `client` directory, update your `main.dart` as follows:
 
     const USE_FIREBASE_LOCAL_EMULATORS = true;
 
+When working with the iOS client, temporarily disable transport security [as documented here](https://firebase.flutter.dev/docs/installation/ios/#enabling-use-of-firebase-emulator-suite).
+
 Then, run your application in its `hack` flavor:
 
     flutter run --flavor=hack

--- a/client/README.md
+++ b/client/README.md
@@ -53,3 +53,23 @@ For example to access the `staging` server (the default), the files are:
 Android: client/android/app/src/<flavor>/google-services.json
 iOS:     client/ios/config/<flavor>/GoogleService-Info.plist
 ```
+
+##### Using the Firebase Emulators
+
+If you'd like to test your app without using a "real" Firebase project, you can use the Firebase Local Emulator Suite as follows.
+
+First, start your local emulators by navigating to your `server/functions` directory and running:
+
+    firebase emulators:start --project=dev
+
+Then, in your `client` directory, update your `main.dart` as follows:
+
+    const USE_FIREBASE_LOCAL_EMULATORS = true;
+
+Then, run your application in its `hack` flavor:
+
+    flutter run --flavor=hack
+
+Your logs will confirm that you are using the local emulators:
+
+    I/flutter (13491): Will use local 🔥🔥 Firebase 🔥🔥 emulator

--- a/client/lib/main.dart
+++ b/client/lib/main.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_performance/firebase_performance.dart';
 import 'package:flutter/material.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
@@ -37,6 +38,10 @@ PackageInfo _packageInfo;
 
 PackageInfo get packageInfo => _packageInfo;
 
+// ATTENTION: never check this in as 'true'! Always set back to 'false' before
+//            sending out your PR. This is verified by `test/firebase_test.dart`.
+const USE_FIREBASE_LOCAL_EMULATORS = false;
+
 void main() async {
   await mainImpl(routes: Routes.map);
 }
@@ -51,6 +56,18 @@ void mainImpl({@required Map<String, WidgetBuilder> routes}) async {
   }
 
   var app = await Firebase.initializeApp();
+
+  if (USE_FIREBASE_LOCAL_EMULATORS) {
+    debugPrint('Will use local 🔥🔥 Firebase 🔥🔥 emulator');
+    // Switch Firebase host based on platform, since iOS and Android
+    // use different ways of contacting localhost.
+    var host = defaultTargetPlatform == TargetPlatform.android
+        ? '10.0.2.2:8080'
+        : 'localhost:8080';
+    FirebaseFirestore.instance.settings =
+        Settings(host: host, sslEnabled: false);
+  }
+
   var projectId = app.options.projectId;
   print('Firebase ProjectID: $projectId');
   var endpoint = Endpoint(projectId);

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -140,21 +140,21 @@ packages:
       name: cloud_firestore
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.16.0+1"
+    version: "0.14.4"
   cloud_firestore_platform_interface:
     dependency: transitive
     description:
       name: cloud_firestore_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.2"
+    version: "2.2.1"
   cloud_firestore_web:
     dependency: transitive
     description:
       name: cloud_firestore_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0+2"
+    version: "0.2.1+2"
   code_builder:
     dependency: transitive
     description:
@@ -273,7 +273,7 @@ packages:
       name: firebase_analytics
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.0.1"
+    version: "6.3.0"
   firebase_analytics_platform_interface:
     dependency: transitive
     description:
@@ -294,63 +294,63 @@ packages:
       name: firebase_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.0"
+    version: "0.5.3"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "2.1.0"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1+3"
+    version: "0.2.1+1"
   firebase_crashlytics:
     dependency: "direct main"
     description:
       name: firebase_crashlytics
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.0+1"
+    version: "0.2.4"
   firebase_crashlytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_crashlytics_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.1.4"
   firebase_messaging:
     dependency: "direct main"
     description:
       name: firebase_messaging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.0.0-dev.15"
+    version: "8.0.0-dev.11"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
       name: firebase_messaging_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0-dev.10"
+    version: "1.0.0-dev.7"
   firebase_messaging_web:
     dependency: transitive
     description:
       name: firebase_messaging_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0-dev.6"
+    version: "0.1.0-dev.2"
   firebase_performance:
     dependency: "direct main"
     description:
       name: firebase_performance
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.0+1"
+    version: "0.4.3"
   fixnum:
     dependency: "direct main"
     description:

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -134,6 +134,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0-nullsafety.1"
+  cloud_firestore:
+    dependency: "direct main"
+    description:
+      name: cloud_firestore
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.16.0+1"
+  cloud_firestore_platform_interface:
+    dependency: transitive
+    description:
+      name: cloud_firestore_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.2"
+  cloud_firestore_web:
+    dependency: transitive
+    description:
+      name: cloud_firestore_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.0+2"
   code_builder:
     dependency: transitive
     description:
@@ -252,7 +273,7 @@ packages:
       name: firebase_analytics
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.2"
+    version: "7.0.1"
   firebase_analytics_platform_interface:
     dependency: transitive
     description:
@@ -273,56 +294,63 @@ packages:
       name: firebase_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.3"
+    version: "0.7.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "3.0.1"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1+1"
+    version: "0.2.1+3"
   firebase_crashlytics:
     dependency: "direct main"
     description:
       name: firebase_crashlytics
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.3"
+    version: "0.4.0+1"
   firebase_crashlytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_crashlytics_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.1.6"
   firebase_messaging:
     dependency: "direct main"
     description:
       name: firebase_messaging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.0.0-dev.8"
+    version: "8.0.0-dev.15"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
       name: firebase_messaging_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0-dev.5"
+    version: "1.0.0-dev.10"
+  firebase_messaging_web:
+    dependency: transitive
+    description:
+      name: firebase_messaging_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.0-dev.6"
   firebase_performance:
     dependency: "direct main"
     description:
       name: firebase_performance
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.5.0+1"
   fixnum:
     dependency: "direct main"
     description:
@@ -693,6 +721,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.3"
+  service_worker:
+    dependency: transitive
+    description:
+      name: service_worker
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.4"
   share:
     dependency: "direct main"
     description:

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -26,14 +26,15 @@ dependencies:
     sdk: flutter
 
   auto_size_text: 2.1.0
+  cloud_firestore: 0.16.0+1
   connectivity: ^2.0.0
   cupertino_icons: ^0.1.3
   expressions: 0.1.5
-  firebase_analytics: ^6.0.0
-  firebase_core: ^0.5.2
-  firebase_crashlytics: ^0.2.3
+  firebase_analytics: ^7.0.1
+  firebase_core: ^0.7.0
+  firebase_crashlytics: ^0.4.0+1
   firebase_messaging: ^8.0.0-dev.8
-  firebase_performance: ^0.4.3
+  firebase_performance: ^0.5.0+1
   fixnum: ^0.10.11
   fl_chart: ^0.8.7
   # TODO: upgrade to ^1.4.0, breaking API change

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -26,15 +26,15 @@ dependencies:
     sdk: flutter
 
   auto_size_text: 2.1.0
-  cloud_firestore: 0.16.0+1
+  cloud_firestore: 0.14.4
   connectivity: ^2.0.0
   cupertino_icons: ^0.1.3
   expressions: 0.1.5
-  firebase_analytics: ^7.0.1
-  firebase_core: ^0.7.0
-  firebase_crashlytics: ^0.4.0+1
+  firebase_analytics: ^6.0.0
+  firebase_core: ^0.5.2
+  firebase_crashlytics: ^0.2.3
   firebase_messaging: ^8.0.0-dev.8
-  firebase_performance: ^0.5.0+1
+  firebase_performance: ^0.4.3
   fixnum: ^0.10.11
   fl_chart: ^0.8.7
   # TODO: upgrade to ^1.4.0, breaking API change

--- a/client/test/firebase_test.dart
+++ b/client/test/firebase_test.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:who_app/main.dart';
+
+void main() {
+  test(
+    'Firebase Emulator usage has been disabled',
+    () {
+      expect(
+        USE_FIREBASE_LOCAL_EMULATORS,
+        false,
+      );
+    },
+  );
+}

--- a/server/firestore.rules
+++ b/server/firestore.rules
@@ -1,10 +1,21 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    // Currently: do not allow any direct reads or writes.
-    // TODO: this will change as we update the client to do direct reads and writes.
+    // Currently: do not allow any direct reads or writes unless otherwise specified.
     match /{document=**} {
       allow read, write: if false;
+    }
+
+    // Allow writes to the "Clients" collection, permitting users to set their FCM
+    // tokens.
+    //
+    // If we were concerned about abuse, we could add constraints around what the user
+    // needs to be writing to be allowed to write. Fortunately since this is write-only,
+    // and since the WHO client ID is a long random string that can't be guessed by others
+    // (preventing others from overwriting your settings) there seems to be little risk
+    // of abuse, and we can suffice with a simple rule.
+    match /Client/{who_client_id} {
+      allow write: if true;
     }
   }
 }

--- a/server/functions/src/firestore_rules.spec.ts
+++ b/server/functions/src/firestore_rules.spec.ts
@@ -36,7 +36,7 @@ after(() => {
 });
 
 describe("Firebase Rules", () => {
-  it("Should not allow direct access anywhere", async () => {
+  it("Should not allow access in random places", async () => {
     // Random location in the database.
     await firebase.assertFails(
       app
@@ -45,7 +45,8 @@ describe("Firebase Rules", () => {
         .doc("nonexistent-doc")
         .get()
     );
-    // The Client collection.
+  });
+  it("Should only allow write access to the Client collection", async () => {
     await firebase.assertFails(
       app
         .firestore()
@@ -53,6 +54,15 @@ describe("Firebase Rules", () => {
         .doc("00000000-0000-0000-0000-000000000000")
         .get()
     );
-    // Add tests for real-life collections and documents here as we add them to Firestore.
+    await firebase.assertSucceeds(
+      app
+        .firestore()
+        .collection("Client")
+        .doc("00000000-0000-0000-0000-000000000000")
+        .set({
+          foo: "bar",
+        })
+    );
   });
+  // Add further tests for real-life collections and documents here as we add them to Firestore.
 });


### PR DESCRIPTION
Before this PR, we would update the client's FCM token by writing to the `putClientSettings` HTTPS endpoint. With this PR, we remove that intermediate API layer and write directly to Firestore.

We don't currently use the FCM token, so the main purposes of this PR are to...
1. Demonstrate how we'll perform direct Firestore access.
2. Demonstrate how to configure the app to use the local Firebase (Firestore) emulator.
3. Prepare the application for later use of the FCM token.

Closes #1973

## Screenshots

N/A

## How did you test the change?

- [ ] iOS Simulator
- [ ] iOS Device
- [X] Android Simulator
- [ ] Android Device
- [ ] `curl` to a dev App Engine server
- [X] other, please describe: updated and ran unit tests in both `client` and `server`.

## Checklist:

- [X] Followed the [Contributor Guidelines](https://github.com/WorldHealthOrganization/app/blob/master/docs/CONTRIBUTING.md) and verified that all contributions are properly licensed pursuant to the [LICENSE](https://github.com/WorldHealthOrganization/app/blob/master/LICENSE).
